### PR TITLE
feat(enrich): per-rule (noenrich) opt-out + pre-send destination notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,30 @@ clean it up.
 Perfect for `learned_from` incidents that have a shelf life, migration
 windows, and "temporarily forbid X until we finish the refactor" rules.
 
+## Per-rule enrichment opt-out — `(noenrich)`
+
+`arai scan --enrich-llm` and `--enrich-api` send the full text of every
+guardrail to whatever LLM you've configured (`ARAI_LLM_CMD` /
+`ARAI_API_URL`). For most rules that's fine — they're already in
+`CLAUDE.md`. But if a single rule mentions an internal codename you'd
+rather not ship to a third-party endpoint, append `(noenrich)`:
+
+```markdown
+- Never deploy to internal-codename-cluster (noenrich)
+```
+
+The annotation is stripped from the rule body at parse time and stored
+separately; the enrichment paths filter the rule out before building the
+prompt. `(noenrich)` and `(expires …)` can appear together in either
+order. To opt out globally, just don't pass `--enrich-llm` /
+`--enrich-api` — neither runs by default.
+
+Before each enrichment run Arai prints a one-line notice with the
+resolved destination and a locality verdict (`local` / `REMOTE` /
+`unknown locality`), plus the count of rules excluded via `(noenrich)`,
+so you can see at a glance whether rule text is about to leave the
+host.
+
 ## Audit log
 
 Every time a rule fires, Arai appends one line to a local JSONL log at

--- a/src/enrich.rs
+++ b/src/enrich.rs
@@ -406,14 +406,21 @@ pub fn enrich_via_llm(store: &Store, llm_command: Option<&str>, arai_base_dir: &
              \n  llm_command = \"claude -p\""
         )?;
 
-    let guardrails = store.load_guardrails().map_err(|e| e.to_string())?;
+    let all = store.load_guardrails().map_err(|e| e.to_string())?;
+    let total = all.len();
+    if total == 0 {
+        return Ok(0);
+    }
+    let guardrails: Vec<_> = all.into_iter().filter(|g| !g.noenrich).collect();
+    let excluded = total - guardrails.len();
     if guardrails.is_empty() {
+        println!("    Skipping LLM enrichment: all {total} rule(s) carry (noenrich).");
         return Ok(0);
     }
 
-    let prompt = build_enrichment_prompt(&guardrails);
-    println!("    Sending {} rules to LLM ({})...", guardrails.len(), cmd);
+    print_destination_notice("LLM CLI", &cmd, classify_cli_locality(&cmd), guardrails.len(), excluded);
 
+    let prompt = build_enrichment_prompt(&guardrails);
     let response = run_llm_command(&cmd, &prompt)?;
     parse_and_apply(store, &guardrails, &response, arai_base_dir)
 }
