### PR TITLE
chore: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Normalize line endings on checkin; check out LF on all platforms.
+# Prevents Windows workspaces from silently rewriting tracked files to CRLF.
+* text=auto eol=lf
+
+# Explicit binary types (no normalization)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.onnx binary


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` with `* text=auto eol=lf` so Windows checkouts stop silently rewriting tracked files to CRLF.
- Marks common binary types explicitly so they are excluded from normalization.

## Context
Tim reported ~25 files (LICENSE, Cargo.lock, CHANGELOG.md, most `src/*.rs`) were rewritten with CRLF endings on checkout to a Windows workspace. This prevents recurrence.

## Test plan
- [ ] CI green
- [ ] After merge, `git ls-files --eol` shows `i/lf` for text files on a fresh clone