### PR TITLE
feat(paths): move default state to .taniwha/arai, rename env var (#71)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -19,9 +19,9 @@ impl Config {
         let project_root = find_project_root()?;
         let home_dir = dirs::home_dir().ok_or("Could not determine home directory")?;
 
-        let arai_base_dir = std::env::var("ARAI_DB_DIR")
+        let arai_base_dir = std::env::var("ARAI_BASE_DIR")
             .map(PathBuf::from)
-            .unwrap_or_else(|_| home_dir.join(".arai"));
+            .unwrap_or_else(|_| home_dir.join(".taniwha").join("arai"));
 
         let llm_command = std::env::var("ARAI_LLM_CMD").ok();
         let api_url = std::env::var("ARAI_API_URL").ok();
@@ -115,7 +115,7 @@ impl Config {
         format!("{dir_name}-{short_hash}")
     }
 
-    /// DB path: ~/.arai/projects/<dirname>-<8char-sha256>/arai.db
+    /// DB path: ~/.taniwha/arai/projects/<dirname>-<8char-sha256>/arai.db
     pub fn db_path(&self) -> PathBuf {
         self.arai_base_dir
             .join("projects")
@@ -174,7 +174,7 @@ mod tests {
         let cfg = Config {
             project_root: PathBuf::from("/usr/src/myproject"),
             home_dir: PathBuf::from("/usr/src"),
-            arai_base_dir: PathBuf::from("/usr/src/.arai"),
+            arai_base_dir: PathBuf::from("/usr/src/.taniwha/arai"),
             extra_sources: Vec::new(),
             guardrails_mode: "advise".to_string(),
             llm_command: None,
@@ -190,7 +190,7 @@ mod tests {
         let cfg = Config {
             project_root: PathBuf::from("/usr/src/myproject"),
             home_dir: PathBuf::from("/usr/src"),
-            arai_base_dir: PathBuf::from("/usr/src/.arai"),
+            arai_base_dir: PathBuf::from("/usr/src/.taniwha/arai"),
             extra_sources: Vec::new(),
             guardrails_mode: "advise".to_string(),
             llm_command: None,
@@ -200,7 +200,7 @@ mod tests {
         };
         let db = cfg.db_path();
         let db_str = db.to_string_lossy();
-        assert!(db_str.starts_with("/usr/src/.arai/projects/myproject-"));
+        assert!(db_str.starts_with("/usr/src/.taniwha/arai/projects/myproject-"));
         assert!(db_str.ends_with("/arai.db"));
     }
 }

--- a/src/enrich.rs
+++ b/src/enrich.rs
@@ -168,7 +168,7 @@ pub fn enrich_guardrails(_store: &Store, _arai_base_dir: &Path) -> Result<usize,
     }
 }
 
-/// Ensure the model is downloaded to ~/.arai/models/all-MiniLM-L6-v2/
+/// Ensure the model is downloaded to ~/.taniwha/arai/models/all-MiniLM-L6-v2/
 #[cfg(feature = "enrich")]
 fn ensure_model_downloaded(arai_base_dir: &Path) -> Result<PathBuf, String> {
     let model_dir = arai_base_dir.join(MODEL_DIR_NAME).join(MODEL_NAME);
@@ -401,7 +401,7 @@ pub fn enrich_via_llm(store: &Store, llm_command: Option<&str>, arai_base_dir: &
              \n  ARAI_LLM_CMD=\"claude -p\"                # Claude Code\
              \n  ARAI_LLM_CMD=\"ollama run llama3\"         # Ollama\
              \n  ARAI_LLM_CMD=\"llm -m gpt-4o\"             # Simon Willison's llm\
-             \n\nOr add to ~/.arai/config.toml:\n\
+             \n\nOr add to ~/.taniwha/arai/config.toml:\n\
              \n  [enrich]\
              \n  llm_command = \"claude -p\""
         )?;
@@ -498,7 +498,7 @@ fn resolve_api_config(
     Err("No API endpoint configured. Set one of:\n\
          \n  ARAI_API_KEY=sk-...                        # Uses OpenAI by default\
          \n  ARAI_API_URL=http://localhost:11434/v1      # Ollama (no key needed)\
-         \n\nOr add to ~/.arai/config.toml:\n\
+         \n\nOr add to ~/.taniwha/arai/config.toml:\n\
          \n  [enrich]\
          \n  api_url = \"https://api.openai.com/v1\"\
          \n  api_key_env = \"OPENAI_API_KEY\"\


### PR DESCRIPTION
## Summary

- Default state dir: \`~/.arai\` → \`~/.taniwha/arai\` (matches kupu's \`.taniwha/kupu/\` pattern, namespaces all Taniwha tools)
- Env var: \`ARAI_DB_DIR\` → \`ARAI_BASE_DIR\` (the var has always governed the whole state dir, not just the DB)
- Bundled user-facing strings in \`src/enrich.rs\` so the config-file path printed in error messages matches the new default

Closes #71. Refs #61.

## What's deliberately NOT here

- **No migration logic** for existing \`~/.arai\` directories — that's #72 (first-run prompt).
- **No deprecation shim** for old env var or path — that's #73 (the actual safety net for existing users; without it, anyone with \`ARAI_DB_DIR\` set or an existing \`~/.arai\` will silently lose access until they re-init).
- **No README / CHANGELOG / llms-install.md sweep** — that's #74 (docs).

Recommend not releasing v0.2.15 until #73 at minimum is merged.

## Test plan

- [x] \`cargo build\` clean
- [x] \`cargo test\` — 277 passed, 0 failed
- [x] \`test_db_path_format\` updated to assert new \`/usr/src/.taniwha/arai/projects/...\` shape
- [x] \`test_claude_memory_slug\` fixture updated
- [ ] Manual: fresh install on a clean machine creates \`~/.taniwha/arai/\` only (deferred — sibling issues will exercise this end-to-end)

## Scope amendment vs. brief

Original brief described the move as \`.kete\` → \`.taniwha/kete\`. Investigation showed Arai's actual storage is \`~/.arai/\`, and the existing \`~/.kete/\` directory belongs to a different tool. Decision recorded in \`.taniwha/kupu/decisions/\`. Renamed all 4 child issues (#71–#74) and the epic (#61) to reflect this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)