@@ -446,16 +453,108 @@ pub fn enrich_via_api(
 ) -> Result<usize, String> {
     let config = resolve_api_config(api_url, api_key_env, api_model)?;
 
-    let guardrails = store.load_guardrails().map_err(|e| e.to_string())?;
+    let all = store.load_guardrails().map_err(|e| e.to_string())?;
+    let total = all.len();
+    if total == 0 {
+        return Ok(0);
+    }
+    let guardrails: Vec<_> = all.into_iter().filter(|g| !g.noenrich).collect();
+    let excluded = total - guardrails.len();
     if guardrails.is_empty() {
+        println!("    Skipping API enrichment: all {total} rule(s) carry (noenrich).");
         return Ok(0);
     }
 
-    let prompt = build_enrichment_prompt(&guardrails);
-    println!("    Sending {} rules to {} (model: {})...", guardrails.len(), config.url, config.model);
+    let label = format!("HTTP API (model: {})", config.model);
+    print_destination_notice(&label, &config.url, classify_url_locality(&config.url), guardrails.len(), excluded);
 
+    let prompt = build_enrichment_prompt(&guardrails);
     let response = call_chat_completions(&config, &prompt)?;
     parse_and_apply(store, &guardrails, &response, arai_base_dir)
+}
+
+/// Locality verdict for an enrichment destination.  `Some(true)` = stays on
+/// the host (loopback, Unix socket, local Ollama binary).  `Some(false)` =
+/// definitely leaves the host (clearly remote URL or known hosted-LLM CLI).
+/// `None` = unable to tell — show the user the raw destination and let them
+/// judge.  Deliberately conservative: a wrong "local" claim is worse than
+/// no claim, because it gives false reassurance.
+type Locality = Option<bool>;
+
+/// Print the pre-send disclosure: destination, locality verdict, rule count,
+/// and how many rules were excluded by `(noenrich)`.  Shared by the LLM
+/// shell-out and HTTP API paths so the wording stays consistent.
+///
+/// Goes to stderr-equivalent (`println!` stays with the existing `cmd_scan`
+/// progress lines) but uses an explicit `[notice]` prefix so a user scanning
+/// the output sees that rule text is about to leave the local process.
+fn print_destination_notice(channel: &str, dest: &str, locality: Locality, rules: usize, excluded: usize) {
+    let locality_str = match locality {
+        Some(true) => "local",
+        Some(false) => "REMOTE",
+        None => "unknown locality",
+    };
+    let mut line = format!(
+        "    [notice] Sending {rules} rule(s) to {channel}: {dest} ({locality_str})"
+    );
+    if excluded > 0 {
+        line.push_str(&format!(" — {excluded} rule(s) skipped via (noenrich)"));
+    }
+    println!("{line}");
+}
+
+/// Classify a configured LLM CLI command as local or remote.  We only
+/// commit to a verdict when the binary's network behaviour is unambiguous:
+/// `ollama` ships with a local model runner, `claude`/`llm`/`gpt`/`openai`
+/// shell out to hosted APIs.  Everything else is `None` so the user sees
+/// the raw command and can decide.
+pub(crate) fn classify_cli_locality(cmd: &str) -> Locality {
+    let binary = cmd.split_whitespace().next().unwrap_or("");
+    let bin_lower = binary
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(binary)
+        .to_ascii_lowercase();
+    match bin_lower.as_str() {
+        "ollama" => Some(true),
+        "claude" | "llm" | "openai" | "gpt" | "anthropic" => Some(false),
+        _ => None,
+    }
+}
+
+/// Classify an HTTP endpoint as local or remote based on the host portion
+/// of the URL.  Loopback addresses and `unix:` schemes are local; anything
+/// with a public-looking host is remote.  Falls back to `None` when the
+/// URL can't be parsed cheaply (e.g. malformed) so we never assert
+/// "local" without evidence.
+pub(crate) fn classify_url_locality(url: &str) -> Locality {
+    let lower = url.to_ascii_lowercase();
+    if lower.starts_with("unix:") || lower.starts_with("file:") {
+        return Some(true);
+    }
+    let after_scheme = lower.split("://").nth(1)?;
+    let authority = after_scheme
+        .split('/')
+        .next()
+        .unwrap_or("")
+        .split('@')
+        .next_back()
+        .unwrap_or("");
+    // Strip the optional port without mangling bracketed IPv6 literals.
+    let host = if let Some(stripped) = authority.strip_prefix('[') {
+        // `[::1]:8080` → take through the closing bracket and reinsert it
+        stripped.split(']').next().map(|s| format!("[{s}]"))
+            .unwrap_or_default()
+    } else {
+        authority.split(':').next().unwrap_or("").to_string()
+    };
+    if host.is_empty() {
+        return None;
+    }
+    if host == "localhost" || host == "127.0.0.1" || host == "[::1]" {
+        return Some(true);
+    }
+    Some(false)
 }
 
 /// Resolve API configuration from env vars, config, and auto-detection.
@@ -867,6 +966,7 @@ mod tests {
             layer: None,
             line_start: None,
             expires_at: None,
+            noenrich: false,
             intent: None,
         };
         let action = fuzzy_match_action("forbid", &g);
