### PR TITLE
docs: clarify enforcement scope across non-Claude assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,24 @@ Every firing is written to a local audit log, and every PostToolUse is correlate
 
 ## Supported Instruction Files
 
-| File | Tool |
-|------|------|
-| `CLAUDE.md` | Claude Code |
-| `~/.claude/CLAUDE.md` | Claude Code (global) |
-| `.cursorrules` / `.cursor/rules` | Cursor |
-| `.github/copilot-instructions.md` | GitHub Copilot |
-| `.windsurfrules` | Windsurf |
-| `~/.claude/projects/*/memory/*.md` | Claude Code memory |
+| File | Tool | Enforcement |
+|------|------|-------------|
+| `CLAUDE.md` | Claude Code | Hooks (block + advise) |
+| `~/.claude/CLAUDE.md` | Claude Code (global) | Hooks (block + advise) |
+| `~/.claude/projects/*/memory/*.md` | Claude Code memory | Hooks (block + advise) |
+| `.cursorrules` / `.cursor/rules` | Cursor | MCP (advise) |
+| `.windsurfrules` | Windsurf | MCP (advise) |
+| `.github/copilot-instructions.md` | GitHub Copilot | Ingest only |
+
+Rules from every file are parsed, classified, and stored the same way — but
+enforcement strength depends on what surface the assistant exposes. Only
+Claude Code has PreToolUse hooks, so only Claude Code can `deny` a tool
+call. Cursor and Windsurf are MCP clients, so they get advisory enforcement
+via [`arai mcp`](#mcp-agent-authored-guardrails) — the agent can list
+guards, register new ones, and self-check recent decisions, but Arai cannot
+block its tool calls. GitHub Copilot has no integration surface today; the
+file is ingested so its rules show up in `arai stats`, `arai diff`, and
+the audit log alongside the rest.
 
 ## Smart Matching
 
@@ -501,6 +511,14 @@ local rules before the parser runs, so the rest of the pipeline sees
 one merged file.
 
 ## MCP: agent-authored guardrails
+
+`arai mcp` is also the integration path for assistants that don't have a
+PreToolUse hook surface. Cursor and Windsurf are both MCP clients — point
+them at `arai mcp` and the agent can read the same rule set Claude Code
+sees, register new guards mid-session, and self-check recent decisions.
+The blocking path is still Claude-Code-only (no other assistant exposes
+a deny hook today), but everything else — rule lookup, agent-authored
+guards, decision history — is shared.
 
 `arai mcp` runs a [Model Context Protocol](https://modelcontextprotocol.io/)
 server on stdio. Three tools, exposed to any MCP-capable agent:

--- a/site/index.html
+++ b/site/index.html
@@ -237,7 +237,7 @@
 <section class="hero">
     <div class="container">
         <h1><span>CLAUDE.md</span> that actually blocks.</h1>
-        <p>Enforce AI coding assistant instruction files via hooks. Rules marked <code>never</code> deny the tool call. Every firing is audited and correlated with the action the model actually took. One command. Local. Zero cost.</p>
+        <p>Enforce AI coding assistant instruction files via Claude Code hooks &mdash; or advisory MCP for Cursor and Windsurf. Rules marked <code>never</code> deny the tool call in Claude Code. Every firing is audited and correlated with the action the model actually took. One command. Local. Zero cost.</p>
         <div class="install-box" onclick="copyInstall(this)">
             <span class="prompt">$</span>
             <span>curl -sSf https://arai.taniwha.ai/install | sh</span>
@@ -278,7 +278,7 @@
             </div>
             <div class="feature">
                 <h3>Block, don&rsquo;t just advise</h3>
-                <p>Rules with <code>never</code>/<code>forbids</code>/<code>must_not</code> emit <code>permissionDecision: "deny"</code>. <code>always</code> and <code>prefers</code> still advise. Incremental rollout via <code>ARAI_DENY_MODE=off</code>.</p>
+                <p>Rules with <code>never</code>/<code>forbids</code>/<code>must_not</code> emit <code>permissionDecision: "deny"</code> in Claude Code. <code>always</code> and <code>prefers</code> still advise. Incremental rollout via <code>ARAI_DENY_MODE=off</code>. Cursor and Windsurf get advisory enforcement via MCP &mdash; no other assistant exposes a deny hook today.</p>
             </div>
             <div class="feature">
                 <h3>Per-rule rollout</h3>
@@ -334,7 +334,7 @@
             </div>
             <div class="feature">
                 <h3>Agent-authored guards</h3>
-                <p>Runs as an MCP server. The agent can register new rules mid-session ("never touch /etc", "always run tests first") and Arai enforces them on the next tool call. <code>arai_recent_decisions</code> lets the agent self-check what it was just denied for &mdash; no more looping on the same refused action.</p>
+                <p>Runs as an MCP server. The agent can register new rules mid-session ("never touch /etc", "always run tests first") and Arai enforces them on the next tool call. <code>arai_recent_decisions</code> lets the agent self-check what it was just denied for &mdash; no more looping on the same refused action. MCP is also how Cursor and Windsurf integrate: same rule set, advisory only.</p>
             </div>
             <div class="feature">
                 <h3>Zero noise</h3>


### PR DESCRIPTION
## Summary
- README's "Supported Instruction Files" table now has an Enforcement column distinguishing hooks (Claude Code), MCP (Cursor/Windsurf), and ingest-only (Copilot), with a paragraph below explaining why.
- README MCP section opens with a note that `arai mcp` is the integration path for non-Claude assistants — same rule set, advisory enforcement only.
- Site hero subtitle, "Block, don't just advise" card, and "Agent-authored guards" card scope the deny path to Claude Code so the wider audience doesn't infer universal blocking.
- No code changes.

## Why
Arai discovers `.cursorrules`, `.windsurfrules`, and `.github/copilot-instructions.md` in [discovery.rs:21-31](src/discovery.rs#L21), but enforcement is wired through `.claude/settings.json` only ([init.rs:65-67](src/init.rs#L65)) and the hook protocol speaks Claude Code's `PreToolUse`/`PostToolUse`/`UserPromptSubmit`. The previous docs implied parity. Now they don't.

## Test plan
- [ ] README renders cleanly on GitHub (table, MCP section paragraph)
- [ ] Site hero, "Block, don't just advise" card, and "Agent-authored guards" card render correctly after deploy
- [ ] No code changes — CI should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)