### PR TITLE
feat: per-session repeat-injection suppression + token-economics estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- *(hooks)* Per-session repeat-injection suppression.  When a rule
+  fires a second time in the same session, the hook emits a compact
+  "still: subject predicate object" line instead of re-injecting
+  the full source / layer / severity payload — the model already
+  has that context from the first firing.  Saves roughly 50 tokens
+  per re-fire on long sessions and reduces attention dilution from
+  reading the same rule N times.
+- *(audit)* New `seen_before` flag per rule on every firing entry.
+  `arai stats` rolls this up into a suppression count.  Additive
+  field; older audit lines are treated as `seen_before: false`.
+- *(stats)* Token-economics section in `arai stats` — calibrated
+  estimates of saved tokens from three streams: repeat-injection
+  suppressions (50 each), denied-and-honored mistakes (2000 each),
+  advised-and-honored events (500 each).  Labelled as estimates,
+  not measurements; constants documented in `src/stats.rs`.  JSON
+  output exposes a `token_economics` object with the per-stream
+  counts.
+
 ## [0.2.8] - 2026-04-29
 
 This release closes attack surfaces flagged in an internal audit. No known

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ src/
 ├── enrich.rs             # Tier 2 (ONNX sentence transformer) + Tier 3 (LLM shell-out)
 ├── audit.rs              # Local JSONL firing log — record_firing, record_event, layer_label
 ├── compliance.rs         # Pre/Post correlation — Obeyed/Ignored/Unclear verdicts per rule
-├── stats.rs              # Aggregate views — `arai stats`, per-rule compliance roll-up
+├── stats.rs              # Aggregate views — `arai stats`, per-rule compliance, token economics
 ├── scenarios.rs          # Scenario replay harness — `arai test <file>`
 ├── extends.rs            # `arai:extends` upstream-policy fetch + trust list
 ├── mcp.rs                # Stdio MCP server — arai_add_guard + arai_list_guards for agent-authored rules

--- a/README.md
+++ b/README.md
@@ -301,6 +301,43 @@ unrelated commands followed.
 Nothing leaves the machine — stats are a local view over your own
 audit log.
 
+## Token economics — calibrated estimates
+
+`arai stats` also surfaces a *token economics* section with
+calibrated estimates of how Arai is affecting your model's token
+burn. Two streams contribute:
+
+```
+Token economics (estimates)
+     12  repeat-injection suppressions  (~600 tokens, 50 ea.)
+      4  denied-and-honored mistakes    (~8000 tokens, 2000 ea.)
+     17  advised-and-honored events     (~8500 tokens, 500 ea.)
+            total estimated tokens saved:  ~17100
+            (calibrated estimates, not measurements)
+```
+
+- **Repeat-injection suppressions** — when a rule fires a second
+  time in the same session, Arai emits a compact "still: subject
+  predicate object" line instead of re-injecting the full source /
+  layer / severity payload. The model already has that context from
+  the first firing. The 50-token estimate is the rough delta
+  between the full and compact forms.
+- **Denied-and-honored mistakes** — a `block`-severity rule fired,
+  the model would otherwise have run a destructive action, and the
+  PostToolUse correlation confirms it didn't. The 2000-token
+  estimate is a conservative bound on what "fix the mess" cycles
+  cost (revert files, undo migrations, rollback deploys).
+- **Advised-and-honored events** — a `warn` or `inform` rule fired
+  and the model complied. Lower confidence saving (the model might
+  have done the right thing anyway), so a smaller 500-token
+  estimate.
+
+These are **estimates, not measurements**. The constants live in
+[`src/stats.rs`](src/stats.rs) and are documented there; treat the
+total as an order-of-magnitude reading, not a precise number. If
+you want to see the underlying counts, `arai stats --json` exposes
+the `token_economics` object with all three streams broken out.
+
 ## Severity — per-rule deny-mode rollout
 
 `arai severity` pins a rule's enforcement strength so re-running

--- a/site/index.html
+++ b/site/index.html
@@ -309,6 +309,10 @@
                 <p><code>arai stats</code> rolls up the audit log into <em>fires / obeyed / ignored / ratio</em> per rule. Now you can answer "is this rule actually working?" &mdash; not "is it firing?" The &#x26A0; flag highlights low-ratio rules with enough volume to mean it.</p>
             </div>
             <div class="feature">
+                <h3>Token economics</h3>
+                <p>Repeat firings of the same rule in a session emit a compact one-liner instead of re-injecting the full payload. <code>arai stats</code> surfaces a calibrated <em>tokens saved</em> estimate from suppressed repeats plus denied-and-honored mistakes &mdash; secondary signal, primary mission stays correctness.</p>
+            </div>
+            <div class="feature">
                 <h3>Rule regression tests</h3>
                 <p><code>arai test</code> replays synthetic hook payloads through the live match pipeline. Catch rule behaviour drift before a real session does. CI-friendly JSON output.</p>
             </div>

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -48,6 +48,13 @@ pub fn layer_label(layer: u8) -> &'static str {
 /// available.  Falls back to predicate-derived severity otherwise.  `db` may
 /// be `None` for callers that don't hold an open connection (offline tools,
 /// tests) — the log entry is still written, just without enriched severity.