@@ -1025,6 +1125,7 @@ mod tests {
                 line_end: Some(1),
                 layer: None,
                 expires_at: None,
+                noenrich: false,
             },
             crate::parser::Triple {
                 subject: "Alembic".to_string(),
@@ -1037,6 +1138,7 @@ mod tests {
                 line_end: Some(2),
                 layer: None,
                 expires_at: None,
+                noenrich: false,
             },
         ];
 
@@ -1112,6 +1214,7 @@ mod tests {
                 layer: None,
                 line_start: None,
                 expires_at: None,
+                noenrich: false,
                 intent: None,
             },
         ];
@@ -1167,6 +1270,7 @@ mod tests {
             line_end: Some(1),
             layer: None,
             expires_at: None,
+            noenrich: false,
         }];
         store.upsert_file("test", "test", &triples, "test").unwrap();
         let guardrails = store.load_guardrails().unwrap();
@@ -1194,7 +1298,106 @@ mod tests {
             layer: None,
             line_start: None,
             expires_at: None,
+            noenrich: false,
             intent: None,
         }
+    }
+
+    #[test]
+    fn classify_cli_locality_known_local() {
+        assert_eq!(classify_cli_locality("ollama run llama3.1"), Some(true));
+        assert_eq!(classify_cli_locality("/usr/local/bin/ollama serve"), Some(true));
+    }
+
+    #[test]
+    fn classify_cli_locality_known_remote() {
+        assert_eq!(classify_cli_locality("claude -p"), Some(false));
+        assert_eq!(classify_cli_locality("llm -m gpt-4o-mini"), Some(false));
+    }
+
+    #[test]
+    fn classify_cli_locality_unknown_is_none() {
+        assert_eq!(classify_cli_locality("custom-llm --flag"), None);
+        assert_eq!(classify_cli_locality(""), None);
+    }
+
+    #[test]
+    fn classify_url_locality_loopback() {
+        assert_eq!(classify_url_locality("http://localhost:11434/v1/chat/completions"), Some(true));
+        assert_eq!(classify_url_locality("http://127.0.0.1:11434"), Some(true));
+        assert_eq!(classify_url_locality("http://[::1]:8080/v1"), Some(true));
+        assert_eq!(classify_url_locality("unix:/var/run/llm.sock"), Some(true));
+    }
+
+    #[test]
+    fn classify_url_locality_remote() {
+        assert_eq!(classify_url_locality("https://api.openai.com/v1/chat/completions"), Some(false));
+        assert_eq!(classify_url_locality("https://api.anthropic.com"), Some(false));
+        assert_eq!(classify_url_locality("https://user:token@api.example.com/v1"), Some(false));
+    }
+
+    #[test]
+    fn classify_url_locality_malformed_is_none() {
+        assert_eq!(classify_url_locality("not-a-url"), None);
+    }
+
+    /// End-to-end check that `(noenrich)` rules are filtered out before the
+    /// prompt is built.  We exercise the filter at the `load_guardrails →
+    /// retain → build_enrichment_prompt` seam rather than going through
+    /// `enrich_via_llm` (which would try to spawn a subprocess); the seam
+    /// IS the filter, so this catches the regression.
+    #[test]
+    fn noenrich_rules_excluded_from_prompt() {
+        use crate::store::Store;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static CTR: AtomicU64 = AtomicU64::new(900);
+
+        let id = CTR.fetch_add(1, Ordering::SeqCst);
+        let dir = std::env::temp_dir().join(format!("arai_noenrich_test_{}", id));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = Store::open(&dir.join("test.db")).unwrap();
+
+        let triples = vec![
+            crate::parser::Triple {
+                subject: "Public".to_string(),
+                predicate: "never".to_string(),
+                object: "leak public string".to_string(),
+                confidence: 0.9,
+                domain: "test".to_string(),
+                source_file: "test".to_string(),
+                line_start: Some(1),
+                line_end: Some(1),
+                layer: Some(1),
+                expires_at: None,
+                noenrich: false,
+            },
+            crate::parser::Triple {
+                subject: "Internal".to_string(),
+                predicate: "never".to_string(),
+                object: "leak internal-codename-zeppelin".to_string(),
+                confidence: 0.9,
+                domain: "test".to_string(),
+                source_file: "test".to_string(),
+                line_start: Some(2),
+                line_end: Some(2),
+                layer: Some(1),
+                expires_at: None,
+                noenrich: true,
+            },
+        ];
+        store.upsert_file("test", "x", &triples, "test").unwrap();
+
+        let all = store.load_guardrails().unwrap();
+        assert_eq!(all.len(), 2, "both rules round-trip from the DB");
+        let kept: Vec<_> = all.into_iter().filter(|g| !g.noenrich).collect();
+        assert_eq!(kept.len(), 1, "noenrich rule is filtered before the prompt");
+        let prompt = build_enrichment_prompt(&kept);
+        assert!(prompt.contains("leak public string"));
+        assert!(
+            !prompt.contains("internal-codename-zeppelin"),
+            "noenrich object must not appear in the LLM prompt: {prompt}"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/guardrails.rs
+++ b/src/guardrails.rs
@@ -646,6 +646,7 @@ mod tests {
                 line_end: Some(1),
                 layer: None,
                 expires_at: None,
+                noenrich: false,
             },
             crate::parser::Triple {
                 subject: "Git".to_string(),
@@ -658,6 +659,7 @@ mod tests {
                 line_end: Some(2),
                 layer: None,
                 expires_at: None,
+                noenrich: false,
             },
         ];
 
@@ -802,6 +804,7 @@ mod tests {
                 line_end: Some(1),
                 layer: None,
                 expires_at: None,
+                noenrich: false,
             },
             crate::parser::Triple {
                 subject: "Git".to_string(),
@@ -814,6 +817,7 @@ mod tests {
                 line_end: Some(2),
                 layer: None,
                 expires_at: None,
+                noenrich: false,
             },
         ];
 
@@ -855,6 +859,7 @@ mod tests {
             layer: Some(1),
             line_start: Some(42),
             expires_at: None,
+            noenrich: false,
             intent: None,
         }
     }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -584,6 +584,7 @@ mod tests {
             layer: Some(1),
             line_start: Some(42),
             expires_at: None,
+            noenrich: false,
             intent: None,
         }
     }
