### PR TITLE
feat: per-rule compliance, severity override, recent_decisions, audit --rule, diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- *(stats)* Per-rule compliance roll-up — `fires / obeyed / ignored /
+  unclear / ratio` joined across Pre firings and Compliance verdicts
+  via `triple_id`.  `arai stats` shows it inline; `arai stats
+  --by-rule` shows only that section.  ⚠ flag highlights low-ratio
+  rules with enough volume to mean it.
+- *(severity)* `arai severity` subcommand — pin a rule's severity
+  for incremental deny-mode rollout.  Stored in a new
+  `rule_intent.severity_override` column that survives `arai scan`
+  re-classification.  `arai severity --reset` drops the override.
+- *(mcp)* `arai_recent_decisions` tool — surfaces recent deny /
+  inject / review decisions back to the agent, so the model can
+  self-check after a refusal instead of repeating the same action.
+  Filters by `session_id`, `limit`, and `since`; skips `Compliance`
+  events.
+- *(audit)* `--rule` filter — case-insensitive substring match
+  against rule subject/predicate/object across both top-level
+  firings and Compliance `payload.rules[]`.  Pairs with `--outcome`.
+- *(diff)* `arai diff <file>` — preview rule-set delta vs. the live
+  store before saving an instruction-file edit.  Reports added,
+  removed, and moved (same SPO, different line); JSON output for
+  pre-commit hooks.
+
+
 ## [0.2.5] - 2026-04-27
 
 ### Miscellaneous
@@ -14,7 +41,6 @@ All notable changes to this project will be documented in this file.
 ### Documentation
 
 - Align v0.3 references with actual v0.2.3 release
-
 
 ## [0.2.3] - 2026-04-24
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,13 @@ cargo run -- audit             # Tail the local firing log (today)
 cargo run -- audit --json      # JSONL stream
 cargo run -- audit --event=Compliance   # Compliance verdicts (Pre/Post correlation)
 cargo run -- audit --outcome=ignored    # Rules the model ran despite a Pre-firing
-cargo run -- stats             # Aggregate the audit log (top rules, tools, days)
+cargo run -- audit --rule alembic       # Filter audit by rule subject/predicate/object
+cargo run -- stats             # Aggregate the audit log (top rules, tools, days, compliance)
+cargo run -- stats --by-rule   # Just the per-rule compliance ratios
+cargo run -- severity          # List active severity overrides
+cargo run -- severity alembic block      # Pin a rule's severity for incremental rollout
+cargo run -- severity --reset alembic    # Drop the override, fall back to classification
+cargo run -- diff CLAUDE.md    # Preview rule-set delta vs. live store, no writes
 cargo run -- lint CLAUDE.md    # Parse a file and preview extracted rules, no DB writes
 cargo run -- test scenarios/alembic-migration.json  # Replay the canonical scenario
 cargo run -- record --since=1h # Build scenarios from recent audit entries
@@ -48,7 +54,7 @@ src/
 ├── enrich.rs             # Tier 2 (ONNX sentence transformer) + Tier 3 (LLM shell-out)
 ├── audit.rs              # Local JSONL firing log — record_firing, record_event, layer_label
 ├── compliance.rs         # Pre/Post correlation — Obeyed/Ignored/Unclear verdicts per rule
-├── stats.rs              # Aggregate views over the audit log — `arai stats`
+├── stats.rs              # Aggregate views — `arai stats`, per-rule compliance roll-up
 ├── scenarios.rs          # Scenario replay harness — `arai test <file>`
 ├── extends.rs            # `arai:extends` upstream-policy fetch + trust list
 ├── mcp.rs                # Stdio MCP server — arai_add_guard + arai_list_guards for agent-authored rules
@@ -88,6 +94,30 @@ leaves the machine.
 - **Severity-aware** — prohibitive predicates block, affirmative predicates warn, prefers informs
 - **<5ms no-match hook** — fast exit when no guardrails apply
 - **Single binary** — no runtime dependencies for users
+
+## v0.2.4 additions at a glance
+
+- **Per-rule compliance roll-up** in `arai stats` — joins Pre firings
+  and Compliance verdicts via `triple_id` to produce
+  `fires/obeyed/ignored/unclear/ratio` per rule. `--by-rule` shows
+  only that section. The maintainer's "is this rule actually
+  working?" question, answered from data Arai already collects.
+- **Per-rule severity override** (`arai severity`).  Stored in a new
+  `rule_intent.severity_override` column that `classify_all_guardrails`
+  doesn't touch on re-scan, so manual rollout decisions survive.
+  `get_rule_intent` returns the override when set; falls back to the
+  classified severity otherwise.
+- **`arai_recent_decisions` MCP tool**.  Mirror of the maintainer-
+  side audit feed, exposed to the agent so it can self-check after a
+  deny without parsing the on-screen reason or re-trying the same
+  thing twice.  Strips `Compliance` events (verdicts, not decisions).
+- **`arai audit --rule <pattern>`** filter.  Substring match against
+  rule subject/predicate/object across both top-level firings and
+  Compliance `payload.rules[]`.  Pairs with `--outcome=ignored`.
+- **`arai diff <file>`**.  Preview rule-set delta against the live
+  store before saving an instruction-file edit; emits added /
+  removed / moved (line number changed for an unchanged SPO).
+  Pre-commit-hook fodder via `--json`.
 
 ## v0.2.3 additions at a glance
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,12 @@ arai scan --enrich-api     # Enhance rules via API (OpenAI-compatible)
 arai add "Never X"         # Add a rule manually
 arai audit                 # Inspect the local log of rule firings
 arai audit --outcome=ignored # Compliance verdicts where the model ignored a rule
-arai stats                 # Aggregate audit log — top rules, tools, days
+arai audit --rule alembic  # Filter audit by rule subject/predicate/object substring
+arai stats                 # Aggregate audit log — top rules, tools, days, per-rule compliance
+arai stats --by-rule       # Just the per-rule compliance section
+arai severity alembic block # Pin a rule's severity (incremental deny rollout)
+arai severity --reset alembic # Drop the override; severity reverts to predicate-derived
+arai diff CLAUDE.md        # Preview rule-set delta before saving an edit
 arai test scenarios.json   # Replay synthetic hook scenarios against rules
 arai record --since=1h     # Capture recent firings as a scenario skeleton
 arai lint CLAUDE.md        # Parse a file and preview extracted rules
@@ -219,8 +224,14 @@ arai audit --tool=Bash        # Only Bash tool calls
 arai audit --event=PreToolUse # Only pre-tool-use firings
 arai audit --event=Compliance # Compliance verdicts (Pre/Post correlation)
 arai audit --outcome=ignored  # Shortcut: Compliance events marked ignored
+arai audit --rule alembic     # Filter to firings/verdicts touching this rule
 arai audit --json             # JSONL stream (pipe-friendly)
 ```
+
+`--rule` is a case-insensitive substring match against the rule's
+subject, predicate, or object — the same shape `arai severity` uses.
+Pairs naturally with `--outcome=ignored` to answer "every time the
+alembic rule was ignored this week".
 
 Useful for answering:
 
@@ -254,15 +265,82 @@ source.
 the questions every maintainer asks after a few weeks of use:
 
 ```bash
-arai stats                # Top rules, tools, days since the log began
+arai stats                # Top rules, tools, days, per-rule compliance
 arai stats --since=30d    # Window to the last month
 arai stats --top=5        # Show only top 5 per section
