### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.2] - 2026-04-20
+
+### Added
+
+- Arai lint, arai record, rule-health check in arai status, alembic example
+
+### Miscellaneous
+
+- Add .gitattributes to enforce LF line endings
+
+
 ## [0.2.1] - 2026-04-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2] - 2026-04-20

### Added

- Arai lint, arai record, rule-health check in arai status, alembic example

### Miscellaneous

- Add .gitattributes to enforce LF line endings
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).