@@ -681,6 +682,7 @@ mod tests {
             line_end: Some(1),
             layer: Some(1),
             expires_at: None,
+            noenrich: false,
         };
         store.upsert_file("CLAUDE.md", "x", &[triple], "test").unwrap();
         let tid = store.load_guardrails().unwrap()[0].triple_id;
@@ -770,6 +772,7 @@ mod tests {
             line_end: Some(1),
             layer: Some(1),
             expires_at: None,
+            noenrich: false,
         };
         store.upsert_file("CLAUDE.md", "x", &[triple], "test").unwrap();
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -29,6 +29,17 @@ pub struct Triple {
     /// after that date without any manual cleanup.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub expires_at: Option<String>,
+    /// Per-rule opt-out from LLM/API enrichment.  Extracted from a trailing
+    /// `(noenrich)` annotation in the rule text.  When set, `enrich_via_llm`
+    /// and `enrich_via_api` exclude the rule from the prompt — useful for
+    /// rules whose object mentions an internal codename the user does not
+    /// want to send to a third-party endpoint.
+    #[serde(skip_serializing_if = "is_false", default)]
+    pub noenrich: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !b
 }
 
 /// Known tool names for subject extraction, "use X" two-signal gate, and content sniffing.
@@ -54,7 +65,7 @@ pub fn extract_rules(content: &str, source_type: &str, base_confidence: f64) -> 
         if let Some((subject, predicate, object, layer)) =
             match_imperative(&item.text, &item.section_context)
         {
-            let (object, expires_at) = extract_expiry(&object);
+            let (object, expires_at, noenrich) = extract_annotations(&object);
             triples.push(Triple {
                 subject,
                 predicate,
@@ -66,6 +77,7 @@ pub fn extract_rules(content: &str, source_type: &str, base_confidence: f64) -> 
                 line_end: Some(item.line_end as i64),
                 layer: Some(layer),
                 expires_at,
+                noenrich,
             });
         }
     }