+arai stats --by-rule      # Just the per-rule compliance table
 arai stats --json         # Machine-readable for dashboards
 ```
 
 Output includes: total firings, most-fired rules, tools attracting the
-most guardrails, day-by-day activity. Nothing leaves the machine —
-stats are a local view over your own audit log.
+most guardrails, day-by-day activity, **and a per-rule compliance
+roll-up** — for every rule that has fired, how many Pre/Post pairs
+ended up `obeyed` vs `ignored`, plus a ratio:
+
+```
+Per-rule compliance
+  fires obeyed ignored unclear   ratio  rule
+     12     11       1       0     92%  alembic must_not: hand-write migrations
+      7      4       3       0     57%  git must_not: --no-verify  ⚠
+      9      9       0       0    100%  cargo always: test before commit
+```
+
+The ⚠ flag highlights rules with low ratios and enough volume to
+mean it — these are the ones to either rewrite (rule subject too
+narrow / object too vague) or escalate via `arai severity` (see
+below) once you trust the wording.
+
+Nothing leaves the machine — stats are a local view over your own
+audit log.
+
+## Severity — per-rule deny-mode rollout
+
+`arai severity` pins a rule's enforcement strength so re-running
+`arai scan` won't reset it to the predicate-derived classification.
+Use it for **incremental deny-mode rollout**: ship the rule set in
+advise mode (`ARAI_DENY_MODE=off`), watch `arai stats --by-rule`,
+and flip individual rules into `block` once the model is honouring
+them in the wild — without forcing the whole rule set into a strict
+mode it isn't ready for yet.
+
+```bash
+arai severity                          # List active overrides
+arai severity alembic block            # Pin every rule whose subject/object
+                                       # contains "alembic" to block
+arai severity git warn                 # Demote git rules to advise-only
+arai severity --reset alembic          # Drop the override; severity reverts
+                                       # to the predicate-derived value
+arai severity alembic block --json     # Machine-readable list of changes
+```
+
+Pattern matching is case-insensitive substring against the rule's
+subject *or* object, so `arai severity migrate` covers both
+`alembic must_not: hand-write migrations` and `migrations require:
+backfill_plan`.
+
+Overrides survive `arai scan` and `arai init` — they live in their
+own column and are never touched by re-classification. Drop one with
+`--reset` when you're ready to re-derive severity from the rule's
+predicate.
+
+## Diff — preview rule-set changes
+
+`arai diff <file>` shows what changes a candidate edit to an
+instruction file would make to the live rule set — added, removed,
+moved — before you save and run `arai scan`. Read-only against
+the store; pairs with `arai lint` (preview a file in isolation)
+and `arai why` (preview a single tool call).
+
+```bash
+arai diff CLAUDE.md                            # Plain table view
+arai diff memory/feedback_testing.md --json    # For pre-commit hooks
+```
+
+Output is grouped into three sections — `Added` (rules in the file
+that aren't in the store yet), `Removed` (rules in the store whose
+text isn't in the new file), `Moved` (same rule, different line
+number — caught when you re-order a file without changing its rules).
+JSON output keeps the same shape for CI.
 
 ## Lint — preview what a file produces
 
@@ -380,18 +458,22 @@ one merged file.
 ## MCP: agent-authored guardrails
 
 `arai mcp` runs a [Model Context Protocol](https://modelcontextprotocol.io/)
-server on stdio. Two tools, exposed to any MCP-capable agent:
+server on stdio. Three tools, exposed to any MCP-capable agent:
 
 | Tool | What it does |
 |------|--------------|
 | `arai_add_guard(rule, reason?)` | Register a new guardrail mid-session. Takes effect on the next PreToolUse hook — same enforcement path as rules in your CLAUDE.md. |
 | `arai_list_guards(pattern?)` | List active guardrails, optionally substring-filtered, so the agent can check what constraints are live before acting. |
+| `arai_recent_decisions(session_id?, limit?, since?)` | Look up recent Ārai decisions (deny / inject / review) so the agent can self-check after a refusal — closes the model-side feedback loop. |
 
-This closes a gap instruction files don't cover: when an agent
+This closes two gaps instruction files don't cover. First, when an agent
 discovers a rule mid-session (*"from now on, never write to /etc"*,
 *"always run the full test suite before pushing"*), it now has
 somewhere to register it for deterministic enforcement rather than
-hoping context retention holds.
+hoping context retention holds. Second, after a deny, the agent can
+call `arai_recent_decisions` to see what it was just refused for —
+useful for avoiding "try the same thing twice" loops when a single
+rule keeps getting hit.
 
 Register it with Claude Code by adding to your MCP settings:
 

--- a/site/index.html
+++ b/site/index.html
@@ -281,8 +281,12 @@
                 <p>Rules with <code>never</code>/<code>forbids</code>/<code>must_not</code> emit <code>permissionDecision: "deny"</code>. <code>always</code> and <code>prefers</code> still advise. Incremental rollout via <code>ARAI_DENY_MODE=off</code>.</p>
             </div>
             <div class="feature">
+                <h3>Per-rule rollout</h3>
+                <p><code>arai severity alembic block</code> pins one rule to deny while the rest of the set stays in advise. Survives <code>arai scan</code>. Ship the set in advise mode, watch which rules earn the trust, then flip them one at a time.</p>
+            </div>
+            <div class="feature">
                 <h3>Compliance tracking</h3>
-                <p>Every PostToolUse is correlated against its PreToolUse firings. Each rule gets an <em>obeyed</em>, <em>ignored</em>, or <em>unclear</em> verdict. <code>arai audit --outcome=ignored</code> tells you which rules the model keeps flouting.</p>
+                <p>Every PostToolUse is correlated against its PreToolUse firings. Each rule gets an <em>obeyed</em>, <em>ignored</em>, or <em>unclear</em> verdict. <code>arai audit --outcome=ignored</code> tells you which rules the model keeps flouting; filter to a specific rule with <code>--rule</code>.</p>
             </div>
             <div class="feature">
                 <h3>Derivation trace</h3>
@@ -301,8 +305,8 @@
                 <p>Every firing is appended to a local JSONL you can query. See which rules fire, on which tools, for which prompts. Nothing leaves your machine.</p>
             </div>
             <div class="feature">
-                <h3>Aggregate stats</h3>
-                <p><code>arai stats</code> rolls up the audit log into top rules, tools, and days &mdash; so you can see which guardrails are load-bearing and which never fire.</p>
+                <h3>Per-rule compliance ratios</h3>
+                <p><code>arai stats</code> rolls up the audit log into <em>fires / obeyed / ignored / ratio</em> per rule. Now you can answer "is this rule actually working?" &mdash; not "is it firing?" The &#x26A0; flag highlights low-ratio rules with enough volume to mean it.</p>
             </div>
             <div class="feature">
                 <h3>Rule regression tests</h3>
@@ -317,12 +321,16 @@
                 <p><code>arai lint CLAUDE.md</code> shows exactly which rules a file produces with their classified intent. Iterate on wording without touching the DB.</p>
             </div>
             <div class="feature">
+                <h3>Diff before save</h3>
+                <p><code>arai diff CLAUDE.md</code> shows what an edit would change in the live rule set &mdash; added, removed, moved &mdash; before you commit it. Pre-commit-hook fodder via <code>--json</code>.</p>
+            </div>
+            <div class="feature">
                 <h3>Shared policies</h3>
                 <p>Inherit org-wide rules with one directive: <code>arai:extends https://...</code>. Trusted per URL, HTTPS only, cached locally. No policy service &mdash; just a markdown file upstream.</p>
             </div>
             <div class="feature">
                 <h3>Agent-authored guards</h3>
-                <p>Runs as an MCP server. The agent can register new rules mid-session ("never touch /etc", "always run tests first") and Arai enforces them on the next tool call.</p>
+                <p>Runs as an MCP server. The agent can register new rules mid-session ("never touch /etc", "always run tests first") and Arai enforces them on the next tool call. <code>arai_recent_decisions</code> lets the agent self-check what it was just denied for &mdash; no more looping on the same refused action.</p>
             </div>
             <div class="feature">
                 <h3>Zero noise</h3>

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,11 @@ enum Commands {
         /// Implies `--event=Compliance` unless one is set explicitly.
         #[arg(long)]
         outcome: Option<String>,
+        /// Filter by rule subject/predicate/object (case-insensitive substring).
+        /// Matches against any rule attached to the firing — handy for
+        /// answering "every time the alembic rule fired this week".
+        #[arg(long)]
+        rule: Option<String>,
         /// Maximum entries to return
         #[arg(long, default_value = "50")]
         limit: usize,
@@ -145,7 +150,9 @@ enum Commands {
         #[arg(long, default_value = "200")]
         limit: usize,
     },
-    /// Aggregate summary of the local audit log — top rules, tools, days
+    /// Aggregate summary of the local audit log — top rules, tools, days,
+    /// plus per-rule compliance ratios when PostToolUse correlation has
+    /// produced verdicts.
     Stats {
         /// Only count firings newer than this (e.g. "7d", "24h", "30m")
         #[arg(long)]
@@ -153,7 +160,57 @@ enum Commands {
         /// Show top N entries per section
         #[arg(long, default_value = "10")]
         top: usize,
+        /// Show only the per-rule compliance section (rules + their
+        /// obeyed/ignored ratios).  Useful when you only care about
+        /// "is the model honouring my rules?"
+        #[arg(long)]
+        by_rule: bool,
         /// Output as JSON instead of a table
+        #[arg(long)]
+        json: bool,
+    },
+    /// Pin a rule's severity so re-running `arai scan` won't reset it to the
+    /// predicate-derived classification.  Use for incremental rollout — flip
+    /// individual rules into deny mode while the rest of the set stays in
+    /// advise mode.  No arguments → list current overrides.
+    ///
+    /// Examples:
+    ///   arai severity                                # list overrides
+    ///   arai severity alembic block                  # pin every rule whose
+    ///                                                # subject/object contains
+    ///                                                # "alembic" to block
+    ///   arai severity --reset alembic                # back to classified
+    Severity {
+        /// Case-insensitive substring against subject/object.  Required when
+        /// setting a severity; with `--reset` it picks which overrides to drop.
+        pattern: Option<String>,
+        /// New severity for matching rules: `block`, `warn`, or `inform`.
+        /// Required unless `--reset` is set.
+        level: Option<String>,
+        /// Drop the override for matching rules; severity reverts to the
+        /// predicate-derived classification.
+        #[arg(long)]
+        reset: bool,
+        /// Output as JSON (machine-readable list of changes)
+        #[arg(long)]
+        json: bool,
+    },
+    /// Preview what changes a candidate edit to an instruction file would
+    /// make to the live rule set — added, removed, severity changes — before
+    /// you save and run `arai scan`.  Read-only against the store; pairs
+    /// with `arai lint` (which previews the file in isolation) and `arai why`
+    /// (which previews single-action firings).
+    ///
+    /// Examples:
+    ///   arai diff CLAUDE.md
+    ///   arai diff memory/feedback_testing.md --json   # for pre-commit hooks
+    Diff {
+        /// Path to the candidate instruction file.  The file must already be
+        /// known to Arai (i.e. picked up by a previous `arai scan` or `arai
+        /// init`); otherwise every rule in it would diff as "added", which
+        /// `arai lint` covers more cleanly.
+        file: String,
+        /// Output as JSON
         #[arg(long)]
         json: bool,
     },
@@ -197,13 +254,15 @@ fn main() {
         Commands::Scan { code, enrich, enrich_llm, enrich_api, enrich_file } => cmd_scan(code, enrich, enrich_llm, enrich_api, enrich_file),
         Commands::Add { rule } => cmd_add(&rule),
         Commands::Upgrade { full, lean } => upgrade::run(full, lean),
-        Commands::Audit { since, tool, event, outcome, limit, json } => cmd_audit(since, tool, event, outcome, limit, json),
+        Commands::Audit { since, tool, event, outcome, rule, limit, json } => cmd_audit(since, tool, event, outcome, rule, limit, json),
         Commands::Mcp => mcp::run(),
         Commands::Lint { file, json } => cmd_lint(&file, json),
         Commands::Trust { add, remove } => cmd_trust(add, remove),
         Commands::Test { file, json } => scenarios::run(std::path::Path::new(&file), json),
         Commands::Record { since, tool, limit } => cmd_record(since, tool, limit),
-        Commands::Stats { since, top, json } => cmd_stats(since, top, json),
+        Commands::Stats { since, top, by_rule, json } => cmd_stats(since, top, by_rule, json),
+        Commands::Severity { pattern, level, reset, json } => cmd_severity(pattern, level, reset, json),
+        Commands::Diff { file, json } => cmd_diff(&file, json),
         Commands::Why { input, tool, event, json } => cmd_why(input, tool, event, json),
     };
 
@@ -423,6 +482,7 @@ fn cmd_audit(
     tool: Option<String>,
     event: Option<String>,
     outcome: Option<String>,
+    rule: Option<String>,
     limit: usize,
     json: bool,
 ) -> Result<(), String> {
@@ -438,15 +498,16 @@ fn cmd_audit(
         (None, None) => None,
     };
 
+    // Over-fetch when post-filters are in play so we don't truncate before
+    // the substring match has had a chance to match.
+    let needs_post_filter = outcome.is_some() || rule.is_some();
     let entries = audit::query(
         &cfg.arai_base_dir,
         &cfg.project_slug(),
         since_epoch,
         tool.as_deref(),
         effective_event.as_deref(),
-        // Over-fetch so the outcome filter has enough material before
-        // truncating to the requested limit.
-        if outcome.is_some() { limit.saturating_mul(4) } else { limit },
+        if needs_post_filter { limit.saturating_mul(4) } else { limit },
     )?;
 
     // Apply outcome filter in-process: an entry passes if any item in
@@ -461,11 +522,26 @@ fn cmd_audit(
                     .map(|rs| rs.iter().any(|r| r.get("outcome").and_then(|o| o.as_str()) == Some(target)))
                     .unwrap_or(false)
             })
