### PR TITLE
perf(release): panic=abort + codegen-units=1 — 4.3% smaller binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,16 @@ proptest = "1"
 opt-level = "z"
 lto = true
 strip = true
+# `panic = "abort"` removes Rust's unwinding tables and the cleanup glue
+# associated with them.  Arai is a CLI that exits-on-error — there is no
+# code that catches a panic, so unwinding has no observable benefit and
+# only costs binary size and cold-start work.  Each hook invocation pays
+# the binary-load cost (~22 ms median per CLAUDE.md hot-path note);
+# shrinking the binary directly shrinks that.
+panic = "abort"
+# `codegen-units = 1` lets the compiler do whole-crate inlining + better
+# dead-code elimination at the cost of a slower clean release build.
+# Pairs naturally with `lto = true` for the same reason.  CI release
+# builds happen rarely; user-facing binary load happens on every Claude
+# Code tool call, so the trade favours the runtime.
+codegen-units = 1


### PR DESCRIPTION
## Summary

Two free additions to the release profile that directly shrink the cold-start cost Arai pays on every Claude Code tool call. CLAUDE.md's hot-path note says the ~22 ms median is dominated by binary fork+exec, not matching — a smaller binary moves that ceiling.

| | Before | After | Delta |
|---|---|---|---|
| Linux x86_64 release binary | 11,654,008 B (11.1 MiB) | 11,157,944 B (10.6 MiB) | **-496 KiB (-4.3%)** |

Two changes, both in [Cargo.toml](Cargo.toml):

- `panic = "abort"` — removes Rust's unwinding tables and the cleanup glue. Arai is a CLI that exits-on-error; nothing catches a panic, so unwinding has no observable benefit and only costs binary size and cold-start work.
- `codegen-units = 1` — whole-crate inlining + better dead-code elimination at the cost of a slower clean release build. Pairs naturally with the existing `lto = true`. CI release builds happen rarely; the trade favours runtime.

## Test plan

- [x] `cargo test` (dev profile) — 283/284 passed
- [x] `cargo test --release` (release profile, exercises `panic = "abort"`) — 283/284 passed
- [x] `cargo build --release` clean
- [x] Binary size measured on Linux x86_64 (cargo 1.95)

The one failing test is the preexisting `enrich::tests::test_resolve_api_config_no_config` that fires when Ollama is running on `localhost:11434` — unrelated to this change, also fails on `main`.

## Out of scope

- Code-level micro-optimizations (e.g. caching `g.subject.to_lowercase()` per Guardrail) — those need profiling first to know they're hot.
- Structural changes to break through the binary fork+exec ceiling (hook-only minimal binary, long-lived daemon, etc.) — bigger design work, separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)