### PR TITLE
chore: release v0.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.15] - 2026-05-10
+
+### Added
+
+- *(demos)* Add example showcasing command blocking with Arai guardrails
+- *(demos)* Update blocking demo to enhance user interaction flow
+- *(paths)* Move default state dir to .taniwha/arai, rename ARAI_DB_DIR ([#71](https://github.com/taniwhaai/arai/pull/71))
+- *(paths)* Deprecation shim for ARAI_DB_DIR + ~/.arai ([#73](https://github.com/taniwhaai/arai/pull/73))
+
+### Documentation
+
+- *(paths)* Sweep README/llms-install/CHANGELOG for v0.2.15 rename ([#74](https://github.com/taniwhaai/arai/pull/74))
+
+### Fixed
+
+- *(demos)* Trim leading typing frames so README poster shows prompt
+
+### Miscellaneous
+
+- *(deps)* Bump openssl in the cargo group across 1 directory ([#59](https://github.com/taniwhaai/arai/pull/59))
+- Track Taniwha + Claude tooling state in repo
+- Add Taniwha agents + skills, ignore WSL Zone.Identifier noise
+
+### Performance
+
+- *(parser)* Hoist regex compilations into OnceLock statics ([#92](https://github.com/taniwhaai/arai/pull/92)) ([#93](https://github.com/taniwhaai/arai/pull/93))
+
+
 ### Changed
 
 - **Default state path**: moved from `~/.arai/` to `~/.taniwha/arai/`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 0.2.14 -> 0.2.15

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.15] - 2026-05-10

### Added

- *(demos)* Add example showcasing command blocking with Arai guardrails
- *(demos)* Update blocking demo to enhance user interaction flow
- *(paths)* Move default state dir to .taniwha/arai, rename ARAI_DB_DIR ([#71](https://github.com/taniwhaai/arai/pull/71))
- *(paths)* Deprecation shim for ARAI_DB_DIR + ~/.arai ([#73](https://github.com/taniwhaai/arai/pull/73))

### Documentation

- *(paths)* Sweep README/llms-install/CHANGELOG for v0.2.15 rename ([#74](https://github.com/taniwhaai/arai/pull/74))

### Fixed

- *(demos)* Trim leading typing frames so README poster shows prompt

### Miscellaneous

- *(deps)* Bump openssl in the cargo group across 1 directory ([#59](https://github.com/taniwhaai/arai/pull/59))
- Track Taniwha + Claude tooling state in repo
- Add Taniwha agents + skills, ignore WSL Zone.Identifier noise

### Performance

- *(parser)* Hoist regex compilations into OnceLock statics ([#92](https://github.com/taniwhaai/arai/pull/92)) ([#93](https://github.com/taniwhaai/arai/pull/93))


### Changed

- **Default state path**: moved from `~/.arai/` to `~/.taniwha/arai/`
  ([#87](https://github.com/taniwhaai/arai/pull/87)). Audit logs, config,
  and the local SQLite store now live under
  `~/.taniwha/arai/{audit,config.toml,db}` by default. The old `~/.arai/`
  path is still honoured by the deprecation shim
  ([#89](https://github.com/taniwhaai/arai/pull/89)) — when detected, Arai
  reads from the legacy location and emits a one-time stderr warning so
  existing installs keep working until users migrate.
- **Env var rename**: `ARAI_DB_DIR` → `ARAI_BASE_DIR`
  ([#87](https://github.com/taniwhaai/arai/pull/87)). The new name reflects
  that the variable now overrides the entire state directory (audit + config
  + db), not just the database. The old `ARAI_DB_DIR` is still honoured by
  the deprecation shim ([#89](https://github.com/taniwhaai/arai/pull/89))
  with a stderr warning prompting users to switch.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).