-            .take(limit)
             .collect()
     } else {
         entries
     };
+
+    // Apply rule-pattern filter: an entry passes if any rule attached to it
+    // (top-level `rules[]` for firings, or `payload.rules[]` for Compliance)
+    // matches the pattern as a case-insensitive substring of subject /
+    // predicate / object.
+    let entries: Vec<serde_json::Value> = if let Some(pat) = rule.as_deref() {
+        let needle = pat.to_lowercase();
+        entries
+            .into_iter()
+            .filter(|e| entry_rules(e).any(|r| rule_matches_pattern(r, &needle)))
+            .collect()
+    } else {
+        entries
+    };
+
+    let entries: Vec<serde_json::Value> = entries.into_iter().take(limit).collect();
 
     if entries.is_empty() {
         if json {
@@ -610,12 +686,309 @@ fn cmd_trust(add: Option<String>, remove: Option<String>) -> Result<(), String> 
 fn cmd_stats(
     since: Option<String>,
     top: usize,
+    by_rule: bool,
     json: bool,
 ) -> Result<(), String> {
     let cfg = config::Config::load()?;
     let since_epoch = since.as_deref().map(parse_since).transpose()?;
-    stats::run(&cfg, since_epoch, top, json)
+    stats::run(&cfg, since_epoch, top, by_rule, json)
 }
+
+/// Return an iterator over every rule object attached to an audit entry,
+/// regardless of whether it lives at the top level (Pre/PostToolUse firings)
+/// or inside `payload.rules[]` (Compliance events).
+fn entry_rules(entry: &serde_json::Value) -> Box<dyn Iterator<Item = &serde_json::Value> + '_> {
+    let direct = entry.get("rules").and_then(|v| v.as_array());
+    let payload = entry
+        .get("payload")
+        .and_then(|p| p.get("rules"))
+        .and_then(|v| v.as_array());
+    match (direct, payload) {
+        (Some(d), Some(p)) => Box::new(d.iter().chain(p.iter())),
+        (Some(d), None) => Box::new(d.iter()),
+        (None, Some(p)) => Box::new(p.iter()),
+        (None, None) => Box::new(std::iter::empty()),
+    }
+}
+
+/// Test a rule object (subject/predicate/object — any may be absent) against
+/// a lowercase substring needle.
+fn rule_matches_pattern(rule: &serde_json::Value, needle: &str) -> bool {
+    let pick = |k: &str| {
+        rule.get(k)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_lowercase()
+    };
+    pick("subject").contains(needle)
+        || pick("predicate").contains(needle)
+        || pick("object").contains(needle)
+}
+
+/// `arai severity` — list overrides, pin a severity, or reset.
+fn cmd_severity(
+    pattern: Option<String>,
+    level: Option<String>,
+    reset: bool,
+    json: bool,
+) -> Result<(), String> {
+    let cfg = config::Config::load()?;
+    let db_path = cfg.db_path();
+    if !db_path.exists() {
+        return Err("No guardrail database found.  Run `arai init` first.".to_string());
+    }
+    let db = store::Store::open(&db_path)?;
+
+    // No args → list current overrides.
+    if pattern.is_none() && level.is_none() && !reset {
+        let overrides = db.list_severity_overrides().map_err(|e| e.to_string())?;
+        if json {
+            println!("{}", serde_json::to_string_pretty(&overrides).map_err(|e| e.to_string())?);
+            return Ok(());
+        }
+        if overrides.is_empty() {
+            println!("No severity overrides.  All rules use predicate-derived severity.");
+            println!("  Pin one with `arai severity <pattern> block|warn|inform`.");
+            return Ok(());
+        }
+        println!("Active severity overrides ({}):", overrides.len());
+        for c in &overrides {
+            println!(
+                "  [{:>6} \u{2192} {:<6}] {} {}: {}",
+                c.from.as_str(),
+                c.to.as_str(),
+                c.subject,
+                c.predicate,
+                c.object,
+            );
+            println!("    from {}", c.source);
+        }
+        return Ok(());
+    }
+
+    let pattern = pattern.ok_or_else(|| {
+        "missing pattern.  Usage: `arai severity <pattern> block|warn|inform` or `arai severity --reset <pattern>`".to_string()
+    })?;
+    if pattern.trim().is_empty() {
+        return Err("pattern is empty (would match every rule)".to_string());
+    }
+
+    if reset {
+        let cleared = db.clear_severity_override(&pattern).map_err(|e| e.to_string())?;
+        if json {
+            println!("{}", serde_json::to_string_pretty(&cleared).map_err(|e| e.to_string())?);
+            return Ok(());
+        }
+        if cleared.is_empty() {
+            println!("No overrides matched `{pattern}` — nothing to clear.");
+            return Ok(());
+        }
+        println!("Cleared {} override(s):", cleared.len());
+        for c in &cleared {
+            println!(
+                "  [{:>6} \u{2192} {:<6}] {} {}: {}",
+                c.from.as_str(),
+                c.to.as_str(),
+                c.subject,
+                c.predicate,
+                c.object,
+            );
+        }
+        return Ok(());
+    }
+
+    let level = level.ok_or_else(|| {
+        "missing severity.  Pass `block`, `warn`, or `inform` (or use `--reset` to drop the override)".to_string()
+    })?;
+    let severity = match level.to_lowercase().as_str() {
+        "block" => intent::Severity::Block,
+        "warn" => intent::Severity::Warn,
+        "inform" => intent::Severity::Inform,
+        other => return Err(format!("invalid severity `{other}` (expected block/warn/inform)")),
+    };
+
+    let changed = db
+        .set_severity_override(&pattern, severity)
+        .map_err(|e| e.to_string())?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&changed).map_err(|e| e.to_string())?);
+        return Ok(());
+    }
+    if changed.is_empty() {
+        println!("No rules matched `{pattern}`.  Run `arai guardrails` to see active rules.");
+        return Ok(());
+    }
+    println!("Pinned severity \u{2192} {} on {} rule(s):", severity.as_str(), changed.len());
+    for c in &changed {
+        println!(
+            "  [{:>6} \u{2192} {:<6}] {} {}: {}",
+            c.from.as_str(),
+            c.to.as_str(),
+            c.subject,
+            c.predicate,
+            c.object,
+        );
+        println!("    from {}", c.source);
+    }
+    Ok(())
+}
+
+/// `arai diff <file>` — preview rule-set delta between the candidate file
+/// content and the rules currently in the store for that source path.
+fn cmd_diff(path: &str, json: bool) -> Result<(), String> {
+    let cfg = config::Config::load()?;
+    let db_path = cfg.db_path();
+    if !db_path.exists() {
+        return Err("No guardrail database found.  Run `arai init` first.".to_string());
+    }
+    let db = store::Store::open(&db_path)?;
+
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read {path}: {e}"))?;
+
+    // Extract from the candidate content.  Use the same "lint" source-type
+    // tag the lint command does so domain bookkeeping stays consistent.
+    let candidate = parser::extract_rules(&content, "lint", 0.90);
+
+    // Look up live rules for this exact source path.  If the file has never
+    // been scanned before, every rule looks "added", which `arai lint` is
+    // already the right tool for — surface that to the user explicitly.
+    let live = db.rules_for_file(path).map_err(|e| e.to_string())?;
+    let cold_file = live.is_empty() && !candidate.is_empty();
+    if cold_file && !json {
+        println!("Diff: {path}");
+        println!("  (this file has not been scanned yet — every rule reads as added)");
+        println!("  Run `arai scan` after saving, or use `arai lint {path}` for a preview.");
+        println!();
+    }
+
+    // Key by (subject, predicate, object) — the natural identity for a rule
+    // independent of which line it lives on.
+    use std::collections::BTreeMap;
+    let key = |s: &str, p: &str, o: &str| (s.to_lowercase(), p.to_lowercase(), o.to_lowercase());
+
+    let mut live_map: BTreeMap<(String, String, String), &store::Guardrail> = BTreeMap::new();
+    for g in &live {
+        live_map.insert(key(&g.subject, &g.predicate, &g.object), g);
+    }
+    let mut cand_map: BTreeMap<(String, String, String), &parser::Triple> = BTreeMap::new();
+    for t in &candidate {
+        cand_map.insert(key(&t.subject, &t.predicate, &t.object), t);
+    }
+
+    let mut added: Vec<&parser::Triple> = Vec::new();
+    let mut removed: Vec<&store::Guardrail> = Vec::new();
+    let mut moved: Vec<(&store::Guardrail, &parser::Triple)> = Vec::new(); // same SPO, line moved
+
+    for (k, t) in &cand_map {
+        match live_map.get(k) {
+            Some(g) => {
+                let live_line = g.line_start;
+                let cand_line = t.line_start;
+                if live_line != cand_line {
+                    moved.push((g, t));
+                }
+            }
+            None => added.push(t),
+        }
+    }
+    for (k, g) in &live_map {
+        if !cand_map.contains_key(k) {
+            removed.push(g);
+        }
+    }
+
+    if json {
+        let added_json: Vec<serde_json::Value> = added
+            .iter()
+            .map(|t| serde_json::json!({
+                "subject": t.subject,
+                "predicate": t.predicate,
+                "object": t.object,
+                "line": t.line_start,
+                "layer": t.layer,
+            }))
+            .collect();
+        let removed_json: Vec<serde_json::Value> = removed
+            .iter()
+            .map(|g| serde_json::json!({
+                "subject": g.subject,
+                "predicate": g.predicate,
+                "object": g.object,
+                "line": g.line_start,
+            }))
+            .collect();
+        let moved_json: Vec<serde_json::Value> = moved
+            .iter()
+            .map(|(g, t)| serde_json::json!({
+                "subject": g.subject,
+                "predicate": g.predicate,
+                "object": g.object,
+                "from_line": g.line_start,
+                "to_line": t.line_start,
+            }))
+            .collect();
+        let out = serde_json::json!({
+            "file": path,
+            "added": added_json,
+            "removed": removed_json,
+            "moved": moved_json,
+            "summary": {
+                "added": added.len(),
+                "removed": removed.len(),
+                "moved": moved.len(),
+            },
+        });
+        println!("{}", serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?);
+        return Ok(());
+    }
+
+    if added.is_empty() && removed.is_empty() && moved.is_empty() {
+        println!("Diff: {path}");
+        println!("  No rule changes — file content differs only outside rule lines (or not at all).");
+        return Ok(());
+    }
+
+    println!("Diff: {path}");
+    println!(
+        "  +{} added   -{} removed   ~{} moved",
+        added.len(),
+        removed.len(),
+        moved.len(),
+    );
+    println!();
+    if !added.is_empty() {
+        println!("  Added:");
+        for t in &added {
+            let line = t.line_start.map(|l| format!(" L{l}")).unwrap_or_default();
+            println!("    + {} {}: {}{}", t.subject, t.predicate, t.object, line);
+        }
+        println!();
+    }
+    if !removed.is_empty() {
+        println!("  Removed:");
+        for g in &removed {
+            let line = g.line_start.map(|l| format!(" L{l}")).unwrap_or_default();
+            println!("    - {} {}: {}{}", g.subject, g.predicate, g.object, line);
+        }
+        println!();
+    }
+    if !moved.is_empty() {
+        println!("  Moved:");
+        for (g, t) in &moved {
+            let from = g.line_start.map(|l| l.to_string()).unwrap_or_default();
+            let to = t.line_start.map(|l| l.to_string()).unwrap_or_default();
+            println!(
+                "    ~ {} {}: {}  (L{from} \u{2192} L{to})",
+                g.subject, g.predicate, g.object,
+            );
+        }
+        println!();
+    }
+    Ok(())
+}
+
 
 /// Explain which guardrails would fire on a hypothetical tool call — same
 /// matching pipeline the live hook uses, but read-only and no audit write.
