### PR TITLE
chore: release v0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.10] - 2026-04-30
+
+### Documentation
+
+- Clarify enforcement scope across non-Claude assistants ([#44](https://github.com/taniwhaai/arai/pull/44))
+- Prep for Cline MCP marketplace submission ([#46](https://github.com/taniwhaai/arai/pull/46))
+
+### Build
+
+- Add Dockerfile + .dockerignore ([#48](https://github.com/taniwhaai/arai/pull/48))
+
+
 ## [0.2.9] - 2026-04-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 0.2.9 -> 0.2.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.10] - 2026-04-30

### Documentation

- Clarify enforcement scope across non-Claude assistants ([#44](https://github.com/taniwhaai/arai/pull/44))
- Prep for Cline MCP marketplace submission ([#46](https://github.com/taniwhaai/arai/pull/46))

### Build

- Add Dockerfile + .dockerignore ([#48](https://github.com/taniwhaai/arai/pull/48))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).