### PR TITLE
chore: release v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.10] - 2026-04-16
+
+### Added
+
+- *(enrich)* Add API-based enrichment and support for OpenAI-compatible endpoints
+
+
 ## [0.1.9] - 2026-04-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "CLAUDE.md that actually works. Enforce AI coding assistant instruction files via hooks."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 0.1.9 -> 0.1.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.10] - 2026-04-16

### Added

- *(enrich)* Add API-based enrichment and support for OpenAI-compatible endpoints
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).