@@ -762,3 +1135,72 @@ fn parse_since(s: &str) -> Result<u64, String> {
         .unwrap_or(0);
     Ok(now.saturating_sub(delta))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn entry_rules_walks_top_level() {
+        let e = json!({"rules": [{"subject": "git", "predicate": "never", "object": "force"}]});
+        let collected: Vec<_> = entry_rules(&e).collect();
+        assert_eq!(collected.len(), 1);
+        assert_eq!(collected[0]["subject"], "git");
+    }
+
+    #[test]
+    fn entry_rules_walks_compliance_payload() {
+        let e = json!({
+            "event": "Compliance",
+            "payload": {"rules": [{"triple_id": 7, "predicate": "never", "object": "force"}]}
+        });
+        let collected: Vec<_> = entry_rules(&e).collect();
+        assert_eq!(collected.len(), 1);
+        assert_eq!(collected[0]["triple_id"], 7);
+    }
+
+    #[test]
+    fn entry_rules_walks_both_when_present() {
+        // Defensive: nothing in the audit format combines both today, but the
+        // helper should still surface every rule it can find.
+        let e = json!({
+            "rules": [{"subject": "a", "predicate": "p", "object": "o"}],
+            "payload": {"rules": [{"triple_id": 1, "predicate": "p", "object": "o"}]},
+        });
+        let collected: Vec<_> = entry_rules(&e).collect();
+        assert_eq!(collected.len(), 2);
+    }
+
+    #[test]
+    fn entry_rules_empty_when_neither_present() {
+        let e = json!({"event": "PreToolUse", "tool": "Bash"});
+        let collected: Vec<_> = entry_rules(&e).collect();
+        assert!(collected.is_empty());
+    }
+
+    #[test]
+    fn rule_matches_pattern_substring_subject() {
+        let r = json!({"subject": "alembic", "predicate": "never", "object": "hand-write"});
+        assert!(rule_matches_pattern(&r, "alem"));
+        assert!(rule_matches_pattern(&r, "lemb")); // mid-substring
+        assert!(!rule_matches_pattern(&r, "django"));
+    }
+
+    #[test]
+    fn rule_matches_pattern_substring_object_and_predicate() {
+        let r = json!({"subject": "git", "predicate": "must_not", "object": "force-push"});
+        assert!(rule_matches_pattern(&r, "force"));
+        assert!(rule_matches_pattern(&r, "must_not"));
+    }
+
+    #[test]
+    fn rule_matches_pattern_handles_missing_fields() {
+        // A Compliance rule object only has predicate/object/triple_id — no
+        // subject.  The matcher must still handle it without panicking.
+        let r = json!({"triple_id": 1, "predicate": "never", "object": "x"});
+        assert!(rule_matches_pattern(&r, "never"));
+        assert!(!rule_matches_pattern(&r, "git"));
+    }
+}
+

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -15,7 +15,7 @@
 //! the agent adds a guard via MCP, Ārai stores it through the same
 //! pipeline as `arai add`, and the next PreToolUse hook sees it.
 
-use crate::{config, enrich, parser, store, telemetry};
+use crate::{audit, config, enrich, parser, store, telemetry};
 use serde_json::{json, Value};
 use std::io::{BufRead, Write};
 
@@ -133,6 +133,42 @@ fn handle_tools_list() -> Value {
                         }
                     }
                 }
+            },
+            {
+                "name": "arai_recent_decisions",
+                "description":
+                    "Look up the most recent guardrail decisions Ārai has emitted in this \
+                     session (or any session if `session_id` is omitted).  Use this when \
+                     you've just been denied or warned and want to check whether you've \
+                     hit the same rule before — closes the feedback loop so you don't \
+                     repeat a refused action.  Returns each firing's tool, decision \
+                     (deny/inject/review), the matched rule(s), and the source file the \
+                     rule came from.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "session_id": {
+                            "type": "string",
+                            "description":
+                                "Optional Claude Code session id.  When set, only decisions \
+                                 from that session are returned.  Match the value Claude Code \
+                                 passes in hook payloads."
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description":
+                                "Maximum decisions to return (default 10, max 50).",
+                            "minimum": 1,
+                            "maximum": 50
+                        },
+                        "since": {
+                            "type": "string",
+                            "description":
+                                "Optional time window like '1h', '24h', '7d'.  Defaults to \
+                                 the last 24 hours so stale entries don't crowd out today's."
+                        }
+                    }
+                }
             }
         ]
     })
@@ -148,6 +184,7 @@ fn handle_tools_call(params: &Value) -> Result<Value, String> {
     match name {
         "arai_add_guard" => tool_add_guard(&args),
         "arai_list_guards" => tool_list_guards(&args),
+        "arai_recent_decisions" => tool_recent_decisions(&args),
         other => Err(format!("unknown tool: {other}")),
     }
 }
@@ -258,6 +295,150 @@ fn tool_list_guards(args: &Value) -> Result<Value, String> {
     Ok(content_text(&text))
 }
 
+/// Look up recent hook decisions from the audit log so the calling agent can
+/// see what Arai has just denied / injected / reviewed.  Pure read — no
+/// audit write, no telemetry.
+fn tool_recent_decisions(args: &Value) -> Result<Value, String> {
+    let session_id = args.get("session_id").and_then(|v| v.as_str()).unwrap_or("");
+    let limit = args
+        .get("limit")
+        .and_then(|v| v.as_u64())
+        .map(|n| n.clamp(1, 50) as usize)
+        .unwrap_or(10);
+    let since = args.get("since").and_then(|v| v.as_str()).unwrap_or("24h");
+    let since_epoch = parse_since_window(since)?;
+
+    let cfg = config::Config::load()?;
+    // Over-fetch when filtering by session so the per-session window has
+    // material — same trick `cmd_audit` uses for outcome/rule filters.
+    let raw_limit = if session_id.is_empty() {
+        limit
+    } else {
+        limit.saturating_mul(8)
+    };
+    let entries = audit::query(
+        &cfg.arai_base_dir,
+        &cfg.project_slug(),
+        Some(since_epoch),
+        None,
+        None,
+        raw_limit,
+    )
+    .map_err(|e| e.to_string())?;
+
+    // Skip Compliance events — they're verdicts, not decisions, and the
+    // model doesn't need to self-check against them via this surface.
+    let filtered: Vec<&Value> = entries
+        .iter()
+        .filter(|e| {
+            let ev = e.get("event").and_then(|v| v.as_str()).unwrap_or("");
+            if ev == "Compliance" {
+                return false;
+            }
+            if !session_id.is_empty() {
+                e.get("session").and_then(|v| v.as_str()) == Some(session_id)
+            } else {
+                true
+            }
+        })
+        .take(limit)
+        .collect();
+
+    if filtered.is_empty() {
+        let scope = if session_id.is_empty() {
+            "any session".to_string()
+        } else {
+            format!("session {session_id}")
+        };
+        return Ok(content_text(&format!(
+            "No Ārai decisions in the last {since} for {scope}."
+        )));
+    }
+
+    let mut lines = Vec::new();
+    for entry in &filtered {
+        let ts = entry.get("ts").and_then(|v| v.as_str()).unwrap_or("?");
+        let event = entry.get("event").and_then(|v| v.as_str()).unwrap_or("?");
+        let tool = entry.get("tool").and_then(|v| v.as_str()).unwrap_or("?");
+        let decision = entry.get("decision").and_then(|v| v.as_str()).unwrap_or("?");
+        let preview = entry
+            .get("prompt_preview")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let rules: Vec<String> = entry
+            .get("rules")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .map(|r| {
+                        format!(
+                            "{} {}: {}",
+                            r.get("subject").and_then(|v| v.as_str()).unwrap_or(""),
+                            r.get("predicate").and_then(|v| v.as_str()).unwrap_or(""),
+                            r.get("object").and_then(|v| v.as_str()).unwrap_or(""),
+                        )
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let rules_part = if rules.is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", rules.join("; "))
+        };
+        let preview_part = if preview.is_empty() {
+            String::new()
+        } else {
+            // Trim long previews so the MCP response stays compact.
+            let short: String = preview.chars().take(80).collect();
+            format!(" — {short}")
+        };
+        lines.push(format!(
+            "{ts}  {event:<13} {tool:<6} {decision:<6}{rules_part}{preview_part}"
+        ));
+    }
+
+    let scope = if session_id.is_empty() {
+        format!("last {since}, all sessions")
+    } else {
+        format!("last {since}, session {session_id}")
+    };
+    let text = format!(
+        "{} recent decision(s) ({scope}):\n{}",
+        filtered.len(),
+        lines.join("\n"),
+    );
+    Ok(content_text(&text))
+}
+
+/// Tiny duration parser shared with `tool_recent_decisions`.  We don't pull
+/// `parse_since` from `main.rs` because that function lives outside the
+/// library surface; duplicating ~10 lines is cheaper than restructuring
+/// the binary just to share it.
+fn parse_since_window(s: &str) -> Result<u64, String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err("`since` cannot be empty".to_string());
+    }
+    let (num_part, unit_secs): (&str, u64) = match s.chars().last().unwrap() {
+        'd' => (&s[..s.len() - 1], 86_400),
+        'h' => (&s[..s.len() - 1], 3_600),
+        'm' => (&s[..s.len() - 1], 60),
+        's' => (&s[..s.len() - 1], 1),
+        c if c.is_ascii_digit() => (s, 1),
+        other => return Err(format!("`since`: unknown unit '{other}' (use d/h/m/s)")),
+    };
+    let n: u64 = num_part
+        .parse()
+        .map_err(|_| format!("`since`: invalid number '{num_part}'"))?;
+    let delta = n.checked_mul(unit_secs).ok_or("`since`: overflow")?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    Ok(now.saturating_sub(delta))
+}
+
 fn content_text(text: &str) -> Value {
     json!({ "content": [{ "type": "text", "text": text }] })
 }