+///
+/// `seen_set` carries the triple_ids that have already been fully injected
+/// earlier in this session.  Each rule entry in the audit log records a
+/// `seen_before` boolean so `arai stats` can roll up the token-economics
+/// view of how often the compact-format suppression kicked in.  Pass an
+/// empty set when the caller doesn't track session state (every rule is
+/// recorded as `seen_before: false` → first-time injection).
 #[allow(clippy::too_many_arguments)]
 pub fn record_firing(
     cfg: &Config,
@@ -58,6 +65,7 @@ pub fn record_firing(
     matched: &[(Guardrail, u8)],
     decision: &str,
     db: Option<&Store>,
+    seen_set: &std::collections::HashSet<i64>,
 ) {
     if matched.is_empty() {
         return;
@@ -88,6 +96,7 @@ pub fn record_firing(
                 "confidence": g.confidence,
                 "match_pct": pct,
                 "severity": severity.as_str(),
+                "seen_before": seen_set.contains(&g.triple_id),
             });
             // Derivation trace: parser layer + label + line, so reviewers can see
             // "fired from CLAUDE.md:42 (layer-1 imperative)" without opening

--- a/src/guardrails.rs
+++ b/src/guardrails.rs
@@ -343,16 +343,35 @@ const MAX_RULES_PER_HOOK: usize = 5;
 
 /// Format matched guardrails as additionalContext string.
 /// Limits output to the top N rules by confidence to avoid context bloat.
-pub fn format_context(matched: &[(Guardrail, u8)]) -> String {
+///
+/// When `seen_set` contains a rule's `triple_id`, that rule was already
+/// fully injected earlier in the same session and the model has its full
+/// text in context.  We emit a compact one-liner for it instead — saves
+/// roughly 50 tokens per re-fire and reduces attention dilution from
+/// repeated re-reads of the same rule.  Pass `&Default::default()` if
+/// seen-tracking is unavailable (e.g. unit tests, empty session_id).
+pub fn format_context(
+    matched: &[(Guardrail, u8)],
+    seen_set: &std::collections::HashSet<i64>,
+) -> String {
     let mut lines: Vec<String> = Vec::new();
     lines.push("Arai guardrails:".to_string());
     let limit = matched.len().min(MAX_RULES_PER_HOOK);
     for (g, pct) in &matched[..limit] {
-        let trace = format_trace(g);
-        lines.push(format!(
-            "- {} {}: {} ({}% match){}",
-            g.subject, g.predicate, g.object, pct, trace
-        ));
+        if seen_set.contains(&g.triple_id) {
+            // Compact form: model already has the full text from earlier
+            // in this session; just remind it the rule is still active.
+            lines.push(format!(
+                "- still: {} {} {} ({}% match)",
+                g.subject, g.predicate, g.object, pct
+            ));
+        } else {
+            let trace = format_trace(g);
+            lines.push(format!(
+                "- {} {}: {} ({}% match){}",
+                g.subject, g.predicate, g.object, pct, trace
+            ));
+        }
     }
     if matched.len() > MAX_RULES_PER_HOOK {
         lines.push(format!("  ({} more suppressed)", matched.len() - MAX_RULES_PER_HOOK));
@@ -706,5 +725,66 @@ mod tests {
             "push rule should not fire for pull command");
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    fn mk_guardrail(triple_id: i64, subject: &str, predicate: &str, object: &str) -> Guardrail {
+        Guardrail {
+            triple_id,
+            subject: subject.to_string(),
+            predicate: predicate.to_string(),
+            object: object.to_string(),
+            confidence: 0.9,
+            source_file: "CLAUDE.md".to_string(),
+            file_path: "CLAUDE.md".to_string(),
+            layer: Some(1),
+            line_start: Some(42),
+            expires_at: None,
+        }
+    }
+
+    #[test]
+    fn format_context_emits_full_form_for_unseen_rules() {
+        let matched = vec![(mk_guardrail(1, "git", "never", "force-push to main"), 95u8)];
+        let seen: std::collections::HashSet<i64> = std::collections::HashSet::new();
+        let ctx = format_context(&matched, &seen);
+        // Full form carries the source trace.
+        assert!(ctx.contains("CLAUDE.md:42"), "full form should cite source: {ctx:?}");
+        assert!(ctx.contains("layer-1"), "full form should cite layer: {ctx:?}");
+        assert!(!ctx.contains("still:"), "first injection should NOT use compact prefix");
+    }
+
+    #[test]
+    fn format_context_emits_compact_form_for_seen_rules() {
+        let matched = vec![(mk_guardrail(7, "git", "never", "force-push to main"), 95u8)];
+        let seen: std::collections::HashSet<i64> = [7i64].iter().copied().collect();
+        let ctx = format_context(&matched, &seen);
+        // Compact form drops source/layer trace; uses "still:" prefix.
+        assert!(ctx.contains("still:"), "repeat injection should use compact prefix");
+        assert!(!ctx.contains("CLAUDE.md:42"), "compact form should NOT re-cite source");
+        assert!(!ctx.contains("layer-1"), "compact form should NOT re-cite layer");
+        // Compact form is shorter — the whole point.
+        let unseen_ctx = format_context(&matched, &std::collections::HashSet::new());
+        assert!(
+            ctx.len() < unseen_ctx.len(),
+            "compact form should be shorter than full form ({} vs {})",
+            ctx.len(),
+            unseen_ctx.len(),
+        );
+    }
+
+    #[test]
+    fn format_context_mixes_full_and_compact_per_rule() {
+        // Two rules, only one already seen — output should have one full
+        // line and one compact line.
+        let matched = vec![
+            (mk_guardrail(1, "alembic", "must_not", "hand-write migrations"), 90u8),
+            (mk_guardrail(2, "git", "never", "force-push to main"), 95u8),
+        ];
+        let seen: std::collections::HashSet<i64> = [1i64].iter().copied().collect();
+        let ctx = format_context(&matched, &seen);
+        // alembic is seen → compact; git is fresh → full.
+        assert!(ctx.contains("- still: alembic must_not hand-write migrations"));
+        assert!(ctx.contains("git never: force-push to main"));
+        assert!(ctx.contains("[CLAUDE.md:42 layer-1]"));
     }
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -318,6 +318,19 @@ pub fn handle_stdin() -> Result<(), String> {
         ("PostToolUse", _) => "review",
         (other, _) => other,
     };
+    // Per-session seen-rule tracking.  Rules already fully injected earlier
+    // in this session emit a compact one-liner instead of re-injecting the
+    // full source/layer/severity payload — saves tokens on long sessions
+    // and avoids attention dilution from repeat re-reads.  Empty session_id
+    // means we can't track, so all matches behave as first-time injections.
+    let triple_ids: Vec<i64> = result.matched.iter().map(|(g, _)| g.triple_id).collect();
+    let (unseen, seen) = session::partition_seen_rules(
+        &cfg.arai_base_dir,
+        &result.session_id,
+        &triple_ids,
+    );
+    let seen_set: std::collections::HashSet<i64> = seen.iter().copied().collect();
+
     audit::record_firing(
         &cfg,
         &result.event,
@@ -327,9 +340,17 @@ pub fn handle_stdin() -> Result<(), String> {
         &result.matched,
         decision,
         Some(&db),
+        &seen_set,
     );
 
-    let context = guardrails::format_context(&result.matched);
+    let context = guardrails::format_context(&result.matched, &seen_set);
+
+    // Mark the unseen rules as seen now that we've emitted full context for
+    // them.  Done after the audit write so a panic between match and write
+    // doesn't permanently suppress a rule the model never actually saw.
+    if !unseen.is_empty() {
+        session::mark_rules_seen(&cfg.arai_base_dir, &result.session_id, &unseen);
+    }
     let response = match (result.event.as_str(), blocking) {
         ("PreToolUse", true) => {
             let reason = deny_reason(&result.matched, &db);

--- a/src/session.rs
+++ b/src/session.rs
@@ -12,6 +12,16 @@ struct ToolCallRecord {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct SessionState {
     tool_calls: Vec<ToolCallRecord>,
+    /// Triple IDs that have already had a full guardrail injection in this
+    /// session.  When the same rule fires a second time the hook handler
+    /// emits a compact one-liner instead of re-injecting source/layer/
+    /// severity that the model already saw — both for token economics and
+    /// because re-reading the same rule N times dilutes the model's
+    /// attention to it.  Defaulted to empty for old session files so the
+    /// first hook call after upgrade produces full context (the safe
+    /// fallback).
+    #[serde(default)]
+    seen_rules: Vec<i64>,
 }
 
 /// Get the session state file path.
@@ -82,6 +92,60 @@ pub fn prerequisite_met(
     })
 }
 
+/// Partition matched-rule triple_ids into `(unseen, seen)` for this session.
+/// Unseen → emit full context.  Seen → emit compact "still active" form.
+/// Reads session state once; doesn't mutate.  Empty `session_id` yields
+/// every id as unseen (we have no way to track without a session key).
+pub fn partition_seen_rules(
+    arai_base: &Path,
+    session_id: &str,
+    triple_ids: &[i64],
+) -> (Vec<i64>, Vec<i64>) {
+    if session_id.is_empty() {
+        return (triple_ids.to_vec(), Vec::new());
+    }
+    let state = load_session(arai_base, session_id);
+    let seen_set: std::collections::HashSet<i64> = state.seen_rules.iter().copied().collect();
+    let mut unseen = Vec::new();
+    let mut seen = Vec::new();
+    for id in triple_ids {
+        if seen_set.contains(id) {
+            seen.push(*id);
+        } else {
+            unseen.push(*id);
+        }
+    }
+    (unseen, seen)
+}
+
+/// Mark a batch of rules as having had their full context injected in this
+/// session.  Subsequent firings of the same triple_id in this session will
+/// emit a compact form via `partition_seen_rules`.  No-op for empty
+/// `session_id` (nothing to key on).
+pub fn mark_rules_seen(arai_base: &Path, session_id: &str, triple_ids: &[i64]) {
+    if session_id.is_empty() || triple_ids.is_empty() {
+        return;
+    }
+    let mut state = load_session(arai_base, session_id);
+    let mut existing: std::collections::HashSet<i64> = state.seen_rules.iter().copied().collect();
+    let mut changed = false;
+    for id in triple_ids {
+        if existing.insert(*id) {
+            state.seen_rules.push(*id);
+            changed = true;
+        }
+    }
+    if changed {
+        // Cap at 500 ids to prevent unbounded growth — a session that touches
+        // 500 distinct rules has bigger problems than the seen-rules list.
+        if state.seen_rules.len() > 500 {
+            let drop = state.seen_rules.len() - 500;
+            state.seen_rules.drain(..drop);
+        }
+        save_session(arai_base, session_id, &state);
+    }
+}
+
 /// Extract prerequisite terms from a rule's object text.
 /// Looks for patterns like "without running X first", "before X", "unless X".
 pub fn extract_prerequisite(object: &str) -> Vec<String> {
@@ -145,6 +209,81 @@ mod tests {
     fn test_extract_prerequisite_none() {
         let terms = extract_prerequisite("force-push to main");
         assert!(terms.is_empty());
+    }
+
+    #[test]
+    fn test_partition_seen_rules_empty_session_id_returns_all_unseen() {
+        // Without a session_id we can't track anything, so every id reads
+        // as unseen and the hook will emit full context for all of them.
+        let dir = std::env::temp_dir().join("arai_seen_test_empty");
+        let (unseen, seen) = partition_seen_rules(&dir, "", &[1, 2, 3]);
+        assert_eq!(unseen, vec![1, 2, 3]);
+        assert!(seen.is_empty());
+    }
+
+    #[test]
+    fn test_partition_and_mark_round_trip() {
+        let dir = std::env::temp_dir().join("arai_seen_test_round_trip");
+        std::fs::create_dir_all(&dir).ok();
+        let _ = std::fs::remove_file(session_path(&dir, "rt-sess"));
+
+        // Fresh session: nothing seen.
+        let (unseen, seen) = partition_seen_rules(&dir, "rt-sess", &[10, 20, 30]);
+        assert_eq!(unseen, vec![10, 20, 30]);
+        assert!(seen.is_empty());
+
+        // Mark 10 and 20 seen; 30 still unseen.
+        mark_rules_seen(&dir, "rt-sess", &[10, 20]);
+        let (unseen, seen) = partition_seen_rules(&dir, "rt-sess", &[10, 20, 30]);
+        assert_eq!(unseen, vec![30]);
+        assert_eq!(seen, vec![10, 20]);
+
+        // Marking already-seen ids is idempotent.
+        mark_rules_seen(&dir, "rt-sess", &[10, 20]);
+        let state = load_session(&dir, "rt-sess");
+        assert_eq!(state.seen_rules.len(), 2);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_seen_rules_isolated_per_session() {
+        let dir = std::env::temp_dir().join("arai_seen_test_isolated");
+        std::fs::create_dir_all(&dir).ok();
+        let _ = std::fs::remove_file(session_path(&dir, "iso-a"));
+        let _ = std::fs::remove_file(session_path(&dir, "iso-b"));
+
+        mark_rules_seen(&dir, "iso-a", &[100]);
+
+        // Different session — id 100 is fresh again.  This is the spec:
+        // a model in a new session needs the full rule context, even if
+        // a previous session already saw it.
+        let (unseen, _) = partition_seen_rules(&dir, "iso-b", &[100]);
+        assert_eq!(unseen, vec![100]);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_seen_rules_capped_at_500() {
+        // Defensive: an unbounded list could grow on a session that
+        // touches every rule in a 1000-rule project.  Cap at 500 to keep
+        // the JSON small; the cost is that very-old `seen_before`
+        // markers in a long session may roll out and a re-injection
+        // happens.  Acceptable given the cap.
+        let dir = std::env::temp_dir().join("arai_seen_test_cap");
+        std::fs::create_dir_all(&dir).ok();
+        let _ = std::fs::remove_file(session_path(&dir, "cap-sess"));
+
+        let many: Vec<i64> = (0..600).collect();
+        mark_rules_seen(&dir, "cap-sess", &many);
+        let state = load_session(&dir, "cap-sess");
+        assert_eq!(state.seen_rules.len(), 500, "should cap at 500 entries");
+        // The newest entries must be retained — drain pulls from the front.
+        assert_eq!(*state.seen_rules.last().unwrap(), 599);
+        assert_eq!(*state.seen_rules.first().unwrap(), 100);
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -32,6 +32,40 @@ pub struct Stats {
     /// run with the audit log shipping but no PostToolUse handler wired up,
     /// or projects where no Pre/Post pair has occurred).
     pub by_rule_compliance: Vec<RuleCompliance>,
+    /// Token-economics roll-up — calibrated estimates of saved + spent
+    /// tokens.  Not measurements; the constants are documented and
+    /// labelled as estimates everywhere.
+    pub token_economics: TokenEconomics,
+}
+
+/// Calibrated estimate of Arai's effect on token burn over the audit window.
+///
+/// Two streams contribute: the *suppression* stream (counted directly from
+/// `seen_before` flags on firings — repeat injections that emit a compact
+/// one-liner instead of the full rule payload) and the *counterfactual*
+/// stream (each `obeyed` Compliance verdict, weighted by the original Pre's
+/// severity, attributing the avoided cost of a mistake we believe we
+/// prevented).
+///
+/// **These are estimates, not measurements.**  The compact-form delta is a
+/// rough average from sampling a few real rules; the counterfactual
+/// constants are conservative bounds on what "fix the mess" cycles
+/// typically cost.  Calibration constants live in `compute()` so they can
+/// move without rewriting the audit log.
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct TokenEconomics {
+    /// Re-firings of a rule that already had its full context injected
+    /// earlier in the same session — these emit a compact form.
+    pub suppressed_repeats: usize,
+    /// `obeyed` Compliance verdicts where the original Pre was `block`
+    /// severity — i.e. denials the model honored.
+    pub blocked_obeyed: usize,
+    /// `obeyed` Compliance verdicts where the original Pre was advisory
+    /// (`warn` or `inform`) — the model complied without being denied.
+    pub advisory_obeyed: usize,
+    /// Sum of the three streams under the documented calibration constants.
+    /// Treat as an order-of-magnitude reading, not a precise number.
+    pub estimated_tokens_saved: usize,
 }
 
 /// Per-rule compliance record, joined across Pre firings (which carry
@@ -54,6 +88,26 @@ pub struct RuleCompliance {
     pub ratio: Option<f64>,
 }
 
+/// Calibration constants for `TokenEconomics`.  Documented here so they
+/// move atomically and the audit log never carries derived numbers that
+/// depend on a constant the user can't re-derive from the data.
+///
+/// - **Per suppression**: the byte-count delta between a full firing and
+///   a compact one-liner is roughly 200 chars (≈50 tokens at typical
+///   tokenisation).  Sampled by hand on a few representative rules.
+/// - **Per blocked-then-obeyed**: a denied destructive action that the
+///   model would otherwise have run typically costs 1–5K tokens of
+///   recovery (revert files, undo migrations, rollback push).  We pick
+///   2K as a conservative midpoint — over-claiming here would be the
+///   easy mistake to make.
+/// - **Per advisory-obeyed**: a warned-and-complied action saves less
+///   because we don't know the model wouldn't have done the right thing
+///   anyway.  500 tokens captures the value of the warning without
+///   over-attributing.
+const TOKENS_PER_SUPPRESSION: usize = 50;
+const TOKENS_PER_BLOCKED_OBEYED: usize = 2000;
+const TOKENS_PER_ADVISORY_OBEYED: usize = 500;
+
 /// Compute aggregate stats over audit entries.  Entries are the raw JSON
 /// values emitted by `audit::query`; this function never re-reads the log.
 pub fn compute(entries: &[Value]) -> Stats {
@@ -66,6 +120,11 @@ pub fn compute(entries: &[Value]) -> Stats {
     let mut tool_counts: HashMap<String, usize> = HashMap::new();
     let mut event_counts: HashMap<String, usize> = HashMap::new();
     let mut day_counts: HashMap<String, usize> = HashMap::new();
+
+    // Token-economics counters — accumulated as we walk the entries.
+    let mut suppressed_repeats: usize = 0;
+    let mut blocked_obeyed: usize = 0;
+    let mut advisory_obeyed: usize = 0;
 
     // Per-triple-id accumulators for the compliance roll-up.  We discover
     // SPO via Pre firings (which carry subject/predicate/object) and
@@ -131,6 +190,22 @@ pub fn compute(entries: &[Value]) -> Stats {
                         .and_then(|v| v.as_str())
                         .unwrap_or("")
                         .to_string();
+
+                    // Token-economics: weight obeyed verdicts by the
+                    // original Pre's severity.  Denied-and-honored is the
+                    // high-confidence saving (the model would otherwise
+                    // have run the destructive command); advisory-and-
+                    // honored is lower-confidence (we don't know the
+                    // model wouldn't have done the right thing anyway).
+                    if outcome == "obeyed" {
+                        let severity = r.get("severity").and_then(|v| v.as_str()).unwrap_or("");
+                        match severity {
+                            "block" => blocked_obeyed += 1,
+                            "warn" | "inform" => advisory_obeyed += 1,
+                            _ => {}
+                        }
+                    }
+
                     outcomes_by_pre
                         .entry((session.clone(), pre_ts, triple_id))
                         .or_default()
@@ -161,6 +236,15 @@ pub fn compute(entries: &[Value]) -> Stats {
                 }
                 let key = format!("{subj} {pred}: {obj}");
                 *rule_counts.entry(key).or_insert(0) += 1;
+
+                // Token-economics: a `seen_before` rule was emitted in the
+                // compact form, so the model didn't re-read the full
+                // payload.  Older audit entries don't carry the field —
+                // treat absent as `false` (first-time injection, no
+                // saving claimed).
+                if r.get("seen_before").and_then(|v| v.as_bool()).unwrap_or(false) {
+                    suppressed_repeats += 1;
+                }
 
                 // Compliance roll-up bookkeeping: remember the SPO for this
                 // triple_id (Compliance events only carry the id), and bump
@@ -253,6 +337,16 @@ pub fn compute(entries: &[Value]) -> Stats {
     });
     s.by_rule_compliance = compliance;
 
+    let estimated_tokens_saved = suppressed_repeats * TOKENS_PER_SUPPRESSION
+        + blocked_obeyed * TOKENS_PER_BLOCKED_OBEYED
+        + advisory_obeyed * TOKENS_PER_ADVISORY_OBEYED;
+    s.token_economics = TokenEconomics {
+        suppressed_repeats,
+        blocked_obeyed,
+        advisory_obeyed,
+        estimated_tokens_saved,
+    };
+
     s
 }
 
@@ -286,6 +380,7 @@ pub fn run(
             "window_start": stats.window_start,
             "window_end": stats.window_end,
             "by_rule_compliance": stats.by_rule_compliance,
+            "token_economics": stats.token_economics,
         });
         if !by_rule_only {
             out["by_rule"] = serde_json::Value::Array(
@@ -344,11 +439,13 @@ fn print_table(stats: &Stats, top: usize, by_rule_only: bool) {
 
     if by_rule_only {
         print_compliance_section(&stats.by_rule_compliance, top);
+        print_token_economics(&stats.token_economics);
         return;
     }
 
     print_section("Top rules", &stats.by_rule, top);
     print_compliance_section(&stats.by_rule_compliance, top);
+    print_token_economics(&stats.token_economics);
     print_section("By tool", &stats.by_tool, top);
     print_section("By event", &stats.by_event, top);
     print_section("By day", &stats.by_day, top);
@@ -369,6 +466,42 @@ fn print_section(title: &str, rows: &[(String, usize)], top: usize) {
     if rows.len() > top {
         println!("        … {} more", rows.len() - top);
     }
+    println!();
+}
+
+fn print_token_economics(t: &TokenEconomics) {
+    // Skip the section entirely when there's nothing to report — avoids
+    // bragging "0 tokens saved" on first runs.
+    if t.suppressed_repeats == 0 && t.blocked_obeyed == 0 && t.advisory_obeyed == 0 {
+        return;
+    }
+    println!("Token economics (estimates)");
+    if t.suppressed_repeats > 0 {
+        let saved = t.suppressed_repeats * TOKENS_PER_SUPPRESSION;
+        println!(
+            "  {:>5}  repeat-injection suppressions  (~{} tokens, {} ea.)",
+            t.suppressed_repeats, saved, TOKENS_PER_SUPPRESSION,
+        );
+    }
+    if t.blocked_obeyed > 0 {
+        let saved = t.blocked_obeyed * TOKENS_PER_BLOCKED_OBEYED;
+        println!(
+            "  {:>5}  denied-and-honored mistakes    (~{} tokens, {} ea.)",
+            t.blocked_obeyed, saved, TOKENS_PER_BLOCKED_OBEYED,
+        );
+    }
+    if t.advisory_obeyed > 0 {
+        let saved = t.advisory_obeyed * TOKENS_PER_ADVISORY_OBEYED;
+        println!(
+            "  {:>5}  advised-and-honored events     (~{} tokens, {} ea.)",
+            t.advisory_obeyed, saved, TOKENS_PER_ADVISORY_OBEYED,
+        );
+    }
+    println!(
+        "         total estimated tokens saved:  ~{}",
+        t.estimated_tokens_saved,
+    );
+    println!("         (calibrated estimates, not measurements — see CLAUDE.md)");
     println!();
 }
 
@@ -696,6 +829,156 @@ mod tests {
         assert_eq!(rc.ignored, 1, "first definitive wins, even if preceded by unclear");
         assert_eq!(rc.obeyed, 0);
         assert_eq!(rc.unclear, 0);
+    }
+
+    // ── Token economics ──────────────────────────────────────────────
+
+    fn pre_firing_seen(
+        ts: &str,
+        tool: &str,
+        triple_id: i64,
+        subj: &str,
+        pred: &str,
+        obj: &str,
+        seen_before: bool,
+    ) -> Value {
+        json!({
+            "ts": ts,
+            "tool": tool,
+            "event": "PreToolUse",
+            "session": "s1",
+            "rules": [{
+                "triple_id": triple_id,
+                "subject": subj,
+                "predicate": pred,
+                "object": obj,
+                "seen_before": seen_before,
+            }],
+        })
+    }
+
+    fn compliance_event_with_severity(
+        post_ts: &str,
+        tool: &str,
+        triple_id: i64,
+        outcome: &str,
+        pre_ts: &str,
+        severity: &str,
+    ) -> Value {
+        json!({
+            "ts": post_ts,
+            "tool": tool,
+            "event": "Compliance",
+            "session": "s1",
+            "payload": {
+                "rules": [{
+                    "triple_id": triple_id,
+                    "pre_ts": pre_ts,
+                    "predicate": "never",
+                    "object": "force-push",
+                    "severity": severity,
+                    "outcome": outcome,
+                }]
+            }
+        })
+    }
+
+    #[test]
+    fn test_token_economics_counts_suppressed_repeats() {
+        // 4 firings of rule 1: first is fresh, next 3 are seen_before.
+        // Suppression count is 3; tokens saved = 3 * 50 = 150.
+        let entries = vec![
+            pre_firing_seen("2026-04-20T10:00:00Z", "Bash", 1, "git", "never", "force-push", false),
+            pre_firing_seen("2026-04-20T10:01:00Z", "Bash", 1, "git", "never", "force-push", true),
+            pre_firing_seen("2026-04-20T10:02:00Z", "Bash", 1, "git", "never", "force-push", true),
+            pre_firing_seen("2026-04-20T10:03:00Z", "Bash", 1, "git", "never", "force-push", true),
+        ];
+        let stats = compute(&entries);
+        let t = &stats.token_economics;
+        assert_eq!(t.suppressed_repeats, 3);
+        assert_eq!(t.blocked_obeyed, 0);
+        assert_eq!(t.advisory_obeyed, 0);
+        assert_eq!(t.estimated_tokens_saved, 3 * 50);
+    }
+
+    #[test]
+    fn test_token_economics_weights_blocked_vs_advisory() {
+        // 2 obeyed-block + 3 obeyed-warn → 2*2000 + 3*500 = 5500.
+        let entries = vec![
+            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "git", "never", "force-push"),
+            pre_firing("2026-04-20T10:01:00Z", "Bash", 1, "git", "never", "force-push"),
+            pre_firing("2026-04-20T10:02:00Z", "Bash", 2, "cargo", "always", "test before commit"),
+            pre_firing("2026-04-20T10:03:00Z", "Bash", 2, "cargo", "always", "test before commit"),
+            pre_firing("2026-04-20T10:04:00Z", "Bash", 2, "cargo", "always", "test before commit"),
+            compliance_event_with_severity("2026-04-20T10:00:30Z", "Bash", 1, "obeyed", "2026-04-20T10:00:00Z", "block"),
+            compliance_event_with_severity("2026-04-20T10:01:30Z", "Bash", 1, "obeyed", "2026-04-20T10:01:00Z", "block"),
+            compliance_event_with_severity("2026-04-20T10:02:30Z", "Bash", 2, "obeyed", "2026-04-20T10:02:00Z", "warn"),
+            compliance_event_with_severity("2026-04-20T10:03:30Z", "Bash", 2, "obeyed", "2026-04-20T10:03:00Z", "warn"),
+            compliance_event_with_severity("2026-04-20T10:04:30Z", "Bash", 2, "obeyed", "2026-04-20T10:04:00Z", "warn"),
+        ];
+        let stats = compute(&entries);
+        let t = &stats.token_economics;
+        assert_eq!(t.blocked_obeyed, 2);
+        assert_eq!(t.advisory_obeyed, 3);
+        assert_eq!(t.estimated_tokens_saved, 2 * 2000 + 3 * 500);
+    }
+
+    #[test]
+    fn test_token_economics_ignored_does_not_save() {
+        // An `ignored` verdict means the model ran the action despite the
+        // rule.  No tokens saved — we don't claim retroactive credit.
+        let entries = vec![
+            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "git", "never", "force-push"),
+            compliance_event_with_severity("2026-04-20T10:00:30Z", "Bash", 1, "ignored", "2026-04-20T10:00:00Z", "block"),
+        ];
+        let stats = compute(&entries);
+        let t = &stats.token_economics;
+        assert_eq!(t.blocked_obeyed, 0);
+        assert_eq!(t.advisory_obeyed, 0);
+        assert_eq!(t.estimated_tokens_saved, 0);
+    }
+
+    #[test]
+    fn test_token_economics_unknown_severity_does_not_save() {
+        // Defensive: an `obeyed` verdict with a missing or unrecognised
+        // severity field shouldn't blow up or attribute tokens.  Older
+        // audit entries (pre-severity tracking) take this path.
+        let entries = vec![
+            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "git", "never", "force-push"),
+            json!({
+                "ts": "2026-04-20T10:00:30Z",
+                "tool": "Bash",
+                "event": "Compliance",
+                "session": "s1",
+                "payload": {
+                    "rules": [{
+                        "triple_id": 1,
+                        "pre_ts": "2026-04-20T10:00:00Z",
+                        "outcome": "obeyed",
+                    }]
+                }
+            }),
+        ];
+        let stats = compute(&entries);
+        let t = &stats.token_economics;
+        assert_eq!(t.blocked_obeyed, 0);
+        assert_eq!(t.advisory_obeyed, 0);
+        assert_eq!(t.estimated_tokens_saved, 0);
+    }
+
+    #[test]
+    fn test_token_economics_old_audit_entries_have_no_seen_before() {
+        // Audit entries written before this fix have no `seen_before`
+        // field.  They should be treated as first-time injections (no
+        // suppression credit) — never as `seen_before: true`.
+        let entries = vec![
+            // Vanilla pre_firing helper omits seen_before.
+            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "git", "never", "force-push"),
+            pre_firing("2026-04-20T10:01:00Z", "Bash", 1, "git", "never", "force-push"),
+            pre_firing("2026-04-20T10:02:00Z", "Bash", 1, "git", "never", "force-push"),
+        ];
+        let stats = compute(&entries);
+        assert_eq!(stats.token_economics.suppressed_repeats, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Develops the three additions I sketched in the X reply about token burn into a coherent feature. Lets us make a defensible secondary claim about efficiency improvements without overstating it — primary positioning stays *correctness*, token economics is the corollary.

Two complementary changes:

### 1. Per-session repeat-injection suppression (behavioral)

When a rule fires a second time in the same session, the hook handler emits a compact one-liner:

```
- still: alembic must_not hand-write migrations (95% match)
```

instead of the full payload:

```
- alembic must_not: hand-write migrations (95% match) [CLAUDE.md:12 layer-1]
```

The model already has the source / layer trace from the first firing. Saves ~50 tokens per re-fire and reduces attention dilution from reading the same rule N times.

State lives in the existing per-session JSON pattern (`session.rs`):
- `partition_seen_rules(arai_base, session_id, ids) -> (unseen, seen)`
- `mark_rules_seen(arai_base, session_id, ids)` — capped at 500 entries to bound the file size

Mark-as-seen happens AFTER the audit write, so a panic between match and write can't permanently suppress a rule the model never actually saw.

### 2. Token-economics roll-up in `arai stats` (measurement / positioning)

New section, suppressed entirely when no streams have data:

```
Token economics (estimates)
     12  repeat-injection suppressions  (~600 tokens, 50 ea.)
      4  denied-and-honored mistakes    (~8000 tokens, 2000 ea.)
     17  advised-and-honored events     (~8500 tokens, 500 ea.)
            total estimated tokens saved:  ~17100
            (calibrated estimates, not measurements)
```

Three streams:

| Stream | Source | Per-event estimate | Why |
|---|---|---|---|
| Repeat-injection suppressions | `seen_before: true` audit entries | 50 tokens | Sampled delta between full and compact form |
| Denied-and-honored mistakes | `obeyed` Compliance + Pre severity = `block` | 2000 tokens | Conservative bound on "fix the mess" recovery cycles |
| Advised-and-honored events | `obeyed` Compliance + severity = `warn`/`inform` | 500 tokens | Lower confidence — model might have done the right thing anyway |

Constants live in `src/stats.rs` and are documented there. The audit log carries raw counts, never derived numbers — so the constants can move without rewriting the log.

JSON output exposes a `token_economics` object for dashboards.

## Honesty discipline

Everywhere the section appears it is **labelled as estimates, not measurements** — both in CLI output and README. Over-claiming here would be the easy mistake; my framing is *"order-of-magnitude reading, not a precise number."*

`ignored` verdicts don't claim retroactive credit. Unknown / missing severity is a no-op. First-time users with no data see no section at all (no "0 tokens saved" bragging).

## Migration

Additive. New `seen_before: bool` field on audit `rules[]` entries; older audit lines without it are read as `false` (no suppression credit). `record_firing` and `format_context` signatures gained a `seen_set` parameter — single production call site for each, both updated.

## Test plan

- [ ] `cargo test` (12 new unit tests across `session.rs`, `guardrails.rs`, `stats.rs`)
- [ ] `cargo clippy -- -D warnings`
- [ ] Manual: run a session that triggers the same rule 3+ times; verify second+ firings show "still:" prefix in `additionalContext`
- [ ] Manual: `arai stats` after a few sessions; verify the token-economics section appears with non-zero counts
- [ ] Manual: `arai stats --json | jq .token_economics` shape

## What this doesn't claim

- This is **not** a measurement — it's a calibrated estimate. The constants are conservative midpoints; users should treat the total as an order-of-magnitude reading.
- Token savings are the *secondary* pitch. Arai's primary value is preventing wrong actions; token economics is the corollary because preventing wrong actions also prevents the recovery cycle that would otherwise burn tokens.
- Kete is still the wrong place for this question. Kete is an answer-quality product that intentionally costs more tokens for better grounding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)