### PR TITLE
feat(npm): add npm package with binary installer and setup script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,3 +174,27 @@ jobs:
             echo "Uploading $(basename $file)..."
             gh release upload "$TAG" "$file" --clobber
           done
+
+  npm-publish:
+    name: Publish to npm
+    needs: attach-binaries
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Sync version from tag
+        run: |
+          TAG=${GITHUB_REF#refs/tags/v}
+          cd npm
+          node -e "const p=require('./package.json'); p.version='$TAG'; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n')"
+
+      - name: Publish
+        run: cd npm && npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,10 @@
 name = "arai"
 version = "0.1.10"
 edition = "2021"
-description = "CLAUDE.md that actually works. Enforce AI coding assistant instruction files via hooks."
+description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/taniwhaai/arai"
-exclude = [".github/", "site/", "npm/", "install.sh", "cliff.toml", "release-plz.toml", "CLAUDE.md"]
+exclude = [".github/", "site/", "npm/", "install.sh", "cliff.toml", "release-plz.toml", "CLAUDE.md", "tasks/"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -68,18 +68,27 @@ Three tiers of rule understanding, each more accurate:
 ```bash
 arai scan                  # Tier 1: Built-in verb taxonomy (free, instant)
 arai scan --enrich         # Tier 2: Sentence transformer model (local, ~80MB download)
-arai scan --enrich-llm     # Tier 3: LLM classification (any provider)
+arai scan --enrich-llm     # Tier 3a: LLM classification via CLI
+arai scan --enrich-api     # Tier 3b: LLM classification via API (no CLI needed)
 ```
 
 Configure your LLM:
 ```bash
-# Via environment variable
+# Via CLI tool (shell-out)
 ARAI_LLM_CMD="claude -p" arai scan --enrich-llm
 ARAI_LLM_CMD="ollama run llama3" arai scan --enrich-llm
 
+# Via API (OpenAI-compatible endpoints)
+ARAI_API_KEY=sk-... arai scan --enrich-api                    # OpenAI (default)
+ARAI_API_URL=http://localhost:11434/v1 arai scan --enrich-api  # Ollama (auto-detected)
+ARAI_API_URL=https://api.groq.com/openai/v1 ARAI_API_KEY=gsk-... ARAI_API_MODEL=llama-3.3-70b-versatile arai scan --enrich-api
+
 # Or in ~/.arai/config.toml
 [enrich]
-llm_command = "llm -m gpt-4o-mini"
+llm_command = "llm -m gpt-4o-mini"       # for --enrich-llm
+api_url = "https://api.openai.com/v1"     # for --enrich-api
+api_key_env = "OPENAI_API_KEY"
+model = "gpt-4o-mini"
 ```
 
 ## Commands
@@ -90,7 +99,8 @@ arai status                # Show what's being enforced
 arai guardrails            # List all active rules
 arai scan                  # Re-scan instruction files
 arai scan --code           # Also scan source code (tree-sitter AST)
-arai scan --enrich-llm     # Enhance rules via LLM
+arai scan --enrich-llm     # Enhance rules via LLM CLI
+arai scan --enrich-api     # Enhance rules via API (OpenAI-compatible)
 arai add "Never X"         # Add a rule manually
 arai upgrade --full        # Switch to full binary (with ONNX enrichment)
 ```
@@ -103,6 +113,9 @@ curl -sSf https://arai.taniwha.ai/install | sh
 
 # Full binary (with local sentence transformer)
 ARAI_FULL=1 curl -sSf https://arai.taniwha.ai/install | sh
+
+# npm
+npm install -g @taniwhaai/arai
 
 # Cargo
 cargo install arai

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,4 @@
+# Downloaded binary (placeholder script is tracked)
+bin/arai.exe
+!/bin/arai
+*.tgz

--- a/npm/bin/arai
+++ b/npm/bin/arai
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "arai: binary not installed. Run: node $(dirname $0)/../install.js" >&2
+exit 1

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+"use strict";
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const REPO = "taniwhaai/arai";
+
+function main() {
+  const platform = detectPlatform();
+  const version = getVersion();
+  const binaryName = getBinaryDownloadName(platform);
+  const url = `https://github.com/${REPO}/releases/download/v${version}/${binaryName}`;
+  const dest = path.join(__dirname, "bin", getLocalBinaryName());
+
+  console.log(`  Downloading arai v${version} for ${platform}...`);
+
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+
+  // Remove placeholder if it exists
+  if (fs.existsSync(dest)) {
+    fs.unlinkSync(dest);
+  }
+
+  try {
+    execSync(`curl -sL --fail -o "${dest}" "${url}"`, { stdio: "pipe" });
+  } catch (e) {
+    console.error(`  Failed to download from ${url}`);
+    console.error(`  You can install manually: https://github.com/${REPO}/releases`);
+    process.exit(1);
+  }
+
+  // Verify file was actually downloaded
+  const stats = fs.statSync(dest);
+  if (stats.size < 10000) {
+    console.error(`  Downloaded file is too small (${stats.size} bytes).`);
+    console.error(`  Check that release v${version} exists at:`);
+    console.error(`  https://github.com/${REPO}/releases`);
+    fs.unlinkSync(dest);
+    process.exit(1);
+  }
+
+  // Make executable on Unix
+  if (process.platform !== "win32") {
+    fs.chmodSync(dest, 0o755);
+  }
+
+  console.log(`  \u2713 arai v${version} installed`);
+}
+
+function detectPlatform() {
+  const platform = os.platform();
+  const arch = os.arch();
+
+  let osName;
+  switch (platform) {
+    case "linux":
+      osName = "linux";
+      break;
+    case "darwin":
+      osName = "darwin";
+      break;
+    case "win32":
+      osName = "windows";
+      break;
+    default:
+      console.error(`  Unsupported platform: ${platform}`);
+      console.error(`  Install manually: https://github.com/${REPO}/releases`);
+      process.exit(1);
+  }
+
+  let archName;
+  switch (arch) {
+    case "x64":
+      archName = "x86_64";
+      break;
+    case "arm64":
+      archName = "aarch64";
+      break;
+    default:
+      console.error(`  Unsupported architecture: ${arch}`);
+      console.error(`  Install manually: https://github.com/${REPO}/releases`);
+      process.exit(1);
+  }
+
+  return `${osName}-${archName}`;
+}
+
+function getBinaryDownloadName(platform) {
+  if (platform.startsWith("windows")) {
+    return `arai-${platform}.exe`;
+  }
+  return `arai-${platform}`;
+}
+
+function getLocalBinaryName() {
+  return process.platform === "win32" ? "arai.exe" : "arai";
+}
+
+function getVersion() {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "package.json"), "utf8")
+  );
+  return pkg.version;
+}
+
+main();

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@taniwhaai/arai",
+  "version": "0.1.10",
+  "description": "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more.",
+  "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/taniwhaai/arai.git"
+  },
+  "homepage": "https://arai.taniwha.ai",
+  "keywords": [
+    "claude",
+    "claude-code",
+    "ai",
+    "guardrails",
+    "cursor",
+    "copilot",
+    "windsurf"
+  ],
+  "bin": {
+    "arai": "bin/arai"
+  },
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "files": [
+    "install.js",
+    "bin/"
+  ]
+}


### PR DESCRIPTION
Introduced npm support for `arai` with a placeholder binary and installation script. Added `postinstall` hook for platform-specific binary downloads. Updated README with npm installation instructions and usage examples. Configured GitHub Actions to publish to npm on new tags.