@@ -288,13 +469,24 @@ mod tests {
     }
 
     #[test]
-    fn tools_list_has_two_entries() {
+    fn tools_list_has_three_entries() {
         let v = handle_tools_list();
         let tools = v["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 2);
+        assert_eq!(tools.len(), 3);
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         assert!(names.contains(&"arai_add_guard"));
         assert!(names.contains(&"arai_list_guards"));
+        assert!(names.contains(&"arai_recent_decisions"));
+    }
+
+    #[test]
+    fn parse_since_window_basics() {
+        assert!(parse_since_window("1h").is_ok());
+        assert!(parse_since_window("7d").is_ok());
+        assert!(parse_since_window("60").is_ok()); // bare digits = seconds
+        assert!(parse_since_window("").is_err());
+        assert!(parse_since_window("xyz").is_err());
+        assert!(parse_since_window("3y").is_err()); // unknown unit
     }
 
     #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -4,6 +4,13 @@
 //! and produces summary counts: which rules fire most, which tools attract
 //! the most firings, activity per day.  Separate from anonymous telemetry —
 //! stats stay on the user's machine.
+//!
+//! Compliance roll-up: when PostToolUse correlation has produced verdicts,
+//! `compute()` joins them against the Pre firings via `triple_id` and reports
+//! per-rule obeyed/ignored/unclear counts plus a "compliance ratio"
+//! `obeyed / (obeyed + ignored)`.  This is the single most actionable
+//! number for a maintainer evaluating Arai on a real project — it tells
+//! you which rules the model honours and which ones it routes around.
 
 use crate::config::Config;
 use crate::audit;
@@ -20,13 +27,38 @@ pub struct Stats {
     pub by_tool: Vec<(String, usize)>,
     pub by_event: Vec<(String, usize)>,
     pub by_day: Vec<(String, usize)>,
+    /// Per-rule compliance roll-up.  Empty when the audit log has no
+    /// `Compliance` events yet (typical for projects that have only ever
+    /// run with the audit log shipping but no PostToolUse handler wired up,
+    /// or projects where no Pre/Post pair has occurred).
+    pub by_rule_compliance: Vec<RuleCompliance>,
+}
+
+/// Per-rule compliance record, joined across Pre firings (which carry
+/// subject/predicate/object) and Compliance events (which carry triple_id +
+/// outcome).  `fires` is the number of Pre firings; `obeyed`/`ignored`/
+/// `unclear` are verdict counts; `ratio` is `obeyed / (obeyed + ignored)`
+/// or `None` when the denominator is zero.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RuleCompliance {
+    pub triple_id: i64,
+    pub subject: String,
+    pub predicate: String,
+    pub object: String,
+    pub fires: usize,
+    pub obeyed: usize,
+    pub ignored: usize,
+    pub unclear: usize,
+    /// Ratio in `[0.0, 1.0]`.  `None` when neither `obeyed` nor `ignored`
+    /// is non-zero — there's no signal yet to compute a ratio from.
+    pub ratio: Option<f64>,
 }
 
 /// Compute aggregate stats over audit entries.  Entries are the raw JSON
 /// values emitted by `audit::query`; this function never re-reads the log.
 pub fn compute(entries: &[Value]) -> Stats {
     let mut s = Stats {
-        total_firings: entries.len(),
+        total_firings: 0,
         ..Stats::default()
     };
 
@@ -35,8 +67,16 @@ pub fn compute(entries: &[Value]) -> Stats {
     let mut event_counts: HashMap<String, usize> = HashMap::new();
     let mut day_counts: HashMap<String, usize> = HashMap::new();
 
+    // Per-triple-id accumulators for the compliance roll-up.  We discover
+    // SPO via Pre firings (which carry subject/predicate/object) and
+    // outcomes via Compliance events (which carry triple_id + outcome).
+    let mut spo_by_id: HashMap<i64, (String, String, String)> = HashMap::new();
+    let mut fires_by_id: HashMap<i64, usize> = HashMap::new();
+    let mut outcomes_by_id: HashMap<i64, (usize, usize, usize)> = HashMap::new(); // obeyed, ignored, unclear
+
     for entry in entries {
         let ts = entry.get("ts").and_then(|v| v.as_str()).unwrap_or("");
+        let ev = entry.get("event").and_then(|v| v.as_str()).unwrap_or("");
         if !ts.is_empty() {
             // Newer entries come first in `entries`, so window_end is the
             // first non-empty timestamp and window_start is the last.
@@ -49,14 +89,42 @@ pub fn compute(entries: &[Value]) -> Stats {
             }
         }
 
+        // Compliance events live in their own bucket: they don't count as
+        // firings, they don't carry tool context worth tallying separately,
+        // and their rules live under `payload.rules[]` not `rules[]`.
+        if ev == "Compliance" {
+            if let Some(rules) = entry
+                .get("payload")
+                .and_then(|p| p.get("rules"))
+                .and_then(|r| r.as_array())
+            {
+                for r in rules {
+                    let triple_id = r.get("triple_id").and_then(|v| v.as_i64()).unwrap_or(-1);
+                    if triple_id < 0 {
+                        continue;
+                    }
+                    let outcome = r.get("outcome").and_then(|v| v.as_str()).unwrap_or("");
+                    let entry_o = outcomes_by_id.entry(triple_id).or_insert((0, 0, 0));
+                    match outcome {
+                        "obeyed" => entry_o.0 += 1,
+                        "ignored" => entry_o.1 += 1,
+                        "unclear" => entry_o.2 += 1,
+                        _ => {}
+                    }
+                }
+            }
+            continue;
+        }
+
+        // Non-Compliance events: count as firings, accumulate top-rule and
+        // tool/event histograms.
+        s.total_firings += 1;
+        if !ev.is_empty() {
+            *event_counts.entry(ev.to_string()).or_insert(0) += 1;
+        }
         let tool = entry.get("tool").and_then(|v| v.as_str()).unwrap_or("");
         if !tool.is_empty() {
             *tool_counts.entry(tool.to_string()).or_insert(0) += 1;
-        }
-
-        let ev = entry.get("event").and_then(|v| v.as_str()).unwrap_or("");
-        if !ev.is_empty() {
-            *event_counts.entry(ev.to_string()).or_insert(0) += 1;
         }
 
         if let Some(rules) = entry.get("rules").and_then(|v| v.as_array()) {
@@ -69,6 +137,20 @@ pub fn compute(entries: &[Value]) -> Stats {
                 }
                 let key = format!("{subj} {pred}: {obj}");
                 *rule_counts.entry(key).or_insert(0) += 1;
+
+                // Compliance roll-up bookkeeping: remember the SPO for this
+                // triple_id (Compliance events only carry the id), and bump
+                // the firing counter.  Only Pre firings count toward
+                // `fires` — Post events would double-count the same call.
+                let triple_id = r.get("triple_id").and_then(|v| v.as_i64()).unwrap_or(-1);
+                if triple_id >= 0 {
+                    spo_by_id
+                        .entry(triple_id)
+                        .or_insert_with(|| (subj.to_string(), pred.to_string(), obj.to_string()));
+                    if ev == "PreToolUse" {
+                        *fires_by_id.entry(triple_id).or_insert(0) += 1;
+                    }
+                }
             }
         }
     }
@@ -82,6 +164,49 @@ pub fn compute(entries: &[Value]) -> Stats {
         v.sort_by(|a, b| a.0.cmp(&b.0));
         v
     };
+
+    // Build the compliance roll-up: every triple_id we saw in a Pre firing
+    // OR a Compliance event becomes a row.  This includes rules that fired
+    // but produced no Compliance verdict (Pre with no matching Post in the
+    // correlation window).
+    let mut compliance: Vec<RuleCompliance> = spo_by_id
+        .into_iter()
+        .map(|(triple_id, (subject, predicate, object))| {
+            let fires = *fires_by_id.get(&triple_id).unwrap_or(&0);
+            let (obeyed, ignored, unclear) = outcomes_by_id
+                .get(&triple_id)
+                .copied()
+                .unwrap_or((0, 0, 0));
+            let denom = obeyed + ignored;
+            let ratio = if denom > 0 {
+                Some(obeyed as f64 / denom as f64)
+            } else {
+                None
+            };
+            RuleCompliance {
+                triple_id,
+                subject,
+                predicate,
+                object,
+                fires,
+                obeyed,
+                ignored,
+                unclear,
+                ratio,
+            }
+        })
+        .collect();
+    // Sort by fires desc, then by ignored desc (floutings float to the top
+    // for equal fire counts), then alphabetical for stability.
+    compliance.sort_by(|a, b| {
+        b.fires
+            .cmp(&a.fires)
+            .then_with(|| b.ignored.cmp(&a.ignored))
+            .then_with(|| a.subject.cmp(&b.subject))
+            .then_with(|| a.object.cmp(&b.object))
+    });
+    s.by_rule_compliance = compliance;
+
     s
 }
 
@@ -96,6 +221,7 @@ pub fn run(
     cfg: &Config,
     since_epoch_secs: Option<u64>,
     top: usize,
+    by_rule_only: bool,
     json: bool,
 ) -> Result<(), String> {
     let entries = audit::query(
@@ -109,25 +235,52 @@ pub fn run(
     let stats = compute(&entries);
 
     if json {
-        let out = serde_json::json!({
+        let mut out = serde_json::json!({
             "total_firings": stats.total_firings,
             "window_start": stats.window_start,
             "window_end": stats.window_end,
-            "by_rule": stats.by_rule.iter().map(|(k, v)| serde_json::json!({"rule": k, "count": v})).collect::<Vec<_>>(),
-            "by_tool": stats.by_tool.iter().map(|(k, v)| serde_json::json!({"tool": k, "count": v})).collect::<Vec<_>>(),
-            "by_event": stats.by_event.iter().map(|(k, v)| serde_json::json!({"event": k, "count": v})).collect::<Vec<_>>(),
-            "by_day": stats.by_day.iter().map(|(k, v)| serde_json::json!({"day": k, "count": v})).collect::<Vec<_>>(),
+            "by_rule_compliance": stats.by_rule_compliance,
         });
+        if !by_rule_only {
+            out["by_rule"] = serde_json::Value::Array(
+                stats
+                    .by_rule
+                    .iter()
+                    .map(|(k, v)| serde_json::json!({"rule": k, "count": v}))
+                    .collect(),
+            );
+            out["by_tool"] = serde_json::Value::Array(
+                stats
+                    .by_tool
+                    .iter()
+                    .map(|(k, v)| serde_json::json!({"tool": k, "count": v}))
+                    .collect(),
+            );
+            out["by_event"] = serde_json::Value::Array(
+                stats
+                    .by_event
+                    .iter()
+                    .map(|(k, v)| serde_json::json!({"event": k, "count": v}))
+                    .collect(),
+            );
+            out["by_day"] = serde_json::Value::Array(
+                stats
+                    .by_day
+                    .iter()
+                    .map(|(k, v)| serde_json::json!({"day": k, "count": v}))
+                    .collect(),
+            );
+        }
         println!("{}", serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?);
         return Ok(());
     }
 
-    print_table(&stats, top);
+    print_table(&stats, top, by_rule_only);
     Ok(())
 }
 
-fn print_table(stats: &Stats, top: usize) {
-    if stats.total_firings == 0 {
+fn print_table(stats: &Stats, top: usize, by_rule_only: bool) {
+    if stats.total_firings == 0 && stats.by_rule_compliance.is_empty() {
         println!("No audit entries.  Rules haven't fired yet, or --since excluded everything.");
         return;
     }
@@ -143,7 +296,13 @@ fn print_table(stats: &Stats, top: usize) {
     }
     println!();
 
+    if by_rule_only {
+        print_compliance_section(&stats.by_rule_compliance, top);
+        return;
+    }
+
     print_section("Top rules", &stats.by_rule, top);
+    print_compliance_section(&stats.by_rule_compliance, top);
     print_section("By tool", &stats.by_tool, top);
     print_section("By event", &stats.by_event, top);
     print_section("By day", &stats.by_day, top);
@@ -167,21 +326,73 @@ fn print_section(title: &str, rows: &[(String, usize)], top: usize) {
     println!();
 }
 
+fn print_compliance_section(rows: &[RuleCompliance], top: usize) {
+    if rows.is_empty() {
+        return;
+    }
+    let any_outcomes = rows.iter().any(|r| r.obeyed + r.ignored + r.unclear > 0);
+    println!("Per-rule compliance");
+    if !any_outcomes {
+        println!("  (no Compliance events yet — Pre/Post correlation produces these on PostToolUse)");
+    }
+    println!(
+        "  {:>5} {:>6} {:>7} {:>7} {:>7}  rule",
+        "fires", "obeyed", "ignored", "unclear", "ratio",
+    );
+    for r in rows.iter().take(top) {
+        let ratio = match r.ratio {
+            Some(v) => format!("{:>6.0}%", v * 100.0),
+            None => "  —  ".to_string(),
+        };
+        // Visual nudge for rules the model is routing around.
+        let flag = match r.ratio {
+            Some(v) if v < 0.6 && (r.obeyed + r.ignored) >= 2 => " ⚠",
+            _ => "",
+        };
+        println!(
+            "  {:>5} {:>6} {:>7} {:>7} {:>7}  {} {}: {}{}",
+            r.fires, r.obeyed, r.ignored, r.unclear, ratio,
+            r.subject, r.predicate, r.object, flag,
+        );
+    }
+    if rows.len() > top {
+        println!("        … {} more", rows.len() - top);
+    }
+    println!();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
 
-    fn e(ts: &str, tool: &str, event: &str, subj: &str, pred: &str, obj: &str) -> Value {
+    fn pre_firing(ts: &str, tool: &str, triple_id: i64, subj: &str, pred: &str, obj: &str) -> Value {
         json!({
             "ts": ts,
             "tool": tool,
-            "event": event,
+            "event": "PreToolUse",
             "rules": [{
+                "triple_id": triple_id,
                 "subject": subj,
                 "predicate": pred,
                 "object": obj,
             }],
+        })
+    }
+
+    fn compliance_event(ts: &str, tool: &str, triple_id: i64, outcome: &str) -> Value {
+        json!({
+            "ts": ts,
+            "tool": tool,
+            "event": "Compliance",
+            "payload": {
+                "rules": [{
+                    "triple_id": triple_id,
+                    "predicate": "never",
+                    "object": "force-push",
+                    "outcome": outcome,
+                }]
+            }
         })
     }
 
@@ -190,14 +401,15 @@ mod tests {
         let stats = compute(&[]);
         assert_eq!(stats.total_firings, 0);
         assert!(stats.by_rule.is_empty());
+        assert!(stats.by_rule_compliance.is_empty());
     }
 
     #[test]
     fn test_rule_count_aggregation() {
         let entries = vec![
-            e("2026-04-20T10:00:00Z", "Bash", "PreToolUse", "git", "never", "force-push"),
-            e("2026-04-20T11:00:00Z", "Bash", "PreToolUse", "git", "never", "force-push"),
-            e("2026-04-20T12:00:00Z", "Write", "PreToolUse", "alembic", "never", "hand-write"),
+            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "git", "never", "force-push"),
+            pre_firing("2026-04-20T11:00:00Z", "Bash", 1, "git", "never", "force-push"),
+            pre_firing("2026-04-20T12:00:00Z", "Write", 2, "alembic", "never", "hand-write"),
         ];
         let stats = compute(&entries);
         assert_eq!(stats.total_firings, 3);
@@ -209,9 +421,14 @@ mod tests {
     #[test]
     fn test_tool_and_event_counts() {
         let entries = vec![
-            e("2026-04-20T10:00:00Z", "Bash", "PreToolUse", "a", "b", "c"),
-            e("2026-04-20T10:01:00Z", "Bash", "PostToolUse", "a", "b", "c"),
-            e("2026-04-20T10:02:00Z", "Write", "PreToolUse", "a", "b", "c"),
+            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "a", "b", "c"),
+            json!({
+                "ts": "2026-04-20T10:01:00Z",
+                "tool": "Bash",
+                "event": "PostToolUse",
+                "rules": [{"triple_id": 1, "subject": "a", "predicate": "b", "object": "c"}]
+            }),
+            pre_firing("2026-04-20T10:02:00Z", "Write", 2, "a", "b", "c"),
         ];
         let stats = compute(&entries);
         assert_eq!(stats.by_tool[0], ("Bash".to_string(), 2));
@@ -223,16 +440,14 @@ mod tests {
     fn test_by_day_ordering() {
         // Newer-first in input (matches audit::query output)
         let entries = vec![
-            e("2026-04-22T10:00:00Z", "Bash", "PreToolUse", "a", "b", "c"),
-            e("2026-04-20T10:00:00Z", "Bash", "PreToolUse", "a", "b", "c"),
-            e("2026-04-20T11:00:00Z", "Bash", "PreToolUse", "a", "b", "c"),
+            pre_firing("2026-04-22T10:00:00Z", "Bash", 1, "a", "b", "c"),
+            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "a", "b", "c"),
+            pre_firing("2026-04-20T11:00:00Z", "Bash", 1, "a", "b", "c"),
         ];
         let stats = compute(&entries);
-        // by_day is chronological ascending
         assert_eq!(stats.by_day[0].0, "2026-04-20");
         assert_eq!(stats.by_day[0].1, 2);
         assert_eq!(stats.by_day[1].0, "2026-04-22");
-        // window_start is oldest (last iterated), window_end is newest (first iterated)
         assert_eq!(stats.window_end.as_deref(), Some("2026-04-22T10:00:00Z"));
         assert_eq!(stats.window_start.as_deref(), Some("2026-04-20T11:00:00Z"));
     }
@@ -240,12 +455,88 @@ mod tests {
     #[test]
     fn test_rule_tiebreak_alphabetical() {
         let entries = vec![
-            e("2026-04-20T10:00:00Z", "Bash", "PreToolUse", "zebra", "never", "x"),
-            e("2026-04-20T11:00:00Z", "Bash", "PreToolUse", "alpha", "never", "x"),
+            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "zebra", "never", "x"),
+            pre_firing("2026-04-20T11:00:00Z", "Bash", 2, "alpha", "never", "x"),
         ];
         let stats = compute(&entries);
-        // equal counts → sorted alphabetically
         assert_eq!(stats.by_rule[0].0, "alpha never: x");
         assert_eq!(stats.by_rule[1].0, "zebra never: x");
+    }
+
+    #[test]
+    fn test_compliance_rollup_basic() {
+        // 3 Pre firings of rule 1, then 2 obeyed + 1 ignored verdicts.
+        let entries = vec![
+            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "git", "never", "force-push"),
+            pre_firing("2026-04-20T10:01:00Z", "Bash", 1, "git", "never", "force-push"),
+            pre_firing("2026-04-20T10:02:00Z", "Bash", 1, "git", "never", "force-push"),
+            compliance_event("2026-04-20T10:00:30Z", "Bash", 1, "obeyed"),
+            compliance_event("2026-04-20T10:01:30Z", "Bash", 1, "obeyed"),
+            compliance_event("2026-04-20T10:02:30Z", "Bash", 1, "ignored"),
+        ];
+        let stats = compute(&entries);
+
+        // Total firings excludes Compliance events.
+        assert_eq!(stats.total_firings, 3);
+
+        // One rule in the compliance roll-up.
+        assert_eq!(stats.by_rule_compliance.len(), 1);
+        let rc = &stats.by_rule_compliance[0];
+        assert_eq!(rc.triple_id, 1);
+        assert_eq!(rc.subject, "git");
+        assert_eq!(rc.predicate, "never");
+        assert_eq!(rc.fires, 3);
+        assert_eq!(rc.obeyed, 2);
+        assert_eq!(rc.ignored, 1);
+        assert_eq!(rc.unclear, 0);
+        // 2 / (2 + 1) = 0.666...
+        let ratio = rc.ratio.unwrap();
+        assert!((ratio - 2.0 / 3.0).abs() < 1e-9, "ratio = {ratio}");
+    }
+
+    #[test]
+    fn test_compliance_rollup_no_outcomes_yields_none_ratio() {
+        // Pre firings only, no Compliance events: ratio is None.
+        let entries = vec![
+            pre_firing("2026-04-20T10:00:00Z", "Bash", 7, "alembic", "never", "hand-write"),
+        ];
+        let stats = compute(&entries);
+        assert_eq!(stats.by_rule_compliance.len(), 1);
+        assert_eq!(stats.by_rule_compliance[0].fires, 1);
+        assert!(stats.by_rule_compliance[0].ratio.is_none());
+    }
+
+    #[test]
+    fn test_compliance_rollup_unclear_does_not_affect_ratio() {
+        // Only unclear verdicts: ratio remains None (no signal).
+        let entries = vec![
+            pre_firing("2026-04-20T10:00:00Z", "Bash", 5, "x", "always", "y"),
+            compliance_event("2026-04-20T10:00:30Z", "Bash", 5, "unclear"),
+            compliance_event("2026-04-20T10:01:30Z", "Bash", 5, "unclear"),
+        ];
+        let stats = compute(&entries);
+        assert_eq!(stats.by_rule_compliance.len(), 1);
+        let rc = &stats.by_rule_compliance[0];
+        assert_eq!(rc.unclear, 2);
+        assert_eq!(rc.obeyed, 0);
+        assert_eq!(rc.ignored, 0);
+        assert!(rc.ratio.is_none());
+    }
+
+    #[test]
+    fn test_compliance_rollup_sort_order() {
+        // Two rules: rule 1 fires more, rule 2 has more ignored — fires
+        // breaks the tie first, so rule 1 wins.
+        let entries = vec![
+            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "a", "never", "x"),
+            pre_firing("2026-04-20T10:01:00Z", "Bash", 1, "a", "never", "x"),
+            pre_firing("2026-04-20T10:02:00Z", "Bash", 1, "a", "never", "x"),
+            pre_firing("2026-04-20T10:03:00Z", "Bash", 2, "b", "never", "y"),
+            compliance_event("2026-04-20T10:00:30Z", "Bash", 1, "obeyed"),
+            compliance_event("2026-04-20T10:03:30Z", "Bash", 2, "ignored"),
+        ];
+        let stats = compute(&entries);
+        assert_eq!(stats.by_rule_compliance[0].triple_id, 1);
+        assert_eq!(stats.by_rule_compliance[1].triple_id, 2);
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -92,7 +92,8 @@ impl Store {
                 allow_inverse INTEGER DEFAULT 0,
                 enriched_by TEXT DEFAULT 'taxonomy',
                 enriched_at TEXT,
-                severity TEXT NOT NULL DEFAULT 'warn'
+                severity TEXT NOT NULL DEFAULT 'warn',
+                severity_override TEXT
             );
 
             PRAGMA foreign_keys = ON;
@@ -103,6 +104,14 @@ impl Store {
         // call on every open — the ALTER is a no-op once the column exists.
         let _ = self.conn.execute(
             "ALTER TABLE rule_intent ADD COLUMN severity TEXT NOT NULL DEFAULT 'warn'",
+            [],
+        );
+
+        // Migration: per-rule severity override.  Survives `arai scan` re-
+        // classification (which would otherwise stomp the predicate-derived
+        // severity back).  NULL means "use the classified severity".
+        let _ = self.conn.execute(
+            "ALTER TABLE rule_intent ADD COLUMN severity_override TEXT",
             [],
         );
 
@@ -366,9 +375,13 @@ impl Store {
     }
 
     /// Get the intent for a specific triple.
+    ///
+    /// If a `severity_override` row is present, it takes precedence over the
+    /// classified severity — that's the surface `arai severity` writes to so
+    /// re-running `arai scan` doesn't stomp a manual rollout decision.
     pub fn get_rule_intent(&self, triple_id: i64) -> rusqlite::Result<Option<crate::intent::RuleIntent>> {
         match self.conn.query_row(
-            "SELECT action, timing, tools, allow_inverse, enriched_by, severity FROM rule_intent WHERE triple_id = ?1",
+            "SELECT action, timing, tools, allow_inverse, enriched_by, severity, severity_override FROM rule_intent WHERE triple_id = ?1",
             params![triple_id],
             |row| {
                 let action_str: String = row.get(0)?;
@@ -377,9 +390,15 @@ impl Store {
                 let allow_inverse: i32 = row.get(3)?;
                 let enriched_by: String = row.get(4)?;
                 let severity_str: String = row.get::<_, Option<String>>(5)?.unwrap_or_else(|| "warn".to_string());
+                let severity_override: Option<String> = row.get(6)?;
 
                 let tools: Vec<String> = serde_json::from_str(&tools_json)
                     .unwrap_or_else(|_| vec!["*".to_string()]);
+
+                let effective = severity_override
+                    .as_deref()
+                    .map(crate::intent::Severity::from_str)
+                    .unwrap_or_else(|| crate::intent::Severity::from_str(&severity_str));
 
                 Ok(crate::intent::RuleIntent {
                     action: crate::intent::Action::from_str(&action_str),
@@ -387,7 +406,7 @@ impl Store {
                     tools,
                     allow_inverse: allow_inverse != 0,
                     enriched_by,
-                    severity: crate::intent::Severity::from_str(&severity_str),
+                    severity: effective,
                 })
             },
         ) {
@@ -395,6 +414,179 @@ impl Store {
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
             Err(e) => Err(e),
         }
+    }
+
+    /// Pin a rule's severity, surviving re-classification by `arai scan`.
+    /// Matches against the rule's subject or object via case-insensitive
+    /// substring; returns the rules that were updated (subject/predicate/
+    /// object/old/new) so the caller can echo the change.
+    ///
+    /// Empty pattern matches every active guardrail — the CLI surface should
+    /// reject empty input rather than rely on this; we don't here so unit
+    /// tests can simulate "set everything" without scaffolding.
+    pub fn set_severity_override(
+        &self,
+        pattern: &str,
+        severity: crate::intent::Severity,
+    ) -> rusqlite::Result<Vec<SeverityChange>> {
+        let needle = pattern.to_lowercase();
+        let guardrails = self.load_guardrails()?;
+        let mut changed = Vec::new();
+        for g in guardrails {
+            let matches = needle.is_empty()
+                || g.subject.to_lowercase().contains(&needle)
+                || g.object.to_lowercase().contains(&needle);
+            if !matches {
+                continue;
+            }
+
+            // Read current effective severity so the caller can show the
+            // delta in a single round-trip.
+            let prev = self
+                .get_rule_intent(g.triple_id)?
+                .map(|i| i.severity)
+                .unwrap_or_else(|| crate::intent::Severity::from_predicate(&g.predicate));
+
+            // Ensure a row exists in rule_intent before setting the override —
+            // a brand-new store may not have been classified yet.
+            self.conn.execute(
+                "INSERT OR IGNORE INTO rule_intent (triple_id, severity_override) VALUES (?1, ?2)",
+                params![g.triple_id, severity.as_str()],
+            )?;
+            self.conn.execute(
+                "UPDATE rule_intent SET severity_override = ?2 WHERE triple_id = ?1",
+                params![g.triple_id, severity.as_str()],
+            )?;
+
+            changed.push(SeverityChange {
+                triple_id: g.triple_id,
+                subject: g.subject,
+                predicate: g.predicate,
+                object: g.object,
+                source: g.file_path,
+                from: prev,
+                to: severity,
+            });
+        }
+        Ok(changed)
+    }
+
+    /// Drop a severity override; the rule reverts to its predicate-derived
+    /// classification.  Returns the rules whose override was cleared.
+    pub fn clear_severity_override(&self, pattern: &str) -> rusqlite::Result<Vec<SeverityChange>> {
+        let needle = pattern.to_lowercase();
+        let guardrails = self.load_guardrails()?;
+        let mut cleared = Vec::new();
+        for g in guardrails {
+            let matches = needle.is_empty()
+                || g.subject.to_lowercase().contains(&needle)
+                || g.object.to_lowercase().contains(&needle);
+            if !matches {
+                continue;
+            }
+
+            // Only clear rows that actually have an override — otherwise we
+            // misreport "cleared 50 rules" when nothing was pinned.
+            let had: Option<String> = self
+                .conn
+                .query_row(
+                    "SELECT severity_override FROM rule_intent WHERE triple_id = ?1",
+                    params![g.triple_id],
+                    |row| row.get(0),
+                )
+                .ok()
+                .flatten();
+            if had.is_none() {
+                continue;
+            }
+
+            self.conn.execute(
+                "UPDATE rule_intent SET severity_override = NULL WHERE triple_id = ?1",
+                params![g.triple_id],
+            )?;
+
+            let from = had
+                .as_deref()
+                .map(crate::intent::Severity::from_str)
+                .unwrap_or_else(|| crate::intent::Severity::from_predicate(&g.predicate));
+            let to = crate::intent::Severity::from_predicate(&g.predicate);
+            cleared.push(SeverityChange {
+                triple_id: g.triple_id,
+                subject: g.subject,
+                predicate: g.predicate,
+                object: g.object,
+                source: g.file_path,
+                from,
+                to,
+            });
+        }
+        Ok(cleared)
+    }
+
+    /// List every active rule that carries a severity override.
+    pub fn list_severity_overrides(&self) -> rusqlite::Result<Vec<SeverityChange>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT t.id, t.s, t.p, t.o, f.path, ri.severity_override
+             FROM triples t
+             JOIN files f ON t.file_id = f.id
+             JOIN rule_intent ri ON ri.triple_id = t.id
+             WHERE ri.severity_override IS NOT NULL
+               AND t.p IN ('forbids','must_not','never','always','requires','enforces','prefers')
+               AND (t.expires_at IS NULL OR t.expires_at >= date('now'))
+             ORDER BY t.s, t.p, t.o",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let triple_id: i64 = row.get(0)?;
+            let subject: String = row.get(1)?;
+            let predicate: String = row.get(2)?;
+            let object: String = row.get(3)?;
+            let source: String = row.get(4)?;
+            let override_str: String = row.get(5)?;
+            let from = crate::intent::Severity::from_predicate(&predicate);
+            let to = crate::intent::Severity::from_str(&override_str);
+            Ok(SeverityChange {
+                triple_id,
+                subject,
+                predicate,
+                object,
+                source,
+                from,
+                to,
+            })
+        })?;
+        rows.collect()
+    }
+
+    /// Fetch the live SPO triples for a single source file path.  Used by
+    /// `arai diff` to compare what's currently in the store against what the
+    /// candidate file would extract — no `JOIN files` because we already know
+    /// the path the caller passed in.
+    pub fn rules_for_file(&self, file_path: &str) -> rusqlite::Result<Vec<Guardrail>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT t.id, t.s, t.p, t.o, t.confidence, t.source_file, f.path, t.layer, t.line_start, t.expires_at
+             FROM triples t
+             JOIN files f ON t.file_id = f.id
+             WHERE f.path = ?1
+               AND t.p IN ('forbids','must_not','never','always','requires','enforces','prefers')
+             ORDER BY t.line_start, t.s, t.p, t.o",
+        )?;
+        let guardrails = stmt
+            .query_map(params![file_path], |row| {
+                Ok(Guardrail {
+                    triple_id: row.get(0)?,
+                    subject: row.get(1)?,
+                    predicate: row.get(2)?,
+                    object: row.get(3)?,
+                    confidence: row.get(4)?,
+                    source_file: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
+                    file_path: row.get(6)?,
+                    layer: row.get::<_, Option<i64>>(7)?.map(|v| v as u8),
+                    line_start: row.get::<_, Option<i64>>(8)?,
+                    expires_at: row.get::<_, Option<String>>(9)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(guardrails)
     }
 
     /// Find pairs of rules that potentially conflict or duplicate.
@@ -500,6 +692,20 @@ pub struct DuplicateRule {
 pub struct OpposingRules {
     pub subject: String,
     pub predicates: Vec<String>,
+}
+
+/// One row in the output of `set_severity_override` / `list_severity_overrides`.
+/// Captures both the previous and new severity so the CLI can render a
+/// diff line per rule without a second query.
+#[derive(Debug, serde::Serialize)]
+pub struct SeverityChange {
+    pub triple_id: i64,
+    pub subject: String,
+    pub predicate: String,
+    pub object: String,
+    pub source: String,
+    pub from: crate::intent::Severity,
+    pub to: crate::intent::Severity,
 }
 
 fn is_prohibitive(p: &str) -> bool {
@@ -715,6 +921,142 @@ mod tests {
         assert_eq!(store.get_meta("last_scan").unwrap(), None);
         store.set_meta("last_scan", "12345").unwrap();
         assert_eq!(store.get_meta("last_scan").unwrap(), Some("12345".to_string()));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_severity_override_round_trip() {
+        let (store, dir) = temp_db();
+        let t = Triple {
+            subject: "alembic".to_string(),
+            predicate: "prefers".to_string(),
+            object: "autogenerate".to_string(),
+            confidence: 0.9,
+            domain: "general".to_string(),
+            source_file: "CLAUDE.md".to_string(),
+            line_start: Some(1),
+            line_end: Some(1),
+            layer: Some(1),
+            expires_at: None,
+        };
+        store.upsert_file("CLAUDE.md", "x", &[t], "claude_md_project").unwrap();
+        store.classify_all_guardrails().unwrap();
+
+        // Predicate-derived: prefers → Inform.
+        let g = &store.load_guardrails().unwrap()[0];
+        assert_eq!(
+            store.get_rule_intent(g.triple_id).unwrap().unwrap().severity,
+            crate::intent::Severity::Inform
+        );
+
+        // Pin to Block.
+        let changed = store
+            .set_severity_override("alembic", crate::intent::Severity::Block)
+            .unwrap();
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].from, crate::intent::Severity::Inform);
+        assert_eq!(changed[0].to, crate::intent::Severity::Block);
+        assert_eq!(
+            store.get_rule_intent(g.triple_id).unwrap().unwrap().severity,
+            crate::intent::Severity::Block,
+            "override should win over classified severity"
+        );
+
+        // Re-classify: must NOT stomp the override.
+        store.classify_all_guardrails().unwrap();
+        assert_eq!(
+            store.get_rule_intent(g.triple_id).unwrap().unwrap().severity,
+            crate::intent::Severity::Block,
+            "classify_all_guardrails should preserve manual overrides"
+        );
+
+        // List shows the pinned rule.
+        let listed = store.list_severity_overrides().unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].subject, "alembic");
+        assert_eq!(listed[0].to, crate::intent::Severity::Block);
+
+        // Clear it: severity reverts to predicate-derived.
+        let cleared = store.clear_severity_override("alembic").unwrap();
+        assert_eq!(cleared.len(), 1);
+        assert!(store.list_severity_overrides().unwrap().is_empty());
+        assert_eq!(
+            store.get_rule_intent(g.triple_id).unwrap().unwrap().severity,
+            crate::intent::Severity::Inform,
+            "after clear, severity should fall back to classification"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_severity_override_pattern_match_is_substring() {
+        let (store, dir) = temp_db();
+        let mk = |s: &str, line: i64| Triple {
+            subject: s.to_string(),
+            predicate: "never".to_string(),
+            object: format!("{s}-action"),
+            confidence: 0.9,
+            domain: "general".to_string(),
+            source_file: "CLAUDE.md".to_string(),
+            line_start: Some(line),
+            line_end: Some(line),
+            layer: Some(1),
+            expires_at: None,
+        };
+        store
+            .upsert_file("CLAUDE.md", "x", &[mk("alembic", 1), mk("git", 2), mk("cargo", 3)], "claude_md_project")
+            .unwrap();
+        store.classify_all_guardrails().unwrap();
+
+        // Pattern matches by case-insensitive substring on subject OR object.
+        let changed = store
+            .set_severity_override("ALEM", crate::intent::Severity::Inform)
+            .unwrap();
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].subject, "alembic");
+
+        // Clear with a no-match pattern is a no-op (doesn't reset other rules).
+        let cleared = store.clear_severity_override("nope").unwrap();
+        assert!(cleared.is_empty());
+        assert_eq!(store.list_severity_overrides().unwrap().len(), 1);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_rules_for_file_returns_only_that_file() {
+        let (store, dir) = temp_db();
+        let mk_in = |path_prefix: &str, line: i64| Triple {
+            subject: format!("{path_prefix}-rule"),
+            predicate: "never".to_string(),
+            object: "do bad".to_string(),
+            confidence: 0.9,
+            domain: "general".to_string(),
+            source_file: path_prefix.to_string(),
+            line_start: Some(line),
+            line_end: Some(line),
+            layer: Some(1),
+            expires_at: None,
+        };
+        store
+            .upsert_file("CLAUDE.md", "a", &[mk_in("CLAUDE.md", 1)], "claude_md_project")
+            .unwrap();
+        store
+            .upsert_file("memory/feedback.md", "b", &[mk_in("memory/feedback.md", 1)], "memory")
+            .unwrap();
+
+        let claude_rules = store.rules_for_file("CLAUDE.md").unwrap();
+        assert_eq!(claude_rules.len(), 1);
+        assert_eq!(claude_rules[0].subject, "CLAUDE.md-rule");
+
+        let memory_rules = store.rules_for_file("memory/feedback.md").unwrap();
+        assert_eq!(memory_rules.len(), 1);
+        assert_eq!(memory_rules[0].subject, "memory/feedback.md-rule");
+
+        let nothing = store.rules_for_file("nonexistent.md").unwrap();
+        assert!(nothing.is_empty());
 
         std::fs::remove_dir_all(&dir).ok();
     }


### PR DESCRIPTION
## Summary

Five adds that complete loops Arai already started — surface data the
audit log already collects, finish the incremental-rollout story, and
mirror the maintainer-side feedback to the agent. No AST-driven rule
discovery, no embeddings, no hosted features (we resisted those by
design — they belong in Kete or its own product).

### `arai stats` — per-rule compliance roll-up
Joins Pre firings to Compliance verdicts via `triple_id` and reports
`fires / obeyed / ignored / unclear / ratio` per rule:

```
Per-rule compliance
  fires obeyed ignored unclear   ratio  rule
     12     11       1       0     92%  alembic must_not: hand-write migrations
      7      4       3       0     57%  git must_not: --no-verify  ⚠
      9      9       0       0    100%  cargo always: test before commit
```

`arai stats --by-rule` shows only this section. The ⚠ flag marks
rules with low ratios and enough volume (`obeyed + ignored >= 2`,
`ratio < 60%`) for the maintainer to act on.

### `arai severity` — per-rule deny-mode rollout
Solves the gap left by the all-or-nothing `ARAI_DENY_MODE` env var.
Stored in a new `rule_intent.severity_override` column that survives
`arai scan` re-classification; `get_rule_intent` returns the override
when set, falls back to predicate-derived otherwise.

```bash
arai severity                          # list active overrides
arai severity alembic block            # pin to block (case-insensitive substring)
arai severity --reset alembic          # drop the override
```

### `arai_recent_decisions` MCP tool
Closes the model-side feedback loop. After a deny, the agent can call
this to see what it was just refused for instead of looping on the
same refused action. Filters by `session_id`, `limit`, `since`. Skips
Compliance events (verdicts, not decisions).

### `arai audit --rule <pattern>`
Case-insensitive substring against subject/predicate/object across
both top-level firings and Compliance `payload.rules[]`. Pairs with
`--outcome=ignored` for "every time the alembic rule was ignored
this week".

### `arai diff <file>`
Preview rule-set delta vs. the live store before saving an
instruction-file edit. Reports added / removed / moved (same SPO,
different line). `--json` for pre-commit hooks.

## Why these five, why now

These complete the compliance + rollout loops Arai already collects
data for, without expanding scope. Three of the five (stats, audit,
recent_decisions) just surface existing data more usefully; the
other two finish partially-built rollout/authoring loops (severity
rollout per rule, edit preview).

Explicitly **not** included:
- AST-driven rule discovery (Kete territory)
- Embedding-based rule similarity (kills the <5ms hook budget)
- Cross-tool hook enforcement (no other agent has a comparable
  hook surface)
- Hosted/team aggregation (issue #29 still gates this on demand)

## Test plan

- [ ] `cargo test` (CI runs this; new unit tests cover severity
      override round-trip + preserve-on-reclassify, stats compliance
      roll-up with all three outcomes, audit `entry_rules` /
      `rule_matches_pattern` helpers, MCP tool list count + since
      parser)
- [ ] `cargo clippy -- -D warnings` (CI runs this)
- [ ] Manual: `arai severity` listing with no overrides
- [ ] Manual: pin a rule, run `arai scan`, verify override survives
- [ ] Manual: `arai stats` after a session with denies + post events
- [ ] Manual: `arai diff CLAUDE.md` after editing a rule line
- [ ] Manual: `arai audit --rule alembic --outcome=ignored`

## Migration notes

Adds one nullable column (`rule_intent.severity_override`) via an
idempotent `ALTER TABLE`. No existing rules change behaviour: the
column defaults to NULL, and `get_rule_intent` falls back to the
classified severity when no override is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)