@@ -89,6 +101,49 @@ pub fn extract_expiry(object: &str) -> (String, Option<String>) {
         (cleaned, date)
     } else {
         (object.to_string(), None)
+    }
+}
+
+/// Strip a trailing `(noenrich)` annotation from the rule object and return
+/// the cleaned object plus a flag indicating whether the marker was present.
+/// Case-insensitive.  Used to opt a single rule out of LLM/API enrichment
+/// without disabling the feature globally.
+pub fn extract_noenrich(object: &str) -> (String, bool) {
+    static NOENRICH_RE: OnceLock<Regex> = OnceLock::new();
+    let re = NOENRICH_RE.get_or_init(|| {
+        Regex::new(r"(?i)\s*\(noenrich\)\s*$").expect("valid regex")
+    });
+    if re.is_match(object) {
+        let cleaned = re.replace(object, "").trim().to_string();
+        (cleaned, true)
+    } else {
+        (object.to_string(), false)
+    }
+}
+
+/// Apply both annotation extractors regardless of the order they appear in.
+/// Annotations always sit at the end of the object, so a single annotation
+/// hides anything to its left from the other regex; we loop until neither
+/// strips anything to handle `(expires ...) (noenrich)` and the reverse
+/// uniformly.
+pub fn extract_annotations(object: &str) -> (String, Option<String>, bool) {
+    let mut current = object.to_string();
+    let mut expires: Option<String> = None;
+    let mut noenrich = false;
+
+    loop {
+        let (after_expiry, found_expiry) = extract_expiry(&current);
+        if found_expiry.is_some() {
+            expires = found_expiry;
+        }
+        let (after_noenrich, found_noenrich) = extract_noenrich(&after_expiry);
+        if found_noenrich {
+            noenrich = true;
+        }
+        if after_noenrich == current {
+            return (after_noenrich, expires, noenrich);
+        }
+        current = after_noenrich;
     }
 }
 
@@ -966,6 +1021,58 @@ mod tests {
             0.9,
         );
         assert_eq!(rules[0].expires_at, None);
+    }
+
+    #[test]
+    fn test_noenrich_is_extracted_and_stripped() {
+        let rules = extract_rules(
+            "- Never deploy to internal-codename-cluster (noenrich)",
+            "test",
+            0.9,
+        );
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].noenrich, "noenrich flag should be set");
+        assert!(
+            !rules[0].object.contains("noenrich"),
+            "object still carries annotation: {}",
+            rules[0].object
+        );
+        assert!(
+            rules[0].object.contains("internal-codename-cluster"),
+            "object missing rule body: {}",
+            rules[0].object
+        );
+
+        // No annotation → flag stays false
+        let rules = extract_rules("- Never force-push to main", "test", 0.9);
+        assert!(!rules[0].noenrich);
+    }
+
+    #[test]
+    fn test_noenrich_combined_with_expiry_either_order() {
+        // (expires ...) (noenrich)
+        let rules = extract_rules(
+            "- Never use legacy-shim (expires 2026-12-31) (noenrich)",
+            "test",
+            0.9,
+        );
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].noenrich);
+        assert_eq!(rules[0].expires_at.as_deref(), Some("2026-12-31"));
+        assert!(!rules[0].object.contains("noenrich"));
+        assert!(!rules[0].object.contains("expires"));
+
+        // (noenrich) (expires ...)
+        let rules = extract_rules(
+            "- Never use legacy-shim (noenrich) (expires 2026-12-31)",
+            "test",
+            0.9,
+        );
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].noenrich);
+        assert_eq!(rules[0].expires_at.as_deref(), Some("2026-12-31"));
+        assert!(!rules[0].object.contains("noenrich"));
+        assert!(!rules[0].object.contains("expires"));
     }
 
     #[test]

