### PR TITLE
site: link the compliance inventory in the family bridge and footer

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -407,14 +407,14 @@
 <section class="family">
     <div class="container">
         <h2>Part of the Taniwha family</h2>
-        <p>Arai is the open-source guardrail core of <a href="https://taniwha.ai/kete">Kete</a>, Taniwha AI&rsquo;s runtime reliability platform for AI coding agents. Arai handles per-developer enforcement and audit locally; Kete adds the team layer on top &mdash; centralised rule distribution, aggregated compliance dashboards across a fleet of developers, semantic enrichment, and impact analysis across callers and transitive dependents. The local audit and verdict pipeline doesn&rsquo;t change. If your instruction files just need enforcing on one machine, Arai is all you need.</p>
+        <p>Arai is the open-source guardrail core of <a href="https://taniwha.ai/kete">Kete</a>, Taniwha AI&rsquo;s runtime reliability platform for AI coding agents. Arai handles per-developer enforcement and audit locally; Kete adds the team layer on top &mdash; centralised rule distribution, aggregated compliance dashboards across a fleet of developers, semantic enrichment, and impact analysis across callers and transitive dependents. The local audit and verdict pipeline doesn&rsquo;t change. If your instruction files just need enforcing on one machine, Arai is all you need. For the full feature inventory mapped to procurement-review questions, see the <a href="https://github.com/taniwhaai/arai/blob/main/docs/arai-compliance-features.docx">compliance inventory</a>.</p>
         <p class="family-links"><a href="https://taniwha.ai">Taniwha.ai</a> &middot; <a href="https://taniwha.ai/kete">Kete</a> &middot; <a href="https://taniwha.ai/products">All products</a></p>
     </div>
 </section>
 
 <footer>
     <div class="container">
-        <p>Built by <a href="https://taniwha.ai">Taniwha.ai</a> &middot; MIT / Apache-2.0 &middot; <a href="https://github.com/taniwhaai/arai">GitHub</a></p>
+        <p>Built by <a href="https://taniwha.ai">Taniwha.ai</a> &middot; MIT / Apache-2.0 &middot; <a href="https://github.com/taniwhaai/arai">GitHub</a> &middot; <a href="https://github.com/taniwhaai/arai/blob/main/docs/arai-compliance-features.docx">Compliance inventory</a></p>
     </div>
 </footer>
 


### PR DESCRIPTION
Two text links pointing at `docs/arai-compliance-features.docx` in the public repo:

1. Inline at the end of the family/Kete bridge paragraph
2. Footer line alongside the existing GitHub link

Direct GitHub blob URLs — single source of truth, updates the moment the docx is bumped in the repo. No CTA button, no new section, no visual weight on the dev-first reading flow above. Two-link, four-line diff.