### PR TITLE
chore: add glama.json for MCP server claim

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "Tim-Marsden",
+    "mattcollie"
+  ]
+}


### PR DESCRIPTION
## Summary

Glama.ai has listed Arai in their MCP server directory; this PR adds the `glama.json` they require at the repo root to claim the server page.

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": [
    "Tim-Marsden",
    "mattcollie"
  ]
}
```

Both human committers on the repo are listed as maintainers (no bots). Pure metadata file — zero build/runtime impact, not picked up by `cargo build` or the Dockerfile, lives at the repo root only because that's where Glama's flow expects it.

## What this enables (per Glama's UI)

- Updating the server's description on the Glama listing
- Configuring Docker build instructions for their build pipeline
- Receiving notifications when reviews land

## Test plan

- [ ] CI green (no code paths touched)
- [ ] After merge, click "Login with GitHub to claim" on Glama's Arai page