--- a/src/scenarios.rs
+++ b/src/scenarios.rs
@@ -366,6 +366,7 @@ mod tests {
                 layer: None,
                 line_start: None,
                 expires_at: None,
+                noenrich: false,
                 intent: None,
             },
             100,

--- a/src/store.rs
+++ b/src/store.rs
@@ -13,7 +13,7 @@ pub struct Store {
 /// migrations may run on a fresh DB or on an upgrading DB that already
 /// happens to have some columns from a previous schema-on-every-open era.
 type Migration = fn(&Connection) -> rusqlite::Result<()>;
-const MIGRATIONS: &[Migration] = &[migrate_v1, migrate_v2];
+const MIGRATIONS: &[Migration] = &[migrate_v1, migrate_v2, migrate_v3];
 
 impl Store {
     pub fn open(db_path: &Path) -> Result<Store, String> {
@@ -127,8 +127,8 @@ impl Store {
         // Insert new triples
         for triple in triples {
             tx.execute(
-                "INSERT INTO triples (file_id, s, p, o, domain, confidence, line_start, line_end, source_file, layer, expires_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                "INSERT INTO triples (file_id, s, p, o, domain, confidence, line_start, line_end, source_file, layer, expires_at, noenrich)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
                 params![
                     file_id,
                     triple.subject,
@@ -141,6 +141,7 @@ impl Store {
                     path,
                     triple.layer.map(|l| l as i64),
                     triple.expires_at,
+                    triple.noenrich as i32,
                 ],
             )?;
         }
@@ -722,7 +723,7 @@ fn is_required(p: &str) -> bool {
 /// `AND <extra>` and `ORDER BY`).  `LEFT JOIN` so unclassified rules still
 /// surface — `intent` will be `None` on those.
 const GUARDRAIL_SELECT_PREDICATE_FILTERED: &str =
-    "SELECT t.id, t.s, t.p, t.o, t.confidence, t.source_file, f.path, t.layer, t.line_start, t.expires_at,
+    "SELECT t.id, t.s, t.p, t.o, t.confidence, t.source_file, f.path, t.layer, t.line_start, t.expires_at, t.noenrich,
             ri.action, ri.timing, ri.tools, ri.allow_inverse, ri.enriched_by, ri.severity, ri.severity_override
      FROM triples t
      JOIN files f ON t.file_id = f.id
@@ -730,7 +731,7 @@ const GUARDRAIL_SELECT_PREDICATE_FILTERED: &str =
      WHERE t.p IN ('forbids','must_not','never','always','requires','enforces','prefers')";
 
 /// Row mapper paired with `GUARDRAIL_SELECT_PREDICATE_FILTERED`.  Pulls
-/// triple columns from indices 0..=9 and intent columns from 10..=16.
+/// triple columns from indices 0..=10 and intent columns from 11..=17.
 fn guardrail_from_row(row: &rusqlite::Row) -> rusqlite::Result<Guardrail> {
     Ok(Guardrail {
         triple_id: row.get(0)?,
@@ -743,7 +744,8 @@ fn guardrail_from_row(row: &rusqlite::Row) -> rusqlite::Result<Guardrail> {
         layer: row.get::<_, Option<i64>>(7)?.map(|v| v as u8),
         line_start: row.get::<_, Option<i64>>(8)?,
         expires_at: row.get::<_, Option<String>>(9)?,
-        intent: parse_intent_from_row(row, 10)?,
+        noenrich: row.get::<_, i64>(10)? != 0,
+        intent: parse_intent_from_row(row, 11)?,
     })
 }
 
@@ -808,6 +810,15 @@ pub struct Guardrail {
     /// `(expires ...)` annotation; always `None` for rules without one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<String>,
+    /// Per-rule opt-out from LLM/API enrichment.  Set by a trailing
+    /// `(noenrich)` annotation in the rule text.  When `true`,
+    /// `enrich::enrich_via_llm` and `enrich_via_api` filter the rule out of
+    /// the prompt before it leaves the machine — useful for rules whose
+    /// object mentions an internal codename the user does not want shipped
+    /// to a third-party endpoint.  Default `false` preserves prior
+    /// enrichment behaviour for every existing rule.
+    #[serde(default, skip_serializing_if = "is_false_ref")]
+    pub noenrich: bool,
     /// Classified intent.  Populated by `load_guardrails` / `rules_for_file`
     /// via a single LEFT JOIN against `rule_intent`, so the hot path no
     /// longer needs an N-way `get_rule_intent` round trip per matched rule.
@@ -815,6 +826,10 @@ pub struct Guardrail {
     /// `arai add`, or a freshly-scanned file before `arai classify` runs).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub intent: Option<crate::intent::RuleIntent>,
+}
+
+fn is_false_ref(b: &bool) -> bool {
+    !b
 }
 
 fn compute_checksum(content: &str) -> String {
@@ -987,6 +1002,16 @@ fn migrate_v2(conn: &Connection) -> rusqlite::Result<()> {
     )
 }
 
+/// Migration v2 -> v3: per-rule LLM/API enrichment opt-out.  Backed by a
+/// trailing `(noenrich)` annotation in the rule text (parsed in `parser.rs`),
+/// surfaced through `Guardrail::noenrich`, and consumed by
+/// `enrich::enrich_via_llm` / `enrich_via_api` to filter rules out of the
+/// prompt before it leaves the machine.  Default 0 means existing rules
+/// remain enrichable — opt-in semantics, never silent removal.
+fn migrate_v3(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_missing(conn, "triples", "noenrich", "INTEGER NOT NULL DEFAULT 0")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1019,6 +1044,7 @@ mod tests {
             line_end: Some(1),
             layer: None,
             expires_at: None,
+            noenrich: false,
         }];
 
         let changed = store.upsert_file("CLAUDE.md", "- Never force-push to main", &triples, "claude_md_project").unwrap();
@@ -1051,6 +1077,7 @@ mod tests {
             line_end: Some(1),
             layer: None,
             expires_at: None,
+            noenrich: false,
         };
         store.upsert_file("CLAUDE.md", "- a", &[t.clone()], "claude_md_project").unwrap();
         store.upsert_file(
@@ -1084,6 +1111,7 @@ mod tests {
             line_end: Some(1),
             layer: None,
             expires_at: None,
+            noenrich: false,
         };
         let always = Triple {
             subject: "alembic".to_string(),
@@ -1096,6 +1124,7 @@ mod tests {
             line_end: Some(2),
             layer: None,
             expires_at: None,
+            noenrich: false,
         };
         store.upsert_file("CLAUDE.md", "- a\n- b", &[never, always], "claude_md_project").unwrap();
 
@@ -1123,6 +1152,7 @@ mod tests {
             line_end: Some(1),
             layer: None,
             expires_at: None,
+            noenrich: false,
         };
         let t2 = Triple {
             subject: "alembic".to_string(),
@@ -1135,6 +1165,7 @@ mod tests {
             line_end: Some(2),
             layer: None,
             expires_at: None,
+            noenrich: false,
         };
         store.upsert_file("CLAUDE.md", "- a\n- b", &[t1, t2], "claude_md_project").unwrap();
 
@@ -1170,6 +1201,7 @@ mod tests {
             line_end: Some(1),
             layer: Some(1),
             expires_at: None,
+            noenrich: false,
         };
         store.upsert_file("CLAUDE.md", "x", &[t], "claude_md_project").unwrap();
         store.classify_all_guardrails().unwrap();
@@ -1235,6 +1267,7 @@ mod tests {
             line_end: Some(line),
             layer: Some(1),
             expires_at: None,
+            noenrich: false,
         };
         store
             .upsert_file("CLAUDE.md", "x", &[mk("alembic", 1), mk("git", 2), mk("cargo", 3)], "claude_md_project")
@@ -1270,6 +1303,7 @@ mod tests {
             line_end: Some(line),
             layer: Some(1),
             expires_at: None,
+            noenrich: false,
         };
         store
             .upsert_file("CLAUDE.md", "a", &[mk_in("CLAUDE.md", 1)], "claude_md_project")
@@ -1306,6 +1340,7 @@ mod tests {
             line_end: Some(1),
             layer: Some(1),
             expires_at: Some("2099-01-01".to_string()), // far future
+            noenrich: false,
         };
         let dead = Triple {
             subject: "legacy".to_string(),
@@ -1318,6 +1353,7 @@ mod tests {
             line_end: Some(2),
             layer: Some(1),
             expires_at: Some("2000-01-01".to_string()), // long past
+            noenrich: false,
         };
         store.upsert_file("CLAUDE.md", "x", &[alive, dead], "claude_md_project").unwrap();
 
@@ -1389,6 +1425,7 @@ mod tests {
                 line_end: Some(1),
                 layer: Some(1),
                 expires_at: None,
+                noenrich: false,
             },
             Triple {
                 subject: "cargo".to_string(),
@@ -1401,6 +1438,7 @@ mod tests {
                 line_end: Some(2),
                 layer: Some(1),
                 expires_at: None,
+                noenrich: false,
             },
         ];
         store.upsert_file("CLAUDE.md", "x", &triples, "test").unwrap();
@@ -1454,6 +1492,7 @@ mod tests {
             line_end: Some(1),
             layer: Some(1),
             expires_at: None,
+            noenrich: false,
         };
         store.upsert_file("CLAUDE.md", "x", &[t.clone()], "test").unwrap();
         store.disable_rule("git", "never", "force-push to main").unwrap();


### PR DESCRIPTION
Closes #94. Tracked alongside #95.

## Summary

- New parser annotation `(noenrich)` that excludes a single rule from `arai scan --enrich-llm` / `--enrich-api`. Mirrors `(expires …)`: stripped from the rule body at parse time, persisted in a new `triples.noenrich` column via `migrate_v3`, surfaced as `Triple::noenrich` / `Guardrail::noenrich`. Combines with `(expires …)` in either order.
- Both enrichment paths filter `noenrich` rules before building the prompt and print a `[notice]` line up front summarising the resolved destination, a locality verdict (`local` / `REMOTE` / `unknown locality`), the rule count, and the number excluded by `(noenrich)`.
- README gains a section under rule expiry explaining the new annotation and pointing at the destination notice.

## Why this fits the existing design

The reviewer's framing was that `--enrich-llm` ships rule text without consent. Strictly speaking the user *configures* the destination (`ARAI_LLM_CMD` / `ARAI_API_URL`), so the choice itself is the consent. What was missing was (a) a surface-level reminder of where rule text lands when the run starts, and (b) a per-rule opt-out for objects that mention an internal codename. Neither change disturbs the planned Arai-itself / local-Kete enrichment paths.

Locality classification is deliberately conservative: `ollama` is `local`, `claude` / `llm` / hosted-API binaries are `REMOTE`, anything else is `unknown locality` so we never falsely reassure a user.

## Test plan

- [x] `cargo test` passes (269/270; the one preexisting failure is `test_resolve_api_config_no_config`, which trips on dev hosts that have a local Ollama answering on `:11434` — confirmed by stashing my changes and re-running on `main`).
- [x] New parser tests for `(noenrich)`: annotation alone, combined with `(expires …)` in both orders.
- [x] New locality classifier tests: loopback IPv4 / IPv6 / Unix socket / hosted endpoints / malformed URLs.
- [x] New end-to-end test: `(noenrich)` rule round-trips through the store and is excluded from `build_enrichment_prompt` output.
- [x] `cargo build --release` clean.

`cargo clippy` ICEs on this rustc 1.95 toolchain — same dead-code-pass crash already noted in CLAUDE.md, unrelated to this change.

## Out of scope

- No redaction or truncation of rule text (the rule text *is* the classification signal).
- No interactive prompt — keeping the run non-blocking for CI.
- The other security-review follow-ups (#95) — hash-chain, intent/compliance integration tests, release signing, audit retention — are separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)