### PR TITLE
chore: release v0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.12] - 2026-05-02
+
+### Documentation
+
+- Replace <5ms latency claims with measured numbers
+
+### Bench
+
+- Subprocess timing harness for the hook hot path
+
+### Discovery
+
+- Walk .cursor/rules as a directory of rule files
+
+### Guardrails
+
+- Replace O(N×L) sniff with Aho-Corasick automaton
+
+### Hooks
+
+- Validate session_id + ARAI_DISABLED kill switch with bypass audit
+- Deny reason includes line number; PreToolUse errors fail-closed
+
+### Mcp
+
+- Add arai_check_action probe tool
+
+### Parser
+
+- Respect <!-- arai:skip --> markers, scoped to next heading
+
+### Store
+
+- Gate schema init behind versioned migration framework + WAL PRAGMAs
+- LEFT JOIN rule_intent into load_guardrails / rules_for_file
+
+### Store+cli
+
+- Arai disable/enable + disabled_rules table (migration v2)
+
+### Telemetry
+
+- Hash rule subject/predicate before queueing for upload
+
+
 ## [0.2.11] - 2026-04-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 0.2.11 -> 0.2.12

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.12] - 2026-05-02

### Documentation

- Replace <5ms latency claims with measured numbers

### Bench

- Subprocess timing harness for the hook hot path

### Discovery

- Walk .cursor/rules as a directory of rule files

### Guardrails

- Replace O(N×L) sniff with Aho-Corasick automaton

### Hooks

- Validate session_id + ARAI_DISABLED kill switch with bypass audit
- Deny reason includes line number; PreToolUse errors fail-closed

### Mcp

- Add arai_check_action probe tool

### Parser

- Respect <!-- arai:skip --> markers, scoped to next heading

### Store

- Gate schema init behind versioned migration framework + WAL PRAGMAs
- LEFT JOIN rule_intent into load_guardrails / rules_for_file

### Store+cli

- Arai disable/enable + disabled_rules table (migration v2)

### Telemetry

- Hash rule subject/predicate before queueing for upload
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).