### PR TITLE
style+ci: cargo fmt sweep + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,16 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -172,10 +172,7 @@ pub fn query(
             Err(_) => continue,
         };
         // Read lines into a buffer then reverse so newest-in-file comes first.
-        let lines: Vec<String> = BufReader::new(file)
-            .lines()
-            .map_while(Result::ok)
-            .collect();
+        let lines: Vec<String> = BufReader::new(file).lines().map_while(Result::ok).collect();
         for line in lines.into_iter().rev() {
             if out.len() >= max_entries {
                 return Ok(out);
@@ -339,11 +336,12 @@ fn civil_to_epoch(y: i32, m: u32, d: u32, h: u32, mi: u32, s: u32) -> u64 {
     let doy: i64 = (153 * mp + 2) / 5 + (d as i64 - 1);
     let doe: i64 = yoe * 365 + yoe / 4 - yoe / 100 + doy;
     let days_since_epoch: i64 = era * 146_097 + doe - 719_468;
-    let secs: i64 = days_since_epoch * 86_400
-        + (h as i64) * 3600
-        + (mi as i64) * 60
-        + (s as i64);
-    if secs < 0 { 0 } else { secs as u64 }
+    let secs: i64 = days_since_epoch * 86_400 + (h as i64) * 3600 + (mi as i64) * 60 + (s as i64);
+    if secs < 0 {
+        0
+    } else {
+        secs as u64
+    }
 }
 
 #[cfg(test)]
@@ -353,9 +351,19 @@ mod tests {
     #[test]
     fn test_epoch_roundtrip() {
         // Round-trip a handful of fixed epochs through format + parse.
-        for epoch in [0u64, 946_684_800, 1_577_836_800, 1_776_013_800, 2_524_608_000] {
+        for epoch in [
+            0u64,
+            946_684_800,
+            1_577_836_800,
+            1_776_013_800,
+            2_524_608_000,
+        ] {
             let ts = format_epoch_utc(epoch);
-            assert_eq!(parse_rfc3339_to_epoch(&ts), Some(epoch), "roundtrip failed for {ts}");
+            assert_eq!(
+                parse_rfc3339_to_epoch(&ts),
+                Some(epoch),
+                "roundtrip failed for {ts}"
+            );
         }
         // And a known reference — 2000-01-01 00:00:00 UTC is 946684800.
         assert_eq!(format_epoch_utc(946_684_800), "2000-01-01T00:00:00Z");

--- a/src/code_scanner.rs
+++ b/src/code_scanner.rs
@@ -18,10 +18,10 @@ pub fn scan_project(project_root: &Path) -> Vec<ImportInfo> {
 
     // Use the `ignore` crate which respects .gitignore, .git/info/exclude, etc.
     let walker = ignore::WalkBuilder::new(project_root)
-        .hidden(true)      // skip hidden files/dirs
-        .git_ignore(true)   // respect .gitignore
-        .git_global(true)   // respect global gitignore
-        .git_exclude(true)  // respect .git/info/exclude
+        .hidden(true) // skip hidden files/dirs
+        .git_ignore(true) // respect .gitignore
+        .git_global(true) // respect global gitignore
+        .git_exclude(true) // respect .git/info/exclude
         .build();
 
     for entry in walker.filter_map(|e| e.ok()) {
@@ -189,7 +189,9 @@ fn extract_python_import(node: Node, source: &[u8], kind: &str) -> Option<String
 }
 
 #[cfg(not(feature = "lang-python"))]
-fn extract_python_import(_: Node, _: &[u8], _: &str) -> Option<String> { None }
+fn extract_python_import(_: Node, _: &[u8], _: &str) -> Option<String> {
+    None
+}
 
 #[cfg(feature = "lang-javascript")]
 fn extract_js_import(node: Node, source: &[u8], kind: &str) -> Option<String> {
@@ -215,7 +217,9 @@ fn extract_js_import(node: Node, source: &[u8], kind: &str) -> Option<String> {
 }
 
 #[cfg(not(feature = "lang-javascript"))]
-fn extract_js_import(_: Node, _: &[u8], _: &str) -> Option<String> { None }
+fn extract_js_import(_: Node, _: &[u8], _: &str) -> Option<String> {
+    None
+}
 
 #[cfg(feature = "lang-rust")]
 fn extract_rust_import(node: Node, source: &[u8], kind: &str) -> Option<String> {
@@ -225,9 +229,7 @@ fn extract_rust_import(node: Node, source: &[u8], kind: &str) -> Option<String> 
             let arg = node.child_by_field_name("argument")?;
             extract_rust_use_path(arg, source)
         }
-        "extern_crate_declaration" => {
-            child_by_field(node, "name", source)
-        }
+        "extern_crate_declaration" => child_by_field(node, "name", source),
         _ => None,
     }
 }
@@ -237,14 +239,13 @@ fn extract_rust_use_path(node: Node, source: &[u8]) -> Option<String> {
     match node.kind() {
         "scoped_identifier" | "scoped_use_list" => {
             // Get the leftmost path segment
-            node.child_by_field_name("path")
-                .and_then(|n| {
-                    if n.kind() == "identifier" || n.kind() == "crate" {
-                        node_text(n, source)
-                    } else {
-                        extract_rust_use_path(n, source)
-                    }
-                })
+            node.child_by_field_name("path").and_then(|n| {
+                if n.kind() == "identifier" || n.kind() == "crate" {
+                    node_text(n, source)
+                } else {
+                    extract_rust_use_path(n, source)
+                }
+            })
         }
         "identifier" => node_text(node, source),
         _ => node_text(node, source),
@@ -252,7 +253,9 @@ fn extract_rust_use_path(node: Node, source: &[u8]) -> Option<String> {
 }
 
 #[cfg(not(feature = "lang-rust"))]
-fn extract_rust_import(_: Node, _: &[u8], _: &str) -> Option<String> { None }
+fn extract_rust_import(_: Node, _: &[u8], _: &str) -> Option<String> {
+    None
+}
 
 #[cfg(feature = "lang-go")]
 fn extract_go_import(node: Node, source: &[u8], kind: &str) -> Option<String> {
@@ -264,7 +267,9 @@ fn extract_go_import(node: Node, source: &[u8], kind: &str) -> Option<String> {
 }
 
 #[cfg(not(feature = "lang-go"))]
-fn extract_go_import(_: Node, _: &[u8], _: &str) -> Option<String> { None }
+fn extract_go_import(_: Node, _: &[u8], _: &str) -> Option<String> {
+    None
+}
 
 #[cfg(feature = "lang-ruby")]
 fn extract_ruby_import(node: Node, source: &[u8], kind: &str) -> Option<String> {
@@ -292,7 +297,9 @@ fn extract_ruby_import(node: Node, source: &[u8], kind: &str) -> Option<String> 
 }
 
 #[cfg(not(feature = "lang-ruby"))]
-fn extract_ruby_import(_: Node, _: &[u8], _: &str) -> Option<String> { None }
+fn extract_ruby_import(_: Node, _: &[u8], _: &str) -> Option<String> {
+    None
+}
 
 #[cfg(feature = "lang-java")]
 fn extract_java_import(node: Node, source: &[u8], kind: &str) -> Option<String> {
@@ -309,14 +316,13 @@ fn extract_java_import(node: Node, source: &[u8], kind: &str) -> Option<String> 
 }
 
 #[cfg(not(feature = "lang-java"))]
-fn extract_java_import(_: Node, _: &[u8], _: &str) -> Option<String> { None }
+fn extract_java_import(_: Node, _: &[u8], _: &str) -> Option<String> {
+    None
+}
 
 /// Normalize an import path to a top-level tool/library name.
 fn normalize_import(import_text: &str, ext: &str) -> Option<String> {
-    let text = import_text
-        .trim()
-        .trim_matches('"')
-        .trim_matches('\'');
+    let text = import_text.trim().trim_matches('"').trim_matches('\'');
 
     if text.is_empty() {
         return None;
@@ -387,24 +393,78 @@ fn is_stdlib(name: &str, ext: &str) -> bool {
     match ext {
         "py" => matches!(
             name,
-            "os" | "sys" | "re" | "io" | "json" | "math" | "time" | "datetime"
-            | "collections" | "functools" | "itertools" | "typing" | "pathlib"
-            | "subprocess" | "logging" | "unittest" | "hashlib" | "abc"
-            | "dataclasses" | "enum" | "copy" | "string" | "textwrap"
-            | "struct" | "csv" | "argparse" | "shutil" | "tempfile"
-            | "glob" | "fnmatch" | "stat" | "contextlib" | "warnings"
+            "os" | "sys"
+                | "re"
+                | "io"
+                | "json"
+                | "math"
+                | "time"
+                | "datetime"
+                | "collections"
+                | "functools"
+                | "itertools"
+                | "typing"
+                | "pathlib"
+                | "subprocess"
+                | "logging"
+                | "unittest"
+                | "hashlib"
+                | "abc"
+                | "dataclasses"
+                | "enum"
+                | "copy"
+                | "string"
+                | "textwrap"
+                | "struct"
+                | "csv"
+                | "argparse"
+                | "shutil"
+                | "tempfile"
+                | "glob"
+                | "fnmatch"
+                | "stat"
+                | "contextlib"
+                | "warnings"
         ),
         "go" => matches!(
             name,
-            "fmt" | "os" | "io" | "log" | "net" | "http" | "strings" | "strconv"
-            | "sync" | "time" | "errors" | "context" | "testing" | "bytes"
-            | "encoding" | "path" | "filepath" | "regexp" | "sort" | "math"
+            "fmt"
+                | "os"
+                | "io"
+                | "log"
+                | "net"
+                | "http"
+                | "strings"
+                | "strconv"
+                | "sync"
+                | "time"
+                | "errors"
+                | "context"
+                | "testing"
+                | "bytes"
+                | "encoding"
+                | "path"
+                | "filepath"
+                | "regexp"
+                | "sort"
+                | "math"
         ),
         "rs" => matches!(name, "std" | "core" | "alloc"),
         "rb" => matches!(
             name,
-            "json" | "yaml" | "csv" | "net" | "uri" | "open-uri" | "fileutils"
-            | "set" | "date" | "time" | "logger" | "pathname" | "stringio"
+            "json"
+                | "yaml"
+                | "csv"
+                | "net"
+                | "uri"
+                | "open-uri"
+                | "fileutils"
+                | "set"
+                | "date"
+                | "time"
+                | "logger"
+                | "pathname"
+                | "stringio"
         ),
         _ => false,
     }
@@ -416,17 +476,32 @@ mod tests {
 
     #[test]
     fn test_normalize_python_import() {
-        assert_eq!(normalize_import("alembic", "py"), Some("alembic".to_string()));
-        assert_eq!(normalize_import("alembic.op", "py"), Some("alembic".to_string()));
+        assert_eq!(
+            normalize_import("alembic", "py"),
+            Some("alembic".to_string())
+        );
+        assert_eq!(
+            normalize_import("alembic.op", "py"),
+            Some("alembic".to_string())
+        );
         assert_eq!(normalize_import("os", "py"), None); // stdlib
-        assert_eq!(normalize_import("sqlalchemy", "py"), Some("sqlalchemy".to_string()));
+        assert_eq!(
+            normalize_import("sqlalchemy", "py"),
+            Some("sqlalchemy".to_string())
+        );
     }
 
     #[test]
     fn test_normalize_js_import() {
-        assert_eq!(normalize_import("express", "js"), Some("express".to_string()));
+        assert_eq!(
+            normalize_import("express", "js"),
+            Some("express".to_string())
+        );
         assert_eq!(normalize_import("./utils", "js"), None); // relative
-        assert_eq!(normalize_import("@scope/package", "js"), Some("package".to_string()));
+        assert_eq!(
+            normalize_import("@scope/package", "js"),
+            Some("package".to_string())
+        );
     }
 
     #[test]
@@ -437,13 +512,19 @@ mod tests {
 
     #[test]
     fn test_normalize_go_import() {
-        assert_eq!(normalize_import("github.com/user/pkg", "go"), Some("pkg".to_string()));
+        assert_eq!(
+            normalize_import("github.com/user/pkg", "go"),
+            Some("pkg".to_string())
+        );
         assert_eq!(normalize_import("fmt", "go"), None); // stdlib
     }
 
     #[test]
     fn test_normalize_java_import() {
-        assert_eq!(normalize_import("org.apache.kafka.clients", "java"), Some("kafka".to_string()));
+        assert_eq!(
+            normalize_import("org.apache.kafka.clients", "java"),
+            Some("kafka".to_string())
+        );
         assert_eq!(normalize_import("java.util.List", "java"), None); // stdlib
     }
 

--- a/src/compliance.rs
+++ b/src/compliance.rs
@@ -169,10 +169,7 @@ pub fn evaluate(
 
     let matches = evidence
         .iter()
-        .filter(|w| {
-            post_terms_lower.iter().any(|t| t.contains(*w))
-                || lower_preview.contains(*w)
-        })
+        .filter(|w| post_terms_lower.iter().any(|t| t.contains(*w)) || lower_preview.contains(*w))
         .count();
 
     let prohibitive = matches!(predicate, "never" | "forbids" | "must_not");

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,11 +80,7 @@ pub struct ResolvedBaseDir {
 /// 3. else `path_exists(<home>/.taniwha/arai)` true → that path, no notice.
 /// 4. else `path_exists(<home>/.arai)` true → that path, `DeprecatedDefaultPath` notice.
 /// 5. else fresh-install fallback → `<home>/.taniwha/arai`, no notice.
-pub fn resolve_base_dir<E, P>(
-    env_lookup: E,
-    path_exists: P,
-    home_dir: &str,
-) -> ResolvedBaseDir
+pub fn resolve_base_dir<E, P>(env_lookup: E, path_exists: P, home_dir: &str) -> ResolvedBaseDir
 where
     E: Fn(&str) -> Option<String>,
     P: Fn(&str) -> bool,
@@ -549,7 +545,10 @@ mod tests {
                 vec![("ARAI_BASE_DIR", None), ("ARAI_DB_DIR", None)],
                 &env_calls,
             ),
-            exists_with(vec![(NEW_DEFAULT, false), (OLD_DEFAULT, false)], &path_calls),
+            exists_with(
+                vec![(NEW_DEFAULT, false), (OLD_DEFAULT, false)],
+                &path_calls,
+            ),
             HOME,
         );
 

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -34,15 +34,29 @@ pub fn discover(cfg: &Config) -> Result<Vec<DiscoveredFile>, String> {
     // when it's a directory the entry above already covered it and
     // `try_read_file` here returns None.
     let project_files: Vec<(PathBuf, &str, f64)> = vec![
-        (cfg.project_root.join("CLAUDE.md"), "claude_md_project", 0.92),
-        (cfg.project_root.join(".cursor").join("rules"), "cursor_rules", 0.90),
+        (
+            cfg.project_root.join("CLAUDE.md"),
+            "claude_md_project",
+            0.92,
+        ),
+        (
+            cfg.project_root.join(".cursor").join("rules"),
+            "cursor_rules",
+            0.90,
+        ),
         (cfg.project_root.join(".cursorrules"), "cursor_rules", 0.90),
         (
-            cfg.project_root.join(".github").join("copilot-instructions.md"),
+            cfg.project_root
+                .join(".github")
+                .join("copilot-instructions.md"),
             "copilot_instructions",
             0.90,
         ),
-        (cfg.project_root.join(".windsurfrules"), "windsurf_rules", 0.90),
+        (
+            cfg.project_root.join(".windsurfrules"),
+            "windsurf_rules",
+            0.90,
+        ),
     ];
 
     for (path, source_type, confidence) in project_files {
@@ -134,26 +148,25 @@ fn read_memory_file(path: &PathBuf) -> Option<DiscoveredFile> {
         .map(|s| s.to_string_lossy().to_string())
         .unwrap_or_default();
 
-    let (source_type, confidence) =
-        if let Some(fm_type) = frontmatter.get("type") {
-            match fm_type.as_str() {
-                "feedback" => ("feedback", 0.95),
-                "user" => ("user", 0.90),
-                "project" => ("project", 0.82),
-                "reference" => ("reference", 0.85),
-                _ => ("project", 0.82),
-            }
-        } else if file_stem.starts_with("feedback_") {
-            ("feedback", 0.95)
-        } else if file_stem.starts_with("user_") {
-            ("user", 0.90)
-        } else if file_stem.starts_with("project_") {
-            ("project", 0.82)
-        } else if file_stem.starts_with("reference_") {
-            ("reference", 0.85)
-        } else {
-            ("project", 0.82)
-        };
+    let (source_type, confidence) = if let Some(fm_type) = frontmatter.get("type") {
+        match fm_type.as_str() {
+            "feedback" => ("feedback", 0.95),
+            "user" => ("user", 0.90),
+            "project" => ("project", 0.82),
+            "reference" => ("reference", 0.85),
+            _ => ("project", 0.82),
+        }
+    } else if file_stem.starts_with("feedback_") {
+        ("feedback", 0.95)
+    } else if file_stem.starts_with("user_") {
+        ("user", 0.90)
+    } else if file_stem.starts_with("project_") {
+        ("project", 0.82)
+    } else if file_stem.starts_with("reference_") {
+        ("reference", 0.85)
+    } else {
+        ("project", 0.82)
+    };
 
     Some(DiscoveredFile {
         path: path.to_string_lossy().to_string(),
@@ -190,7 +203,11 @@ pub fn parse_frontmatter(content: &str) -> (HashMap<String, String>, String) {
             let line = line.trim();
             if let Some((key, value)) = line.split_once(':') {
                 let key = key.trim().to_string();
-                let value = value.trim().trim_matches('"').trim_matches('\'').to_string();
+                let value = value
+                    .trim()
+                    .trim_matches('"')
+                    .trim_matches('\'')
+                    .to_string();
                 if !key.is_empty() && !value.is_empty() {
                     map.insert(key, value);
                 }
@@ -260,10 +277,23 @@ mod tests {
 
         let out = read_cursor_rules_dir(&rules);
         let names: Vec<String> = out.iter().map(|f| f.path.clone()).collect();
-        assert_eq!(out.len(), 3, "should pick up all 3 .md/.mdc files: {names:?}");
-        assert!(names.iter().any(|n| n.ends_with("a.md")), "a.md missing: {names:?}");
-        assert!(names.iter().any(|n| n.ends_with("b.mdc")), "b.mdc missing: {names:?}");
-        assert!(names.iter().any(|n| n.ends_with("c.md")), "sub/c.md missing: {names:?}");
+        assert_eq!(
+            out.len(),
+            3,
+            "should pick up all 3 .md/.mdc files: {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n.ends_with("a.md")),
+            "a.md missing: {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n.ends_with("b.mdc")),
+            "b.mdc missing: {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n.ends_with("c.md")),
+            "sub/c.md missing: {names:?}"
+        );
         assert!(
             !names.iter().any(|n| n.ends_with("ignored.txt")),
             "txt leaked: {names:?}"

--- a/src/enrich.rs
+++ b/src/enrich.rs
@@ -16,9 +16,11 @@ const MODEL_DIR_NAME: &str = "models";
 const MODEL_NAME: &str = "all-MiniLM-L6-v2";
 
 #[cfg(feature = "enrich")]
-const MODEL_URL: &str = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model.onnx";
+const MODEL_URL: &str =
+    "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model.onnx";
 #[cfg(feature = "enrich")]
-const TOKENIZER_URL: &str = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json";
+const TOKENIZER_URL: &str =
+    "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json";
 
 #[cfg(feature = "enrich")]
 /// Archetype sentences for each intent category.
@@ -132,7 +134,12 @@ pub fn enrich_guardrails(store: &Store, arai_base_dir: &Path) -> Result<usize, S
             };
 
             // Use taxonomy for timing classification (model doesn't handle this)
-            let timing = crate::intent::classify_rule_with_subject(&g.predicate, &g.object, Some(&g.subject)).timing;
+            let timing = crate::intent::classify_rule_with_subject(
+                &g.predicate,
+                &g.object,
+                Some(&g.subject),
+            )
+            .timing;
 
             let intent = RuleIntent {
                 action: best_action,
@@ -143,7 +150,8 @@ pub fn enrich_guardrails(store: &Store, arai_base_dir: &Path) -> Result<usize, S
                 severity: crate::intent::Severity::from_predicate(&g.predicate),
             };
 
-            store.upsert_rule_intent(g.triple_id, &intent)
+            store
+                .upsert_rule_intent(g.triple_id, &intent)
                 .map_err(|e| e.to_string())?;
             count += 1;
         }
@@ -208,10 +216,12 @@ fn download_file(url: &str, dest: &Path) -> Result<(), String> {
     }
 
     // Verify file was created and has content
-    let meta = std::fs::metadata(dest)
-        .map_err(|e| format!("Downloaded file not found: {e}"))?;
+    let meta = std::fs::metadata(dest).map_err(|e| format!("Downloaded file not found: {e}"))?;
     if meta.len() < 1000 {
-        return Err(format!("Downloaded file is suspiciously small ({} bytes)", meta.len()));
+        return Err(format!(
+            "Downloaded file is suspiciously small ({} bytes)",
+            meta.len()
+        ));
     }
 
     Ok(())
@@ -237,11 +247,16 @@ fn embed_single(
     tokenizer: &tokenizers::Tokenizer,
     text: &str,
 ) -> Result<Vec<f32>, String> {
-    let encoding = tokenizer.encode(text, true)
+    let encoding = tokenizer
+        .encode(text, true)
         .map_err(|e| format!("Tokenization failed: {e}"))?;
 
     let ids: Vec<i64> = encoding.get_ids().iter().map(|&id| id as i64).collect();
-    let mask: Vec<i64> = encoding.get_attention_mask().iter().map(|&m| m as i64).collect();
+    let mask: Vec<i64> = encoding
+        .get_attention_mask()
+        .iter()
+        .map(|&m| m as i64)
+        .collect();
     let type_ids: Vec<i64> = encoding.get_type_ids().iter().map(|&t| t as i64).collect();
     let len = ids.len();
 
@@ -257,8 +272,7 @@ fn embed_single(
         .map_err(|e| format!("Inference failed: {e}"))?;
 
     // Get the first output (last_hidden_state) — shape [1, seq_len, 384]
-    let output = outputs.values().next()
-        .ok_or("No output from model")?;
+    let output = outputs.values().next().ok_or("No output from model")?;
 
     let (shape, raw_data) = output
         .try_extract_tensor::<f32>()
@@ -266,7 +280,11 @@ fn embed_single(
 
     // Mean pooling: average across sequence length dimension
     let hidden_size = *shape.last().unwrap_or(&384) as usize;
-    let seq_len = if shape.len() >= 2 { shape[shape.len() - 2] as usize } else { 1 };
+    let seq_len = if shape.len() >= 2 {
+        shape[shape.len() - 2] as usize
+    } else {
+        1
+    };
 
     let mut embedding = vec![0.0f32; hidden_size];
     for i in 0..seq_len {
@@ -314,12 +332,16 @@ fn build_enrichment_prompt(guardrails: &[crate::store::Guardrail]) -> String {
     for (i, g) in guardrails.iter().enumerate() {
         rules_text.push_str(&format!(
             "{}. [id:{}] {} {}: {}\n",
-            i + 1, g.triple_id, g.subject, g.predicate, g.object
+            i + 1,
+            g.triple_id,
+            g.subject,
+            g.predicate,
+            g.object
         ));
     }
 
     format!(
-r#"You are classifying guardrail rules for a CLI tool called Arai. For each rule, determine:
+        r#"You are classifying guardrail rules for a CLI tool called Arai. For each rule, determine:
 
 1. **action**: What type of action does this rule govern?
    - "create" — about creating NEW files (Write tool)
@@ -364,7 +386,11 @@ fn parse_and_apply(
         Some(s) => s,
         None => {
             save_failed_response(arai_base_dir, response);
-            let preview = if response.len() > 500 { &response[..500] } else { response };
+            let preview = if response.len() > 500 {
+                &response[..500]
+            } else {
+                response
+            };
             return Err(format!(
                 "Could not parse LLM response as JSON array.\n\
                  Raw output (first 500 chars):\n{preview}\n\n\
@@ -392,7 +418,11 @@ fn parse_and_apply(
 /// Enrich guardrails by shelling out to an LLM CLI.
 /// Uses the configured command (ARAI_LLM_CMD env var or config.toml).
 /// Falls back to `claude -p` if nothing configured.
-pub fn enrich_via_llm(store: &Store, llm_command: Option<&str>, arai_base_dir: &Path) -> Result<usize, String> {
+pub fn enrich_via_llm(
+    store: &Store,
+    llm_command: Option<&str>,
+    arai_base_dir: &Path,
+) -> Result<usize, String> {
     let cmd = llm_command
         .map(String::from)
         .or_else(detect_llm_command)
@@ -403,7 +433,7 @@ pub fn enrich_via_llm(store: &Store, llm_command: Option<&str>, arai_base_dir: &
              \n  ARAI_LLM_CMD=\"llm -m gpt-4o\"             # Simon Willison's llm\
              \n\nOr add to ~/.taniwha/arai/config.toml:\n\
              \n  [enrich]\
-             \n  llm_command = \"claude -p\""
+             \n  llm_command = \"claude -p\"",
         )?;
 
     let all = store.load_guardrails().map_err(|e| e.to_string())?;
@@ -418,7 +448,13 @@ pub fn enrich_via_llm(store: &Store, llm_command: Option<&str>, arai_base_dir: &
         return Ok(0);
     }
 
-    print_destination_notice("LLM CLI", &cmd, classify_cli_locality(&cmd), guardrails.len(), excluded);
+    print_destination_notice(
+        "LLM CLI",
+        &cmd,
+        classify_cli_locality(&cmd),
+        guardrails.len(),
+        excluded,
+    );
 
     let prompt = build_enrichment_prompt(&guardrails);
     let response = run_llm_command(&cmd, &prompt)?;
@@ -466,7 +502,13 @@ pub fn enrich_via_api(
     }
 
     let label = format!("HTTP API (model: {})", config.model);
-    print_destination_notice(&label, &config.url, classify_url_locality(&config.url), guardrails.len(), excluded);
+    print_destination_notice(
+        &label,
+        &config.url,
+        classify_url_locality(&config.url),
+        guardrails.len(),
+        excluded,
+    );
 
     let prompt = build_enrichment_prompt(&guardrails);
     let response = call_chat_completions(&config, &prompt)?;
@@ -488,15 +530,20 @@ type Locality = Option<bool>;
 /// Goes to stderr-equivalent (`println!` stays with the existing `cmd_scan`
 /// progress lines) but uses an explicit `[notice]` prefix so a user scanning
 /// the output sees that rule text is about to leave the local process.
-fn print_destination_notice(channel: &str, dest: &str, locality: Locality, rules: usize, excluded: usize) {
+fn print_destination_notice(
+    channel: &str,
+    dest: &str,
+    locality: Locality,
+    rules: usize,
+    excluded: usize,
+) {
     let locality_str = match locality {
         Some(true) => "local",
         Some(false) => "REMOTE",
         None => "unknown locality",
     };
-    let mut line = format!(
-        "    [notice] Sending {rules} rule(s) to {channel}: {dest} ({locality_str})"
-    );
+    let mut line =
+        format!("    [notice] Sending {rules} rule(s) to {channel}: {dest} ({locality_str})");
     if excluded > 0 {
         line.push_str(&format!(" — {excluded} rule(s) skipped via (noenrich)"));
     }
@@ -543,7 +590,10 @@ pub(crate) fn classify_url_locality(url: &str) -> Locality {
     // Strip the optional port without mangling bracketed IPv6 literals.
     let host = if let Some(stripped) = authority.strip_prefix('[') {
         // `[::1]:8080` → take through the closing bracket and reinsert it
-        stripped.split(']').next().map(|s| format!("[{s}]"))
+        stripped
+            .split(']')
+            .next()
+            .map(|s| format!("[{s}]"))
             .unwrap_or_default()
     } else {
         authority.split(':').next().unwrap_or("").to_string()
@@ -601,7 +651,8 @@ fn resolve_api_config(
          \n  [enrich]\
          \n  api_url = \"https://api.openai.com/v1\"\
          \n  api_key_env = \"OPENAI_API_KEY\"\
-         \n  model = \"gpt-4o-mini\"".to_string())
+         \n  model = \"gpt-4o-mini\""
+        .to_string())
 }
 
 /// Ensure the URL ends with /chat/completions.
@@ -625,7 +676,11 @@ fn probe_ollama() -> bool {
     match agent.get("http://localhost:11434/").call() {
         Ok(response) => {
             let mut body = String::new();
-            response.into_body().as_reader().read_to_string(&mut body).ok();
+            response
+                .into_body()
+                .as_reader()
+                .read_to_string(&mut body)
+                .ok();
             body.contains("Ollama")
         }
         Err(_) => false,
@@ -654,31 +709,32 @@ fn call_chat_completions(config: &ApiConfig, prompt: &str) -> Result<String, Str
         .build()
         .new_agent();
 
-    let mut request = agent.post(&config.url)
+    let mut request = agent
+        .post(&config.url)
         .header("Content-Type", "application/json");
 
     if let Some(ref key) = config.api_key {
         request = request.header("Authorization", &format!("Bearer {key}"));
     }
 
-    let response = request
-        .send_json(&body)
-        .map_err(|e| {
-            match &e {
-                ureq::Error::StatusCode(401) =>
-                    "Authentication failed. Check your ARAI_API_KEY.".to_string(),
-                ureq::Error::StatusCode(429) =>
-                    "Rate limited by API. Try again in a moment.".to_string(),
-                ureq::Error::StatusCode(404) =>
-                    format!("Endpoint not found: {}. Check your ARAI_API_URL.", config.url),
-                ureq::Error::StatusCode(code) =>
-                    format!("API returned HTTP {code}"),
-                _ => format!("API request failed: {e}"),
-            }
-        })?;
+    let response = request.send_json(&body).map_err(|e| match &e {
+        ureq::Error::StatusCode(401) => {
+            "Authentication failed. Check your ARAI_API_KEY.".to_string()
+        }
+        ureq::Error::StatusCode(429) => "Rate limited by API. Try again in a moment.".to_string(),
+        ureq::Error::StatusCode(404) => format!(
+            "Endpoint not found: {}. Check your ARAI_API_URL.",
+            config.url
+        ),
+        ureq::Error::StatusCode(code) => format!("API returned HTTP {code}"),
+        _ => format!("API request failed: {e}"),
+    })?;
 
     let mut response_str = String::new();
-    response.into_body().as_reader().read_to_string(&mut response_str)
+    response
+        .into_body()
+        .as_reader()
+        .read_to_string(&mut response_str)
         .map_err(|e| format!("Failed to read API response: {e}"))?;
 
     let response_body: serde_json::Value = serde_json::from_str(&response_str)
@@ -693,15 +749,17 @@ fn call_chat_completions(config: &ApiConfig, prompt: &str) -> Result<String, Str
         .and_then(|c: &serde_json::Value| c.as_str())
         .map(String::from)
         .ok_or_else(|| {
-            format!("Unexpected API response structure: {}",
-                serde_json::to_string_pretty(&response_body).unwrap_or_default())
+            format!(
+                "Unexpected API response structure: {}",
+                serde_json::to_string_pretty(&response_body).unwrap_or_default()
+            )
         })
 }
 
 /// Import enrichment from a JSON file (same format as LLM output).
 pub fn enrich_from_file(store: &Store, path: &str, arai_base_dir: &Path) -> Result<usize, String> {
-    let content = std::fs::read_to_string(path)
-        .map_err(|e| format!("Failed to read {path}: {e}"))?;
+    let content =
+        std::fs::read_to_string(path).map_err(|e| format!("Failed to read {path}: {e}"))?;
 
     let guardrails = store.load_guardrails().map_err(|e| e.to_string())?;
     parse_and_apply(store, &guardrails, &content, arai_base_dir)
@@ -729,14 +787,27 @@ fn apply_classifications(
         }
         let g = guardrail.unwrap();
 
-        let raw_action = entry.get("action").and_then(|v| v.as_str()).unwrap_or("general");
-        let raw_timing = entry.get("timing").and_then(|v| v.as_str()).unwrap_or("principle");
-        let allow_inverse = entry.get("allow_inverse").and_then(|v| v.as_bool()).unwrap_or(false);
+        let raw_action = entry
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or("general");
+        let raw_timing = entry
+            .get("timing")
+            .and_then(|v| v.as_str())
+            .unwrap_or("principle");
+        let allow_inverse = entry
+            .get("allow_inverse")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
 
         let tools: Vec<String> = entry
             .get("tools")
             .and_then(|v| v.as_array())
-            .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
             .unwrap_or_else(|| vec!["*".to_string()]);
 
         // Validate + fuzzy match each enum field
@@ -745,7 +816,10 @@ fn apply_classifications(
         let action = if Action::is_valid(raw_action) {
             Action::from_str(raw_action)
         } else {
-            eprintln!("    \u{26a0} Rule '{}': unrecognized action '{}', using fuzzy match", g.subject, raw_action);
+            eprintln!(
+                "    \u{26a0} Rule '{}': unrecognized action '{}', using fuzzy match",
+                g.subject, raw_action
+            );
             is_partial = true;
             fuzzy_match_action(raw_action, g)
         };
@@ -753,7 +827,10 @@ fn apply_classifications(
         let timing_raw = if crate::intent::Timing::is_valid(raw_timing) {
             crate::intent::Timing::from_str(raw_timing)
         } else {
-            eprintln!("    \u{26a0} Rule '{}': unrecognized timing '{}', using fuzzy match", g.subject, raw_timing);
+            eprintln!(
+                "    \u{26a0} Rule '{}': unrecognized timing '{}', using fuzzy match",
+                g.subject, raw_timing
+            );
             is_partial = true;
             fuzzy_match_timing(raw_timing, g)
         };
@@ -763,7 +840,9 @@ fn apply_classifications(
         if timing == crate::intent::Timing::ToolCall {
             let full_text = format!("{} {}", g.subject.to_lowercase(), g.object.to_lowercase());
             let has_tool = crate::parser::KNOWN_TOOLS.iter().any(|tool| {
-                full_text.split(|c: char| !c.is_alphanumeric()).any(|w| w == *tool)
+                full_text
+                    .split(|c: char| !c.is_alphanumeric())
+                    .any(|w| w == *tool)
             });
             if !has_tool {
                 timing = crate::intent::Timing::Principle;
@@ -779,11 +858,17 @@ fn apply_classifications(
             timing,
             tools,
             allow_inverse,
-            enriched_by: if is_partial { "llm-partial".to_string() } else { "llm".to_string() },
+            enriched_by: if is_partial {
+                "llm-partial".to_string()
+            } else {
+                "llm".to_string()
+            },
             severity: crate::intent::Severity::from_predicate(&g.predicate),
         };
 
-        store.upsert_rule_intent(id, &intent).map_err(|e| e.to_string())?;
+        store
+            .upsert_rule_intent(id, &intent)
+            .map_err(|e| e.to_string())?;
         count += 1;
     }
 
@@ -803,15 +888,32 @@ fn fuzzy_match_action(raw: &str, g: &crate::store::Guardrail) -> Action {
     if lower.contains("creat") || lower.contains("writ") || lower.contains("generat") {
         return Action::Create;
     }
-    if lower.contains("modif") || lower.contains("edit") || lower.contains("updat") || lower.contains("chang") {
+    if lower.contains("modif")
+        || lower.contains("edit")
+        || lower.contains("updat")
+        || lower.contains("chang")
+    {
         return Action::Modify;
     }
-    if lower.contains("exec") || lower.contains("run") || lower.contains("command") || lower.contains("invoke") {
+    if lower.contains("exec")
+        || lower.contains("run")
+        || lower.contains("command")
+        || lower.contains("invoke")
+    {
         return Action::Execute;
     }
-    if lower.contains("forbid") || lower.contains("prevent") || lower.contains("block") || lower.contains("deny") {
+    if lower.contains("forbid")
+        || lower.contains("prevent")
+        || lower.contains("block")
+        || lower.contains("deny")
+    {
         // "forbid" is about the predicate, not the action — fall back to taxonomy
-        return crate::intent::classify_rule_with_subject(&g.predicate, &g.object, Some(&g.subject)).action;
+        return crate::intent::classify_rule_with_subject(
+            &g.predicate,
+            &g.object,
+            Some(&g.subject),
+        )
+        .action;
     }
 
     // Fall back to taxonomy
@@ -832,7 +934,11 @@ fn fuzzy_match_timing(raw: &str, g: &crate::store::Guardrail) -> crate::intent::
     if lower.contains("start") || lower.contains("begin") || lower.contains("prompt") {
         return crate::intent::Timing::Start;
     }
-    if lower.contains("stop") || lower.contains("end") || lower.contains("finish") || lower.contains("complet") {
+    if lower.contains("stop")
+        || lower.contains("end")
+        || lower.contains("finish")
+        || lower.contains("complet")
+    {
         return crate::intent::Timing::Stop;
     }
     if lower.contains("princip") || lower.contains("general") || lower.contains("always") {
@@ -978,7 +1084,11 @@ mod tests {
     fn test_fuzzy_action_prevent() {
         let g = dummy_guardrail();
         let action = fuzzy_match_action("prevent", &g);
-        assert_ne!(action, Action::Create, "prevent should fall back to taxonomy");
+        assert_ne!(
+            action,
+            Action::Create,
+            "prevent should fall back to taxonomy"
+        );
     }
 
     #[test]
@@ -1027,13 +1137,34 @@ mod tests {
     #[test]
     fn test_fuzzy_timing_variants() {
         let g = dummy_guardrail();
-        assert_eq!(fuzzy_match_timing("pre_tool_use", &g), crate::intent::Timing::ToolCall);
-        assert_eq!(fuzzy_match_timing("pretool", &g), crate::intent::Timing::ToolCall);
-        assert_eq!(fuzzy_match_timing("on_start", &g), crate::intent::Timing::Start);
-        assert_eq!(fuzzy_match_timing("before_finish", &g), crate::intent::Timing::Stop);
-        assert_eq!(fuzzy_match_timing("completion", &g), crate::intent::Timing::Stop);
-        assert_eq!(fuzzy_match_timing("general_principle", &g), crate::intent::Timing::Principle);
-        assert_eq!(fuzzy_match_timing("always_apply", &g), crate::intent::Timing::Principle);
+        assert_eq!(
+            fuzzy_match_timing("pre_tool_use", &g),
+            crate::intent::Timing::ToolCall
+        );
+        assert_eq!(
+            fuzzy_match_timing("pretool", &g),
+            crate::intent::Timing::ToolCall
+        );
+        assert_eq!(
+            fuzzy_match_timing("on_start", &g),
+            crate::intent::Timing::Start
+        );
+        assert_eq!(
+            fuzzy_match_timing("before_finish", &g),
+            crate::intent::Timing::Stop
+        );
+        assert_eq!(
+            fuzzy_match_timing("completion", &g),
+            crate::intent::Timing::Stop
+        );
+        assert_eq!(
+            fuzzy_match_timing("general_principle", &g),
+            crate::intent::Timing::Principle
+        );
+        assert_eq!(
+            fuzzy_match_timing("always_apply", &g),
+            crate::intent::Timing::Principle
+        );
     }
 
     #[test]
@@ -1202,22 +1333,20 @@ mod tests {
 
     #[test]
     fn test_build_enrichment_prompt_format() {
-        let guardrails = vec![
-            crate::store::Guardrail {
-                triple_id: 1,
-                subject: "Git".to_string(),
-                predicate: "never".to_string(),
-                object: "force-push to main".to_string(),
-                confidence: 0.92,
-                source_file: "test".to_string(),
-                file_path: "test".to_string(),
-                layer: None,
-                line_start: None,
-                expires_at: None,
-                noenrich: false,
-                intent: None,
-            },
-        ];
+        let guardrails = vec![crate::store::Guardrail {
+            triple_id: 1,
+            subject: "Git".to_string(),
+            predicate: "never".to_string(),
+            object: "force-push to main".to_string(),
+            confidence: 0.92,
+            source_file: "test".to_string(),
+            file_path: "test".to_string(),
+            layer: None,
+            line_start: None,
+            expires_at: None,
+            noenrich: false,
+            intent: None,
+        }];
         let prompt = build_enrichment_prompt(&guardrails);
         assert!(prompt.contains("[id:1] Git never: force-push to main"));
         assert!(prompt.contains("\"action\""));
@@ -1227,11 +1356,9 @@ mod tests {
 
     #[test]
     fn test_resolve_api_config_explicit_url() {
-        let config = resolve_api_config(
-            Some("https://api.example.com/v1"),
-            None,
-            Some("test-model"),
-        ).unwrap();
+        let config =
+            resolve_api_config(Some("https://api.example.com/v1"), None, Some("test-model"))
+                .unwrap();
         assert_eq!(config.url, "https://api.example.com/v1/chat/completions");
         assert_eq!(config.model, "test-model");
         assert!(config.api_key.is_none());
@@ -1306,7 +1433,10 @@ mod tests {
     #[test]
     fn classify_cli_locality_known_local() {
         assert_eq!(classify_cli_locality("ollama run llama3.1"), Some(true));
-        assert_eq!(classify_cli_locality("/usr/local/bin/ollama serve"), Some(true));
+        assert_eq!(
+            classify_cli_locality("/usr/local/bin/ollama serve"),
+            Some(true)
+        );
     }
 
     #[test]
@@ -1323,7 +1453,10 @@ mod tests {
 
     #[test]
     fn classify_url_locality_loopback() {
-        assert_eq!(classify_url_locality("http://localhost:11434/v1/chat/completions"), Some(true));
+        assert_eq!(
+            classify_url_locality("http://localhost:11434/v1/chat/completions"),
+            Some(true)
+        );
         assert_eq!(classify_url_locality("http://127.0.0.1:11434"), Some(true));
         assert_eq!(classify_url_locality("http://[::1]:8080/v1"), Some(true));
         assert_eq!(classify_url_locality("unix:/var/run/llm.sock"), Some(true));
@@ -1331,9 +1464,18 @@ mod tests {
 
     #[test]
     fn classify_url_locality_remote() {
-        assert_eq!(classify_url_locality("https://api.openai.com/v1/chat/completions"), Some(false));
-        assert_eq!(classify_url_locality("https://api.anthropic.com"), Some(false));
-        assert_eq!(classify_url_locality("https://user:token@api.example.com/v1"), Some(false));
+        assert_eq!(
+            classify_url_locality("https://api.openai.com/v1/chat/completions"),
+            Some(false)
+        );
+        assert_eq!(
+            classify_url_locality("https://api.anthropic.com"),
+            Some(false)
+        );
+        assert_eq!(
+            classify_url_locality("https://user:token@api.example.com/v1"),
+            Some(false)
+        );
     }
 
     #[test]

--- a/src/extends.rs
+++ b/src/extends.rs
@@ -71,8 +71,7 @@ fn read_trust(arai_base: &Path) -> TrustFile {
 fn write_trust(arai_base: &Path, tf: &TrustFile) -> Result<(), String> {
     let path = trust_path(arai_base);
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| format!("Failed to create trust dir: {e}"))?;
+        std::fs::create_dir_all(parent).map_err(|e| format!("Failed to create trust dir: {e}"))?;
     }
     let encoded =
         toml::to_string_pretty(tf).map_err(|e| format!("Failed to encode trust file: {e}"))?;
@@ -124,8 +123,7 @@ fn validate_url(url: &str) -> Result<(), String> {
     if url.len() > 2048 {
         return Err("URL is implausibly long (>2048 chars)".to_string());
     }
-    let host = extract_host(url)
-        .ok_or_else(|| format!("could not parse host from {url:?}"))?;
+    let host = extract_host(url).ok_or_else(|| format!("could not parse host from {url:?}"))?;
     validate_host_not_private(host)?;
     Ok(())
 }
@@ -344,8 +342,7 @@ fn fetch_remote(url: &str) -> Result<String, String> {
         ));
     }
 
-    String::from_utf8(bytes)
-        .map_err(|e| format!("response was not valid UTF-8: {e}"))
+    String::from_utf8(bytes).map_err(|e| format!("response was not valid UTF-8: {e}"))
 }
 
 fn filetouch(path: &Path) -> std::io::Result<()> {
@@ -512,9 +509,18 @@ mod tests {
     #[test]
     fn test_extract_host_basic() {
         assert_eq!(extract_host("https://example.com"), Some("example.com"));
-        assert_eq!(extract_host("https://example.com/path"), Some("example.com"));
-        assert_eq!(extract_host("https://example.com:443/p"), Some("example.com"));
-        assert_eq!(extract_host("https://user:pw@example.com/p"), Some("example.com"));
+        assert_eq!(
+            extract_host("https://example.com/path"),
+            Some("example.com")
+        );
+        assert_eq!(
+            extract_host("https://example.com:443/p"),
+            Some("example.com")
+        );
+        assert_eq!(
+            extract_host("https://user:pw@example.com/p"),
+            Some("example.com")
+        );
         assert_eq!(extract_host("https://[::1]:443/p"), Some("::1"));
         assert_eq!(extract_host("https://[2001:db8::1]/p"), Some("2001:db8::1"));
     }
@@ -544,10 +550,17 @@ mod tests {
     fn test_is_private_ip_classifications() {
         use std::str::FromStr;
         let private_cases = [
-            "127.0.0.1", "10.0.0.1", "172.20.5.1", "192.168.0.1",
-            "169.254.169.254", "0.0.0.0", "224.0.0.1",
+            "127.0.0.1",
+            "10.0.0.1",
+            "172.20.5.1",
+            "192.168.0.1",
+            "169.254.169.254",
+            "0.0.0.0",
+            "224.0.0.1",
             "100.64.0.1", // CGNAT
-            "::1", "fc00::1", "fe80::1",
+            "::1",
+            "fc00::1",
+            "fe80::1",
         ];
         for s in private_cases {
             let ip: IpAddr = IpAddr::from_str(s).unwrap();
@@ -563,10 +576,7 @@ mod tests {
 
     #[test]
     fn test_trust_add_and_list() {
-        let tmp = std::env::temp_dir().join(format!(
-            "arai_trust_test_{}",
-            std::process::id()
-        ));
+        let tmp = std::env::temp_dir().join(format!("arai_trust_test_{}", std::process::id()));
         std::fs::create_dir_all(&tmp).unwrap();
         let url = "https://example.com/rules.md";
         assert!(trust_add(url, &tmp).unwrap());
@@ -582,10 +592,7 @@ mod tests {
     #[test]
     fn test_resolve_inlines_untrusted_url_silently_noops() {
         // Untrusted URL: resolve returns original content, prints to stderr.
-        let tmp = std::env::temp_dir().join(format!(
-            "arai_resolve_untrust_{}",
-            std::process::id()
-        ));
+        let tmp = std::env::temp_dir().join(format!("arai_resolve_untrust_{}", std::process::id()));
         std::fs::create_dir_all(&tmp).unwrap();
         let content = "<!-- arai:extends https://example.com/not-trusted.md -->\n\n- local rule\n";
         let resolved = resolve(content, &tmp);

--- a/src/guardrails.rs
+++ b/src/guardrails.rs
@@ -9,10 +9,9 @@ const SKIP_TOOLS: &[&str] = &["Read", "Glob", "Agent", "ToolSearch"];
 
 /// Noise words to skip when extracting terms from Bash commands.
 const NOISE_WORDS: &[&str] = &[
-    "run", "sudo", "cd", "echo", "python", "bash", "sh", "cat", "head",
-    "tail", "ls", "mkdir", "rm", "cp", "mv", "true", "false",
-    "set", "export", "source", "exec", "xargs", "env", "time", "nice",
-    "nohup", "eval",
+    "run", "sudo", "cd", "echo", "python", "bash", "sh", "cat", "head", "tail", "ls", "mkdir",
+    "rm", "cp", "mv", "true", "false", "set", "export", "source", "exec", "xargs", "env", "time",
+    "nice", "nohup", "eval",
 ];
 
 /// Short tokens that are valid tool names (allowlisted despite < 3 chars).
@@ -29,8 +28,8 @@ const SHORT_TOOL_ALLOWLIST: &[&str] = &["go", "gh", "uv", "mv", "rm", "ls", "cd"
 /// preposition-only on purpose: short verbs like `run`, `test`, `build`
 /// MUST remain extractable as subcommands.
 const PHRASE_STOPWORDS: &[&str] = &[
-    "for", "in", "with", "to", "the", "a", "an", "as", "from", "into",
-    "on", "of", "by", "at", "is", "are", "or", "and", "via",
+    "for", "in", "with", "to", "the", "a", "an", "as", "from", "into", "on", "of", "by", "at",
+    "is", "are", "or", "and", "via",
 ];
 
 /// Check if a tool should skip guardrail matching entirely.
@@ -58,9 +57,7 @@ pub fn enrich_terms_from_graph(
 ) {
     // Only enrich for file-based operations
     let file_path = match tool_name {
-        "Edit" | "Write" | "NotebookEdit" => {
-            tool_input.get("file_path").and_then(|v| v.as_str())
-        }
+        "Edit" | "Write" | "NotebookEdit" => tool_input.get("file_path").and_then(|v| v.as_str()),
         _ => None,
     };
 
@@ -345,9 +342,7 @@ fn extract_phrases_from_segment(segment: &str, phrases: &mut Vec<String>) {
             }
             if j < raw_tokens.len() {
                 let sub = raw_tokens[j].to_lowercase();
-                let clean: String = sub
-                    .trim_matches(|c: char| !c.is_alphanumeric())
-                    .to_string();
+                let clean: String = sub.trim_matches(|c: char| !c.is_alphanumeric()).to_string();
                 if !clean.is_empty() {
                     phrases.push(format!("{tool} {clean}"));
                 }
@@ -435,7 +430,13 @@ pub fn match_guardrails(
         .collect();
 
     // Sort by relevance score (highest first), then by confidence
-    matched.sort_by(|a, b| b.1.cmp(&a.1).then(b.0.confidence.partial_cmp(&a.0.confidence).unwrap_or(std::cmp::Ordering::Equal)));
+    matched.sort_by(|a, b| {
+        b.1.cmp(&a.1).then(
+            b.0.confidence
+                .partial_cmp(&a.0.confidence)
+                .unwrap_or(std::cmp::Ordering::Equal),
+        )
+    });
 
     // If we have high-relevance matches, suppress low-relevance ones
     let top_score = matched.first().map(|(_, s)| *s).unwrap_or(0);
@@ -443,10 +444,13 @@ pub fn match_guardrails(
         matched.retain(|(_, s)| *s >= top_score);
     }
 
-    matched.into_iter().map(|(g, score)| {
-        let pct = relevance_percentage(score, terms.len(), g.confidence);
-        (g, pct)
-    }).collect()
+    matched
+        .into_iter()
+        .map(|(g, score)| {
+            let pct = relevance_percentage(score, terms.len(), g.confidence);
+            (g, pct)
+        })
+        .collect()
 }
 
 /// Convert raw relevance score into a confidence percentage (0-100).
@@ -482,10 +486,35 @@ fn relevance_percentage(score: usize, total_terms: usize, base_confidence: f64) 
 /// multi-word verb matching (treat `docker run` as a phrase); tracked
 /// separately.
 const COMMAND_VERBS: &[&str] = &[
-    "push", "pull", "commit", "merge", "rebase", "checkout", "clone", "fetch",
-    "stash", "reset", "revert", "cherry", "bisect", "tag", "branch",
-    "install", "uninstall", "build", "test", "deploy", "publish",
-    "start", "stop", "create", "delete", "remove", "add", "update", "upgrade",
+    "push",
+    "pull",
+    "commit",
+    "merge",
+    "rebase",
+    "checkout",
+    "clone",
+    "fetch",
+    "stash",
+    "reset",
+    "revert",
+    "cherry",
+    "bisect",
+    "tag",
+    "branch",
+    "install",
+    "uninstall",
+    "build",
+    "test",
+    "deploy",
+    "publish",
+    "start",
+    "stop",
+    "create",
+    "delete",
+    "remove",
+    "add",
+    "update",
+    "upgrade",
 ];
 
 /// Check whether a rule's subject overlaps with any extracted command term as
@@ -507,9 +536,7 @@ fn subject_matches_terms(subject: &str, terms: &[String]) -> bool {
     if subj_tokens.is_empty() {
         return false;
     }
-    subj_tokens
-        .iter()
-        .any(|st| terms.iter().any(|t| t == st))
+    subj_tokens.iter().any(|st| terms.iter().any(|t| t == st))
 }
 
 /// Score a rule's object text against the extracted command terms and
@@ -535,11 +562,7 @@ fn subject_matches_terms(subject: &str, terms: &[String]) -> bool {
 /// fires; `n` may be zero for general rules whose object names no
 /// command verbs and no command-term overlap (e.g. "hand-write
 /// migration files" firing on a Write because the *subject* matched).
-fn relevance_score(
-    object: &str,
-    terms: &[String],
-    command_phrases: &[String],
-) -> Option<usize> {
+fn relevance_score(object: &str, terms: &[String], command_phrases: &[String]) -> Option<usize> {
     let object_words: Vec<String> = object
         .to_lowercase()
         .split(|c: char| !c.is_alphanumeric())
@@ -562,7 +585,8 @@ fn relevance_score(
         }
     }
 
-    let base_score: usize = terms.iter()
+    let base_score: usize = terms
+        .iter()
         .filter(|t| object_words.iter().any(|w| w == *t))
         .count();
 
@@ -570,11 +594,11 @@ fn relevance_score(
     // them appear in the command terms.  Previously this halved the score
     // (min 1) so the rule still fired; that let a `git push` rule block
     // every `git status`.  Now: drop the match entirely.
-    let rule_verbs: Vec<&String> = object_words.iter()
+    let rule_verbs: Vec<&String> = object_words
+        .iter()
         .filter(|w| COMMAND_VERBS.contains(&w.as_str()))
         .collect();
-    let has_verb_mismatch = !rule_verbs.is_empty()
-        && !rule_verbs.iter().any(|v| terms.contains(v));
+    let has_verb_mismatch = !rule_verbs.is_empty() && !rule_verbs.iter().any(|v| terms.contains(v));
 
     if has_verb_mismatch {
         None
@@ -619,7 +643,10 @@ pub fn format_context(
         }
     }
     if matched.len() > MAX_RULES_PER_HOOK {
-        lines.push(format!("  ({} more suppressed)", matched.len() - MAX_RULES_PER_HOOK));
+        lines.push(format!(
+            "  ({} more suppressed)",
+            matched.len() - MAX_RULES_PER_HOOK
+        ));
     }
     lines.join("\n")
 }
@@ -754,7 +781,10 @@ mod tests {
     fn sniff_finds_tool_at_word_boundary_case_insensitively() {
         let mut terms = Vec::new();
         sniff_content_for_tools("Git pull origin main", &mut terms);
-        assert!(terms.contains(&"git".to_string()), "case-insensitive prefix match: {terms:?}");
+        assert!(
+            terms.contains(&"git".to_string()),
+            "case-insensitive prefix match: {terms:?}"
+        );
     }
 
     #[test]
@@ -762,7 +792,10 @@ mod tests {
         // "github" contains "git" but is its own word — must NOT match `git`.
         let mut terms = Vec::new();
         sniff_content_for_tools("see github.com/foo", &mut terms);
-        assert!(!terms.contains(&"git".to_string()), "substring leak: {terms:?}");
+        assert!(
+            !terms.contains(&"git".to_string()),
+            "substring leak: {terms:?}"
+        );
     }
 
     #[test]
@@ -881,7 +914,9 @@ mod tests {
             },
         ];
 
-        store.upsert_file("CLAUDE.md", "test content", &triples, "test").unwrap();
+        store
+            .upsert_file("CLAUDE.md", "test content", &triples, "test")
+            .unwrap();
         store.classify_all_guardrails().unwrap();
 
         let guardrails = store.load_guardrails().unwrap();
@@ -891,22 +926,38 @@ mod tests {
         // is irrelevant — pass &[] across the board.
         let terms = vec!["alembic".to_string()];
         let matched = match_guardrails(&guardrails, &terms, &[], "Write", "PreToolUse");
-        assert_eq!(matched.len(), 1, "hand-write rule should fire on Write/PreToolUse");
+        assert_eq!(
+            matched.len(),
+            1,
+            "hand-write rule should fire on Write/PreToolUse"
+        );
 
         let matched = match_guardrails(&guardrails, &terms, &[], "Bash", "PreToolUse");
         assert_eq!(matched.len(), 0, "hand-write rule should not fire on Bash");
 
         let matched = match_guardrails(&guardrails, &terms, &[], "Edit", "PreToolUse");
-        assert_eq!(matched.len(), 0, "hand-write rule should not fire on Edit (allow_inverse)");
+        assert_eq!(
+            matched.len(),
+            0,
+            "hand-write rule should not fire on Edit (allow_inverse)"
+        );
 
         // Git "force-push" rule: principle timing → doesn't fire on any hook
         // (principles are already in CLAUDE.md, Arai doesn't repeat them)
         let terms = vec!["git".to_string()];
         let matched = match_guardrails(&guardrails, &terms, &[], "Bash", "PreToolUse");
-        assert_eq!(matched.len(), 0, "principle rule should not fire on PreToolUse");
+        assert_eq!(
+            matched.len(),
+            0,
+            "principle rule should not fire on PreToolUse"
+        );
 
         let matched = match_guardrails(&guardrails, &terms, &[], "Bash", "UserPromptSubmit");
-        assert_eq!(matched.len(), 0, "principle rule should not fire on UserPromptSubmit either");
+        assert_eq!(
+            matched.len(),
+            0,
+            "principle rule should not fire on UserPromptSubmit either"
+        );
 
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -927,7 +978,12 @@ mod tests {
     #[test]
     fn test_relevance_score() {
         // "push" and "main" both overlap, phrase matches, no verb mismatch
-        let terms = vec!["git".to_string(), "push".to_string(), "origin".to_string(), "main".to_string()];
+        let terms = vec![
+            "git".to_string(),
+            "push".to_string(),
+            "origin".to_string(),
+            "main".to_string(),
+        ];
         let phrases = vec!["git push".to_string()];
         let score = relevance_score("git push to main without a PR", &terms, &phrases)
             .expect("push verb matches — should score Some");
@@ -936,20 +992,35 @@ mod tests {
         // commit ≠ push: phrase mismatch (#98) drops first; even without
         // phrases the verb-mismatch fallback would also drop.
         let score = relevance_score("git commit with signed commits", &terms, &phrases);
-        assert!(score.is_none(),
-            "commit-verb rule should be dropped for a push command — got {score:?}");
+        assert!(
+            score.is_none(),
+            "commit-verb rule should be dropped for a push command — got {score:?}"
+        );
     }
 
     #[test]
     fn test_relevance_verb_mismatch_drops_rule() {
         // Rule says "push" but command is "pull" — phrase mismatch drops.
-        let pull_terms = vec!["git".to_string(), "pull".to_string(), "origin".to_string(), "main".to_string()];
+        let pull_terms = vec![
+            "git".to_string(),
+            "pull".to_string(),
+            "origin".to_string(),
+            "main".to_string(),
+        ];
         let pull_phrases = vec!["git pull".to_string()];
-        assert!(relevance_score("git push to main without a PR", &pull_terms, &pull_phrases).is_none());
-        assert!(relevance_score("git commit with signed commits", &pull_terms, &pull_phrases).is_none());
+        assert!(
+            relevance_score("git push to main without a PR", &pull_terms, &pull_phrases).is_none()
+        );
+        assert!(
+            relevance_score("git commit with signed commits", &pull_terms, &pull_phrases).is_none()
+        );
 
         // Rule says "install" but command is "uninstall" — phrase mismatch.
-        let terms = vec!["npm".to_string(), "uninstall".to_string(), "package".to_string()];
+        let terms = vec![
+            "npm".to_string(),
+            "uninstall".to_string(),
+            "package".to_string(),
+        ];
         let phrases = vec!["npm uninstall".to_string()];
         assert!(relevance_score("npm install with --save-exact", &terms, &phrases).is_none());
     }
@@ -961,7 +1032,10 @@ mod tests {
         let phrases = vec!["cargo test".to_string()];
         let score = relevance_score("run cargo test before pushing", &terms, &phrases)
             .expect("test verb matches");
-        assert!(score >= 2, "exact verb match should score high — got {score}");
+        assert!(
+            score >= 2,
+            "exact verb match should score high — got {score}"
+        );
     }
 
     #[test]
@@ -972,13 +1046,20 @@ mod tests {
         let terms = vec!["git".to_string(), "push".to_string(), "main".to_string()];
         let score = relevance_score("always use feature branches for main", &terms, &[])
             .expect("no command verb in rule → no mismatch path");
-        assert!(score >= 1, "should match 'main' without penalty — got {score}");
+        assert!(
+            score >= 1,
+            "should match 'main' without penalty — got {score}"
+        );
     }
 
     #[test]
     fn test_relevance_zero_overlap() {
         // No terms match at all AND no command verbs in rule → Some(0)
-        let terms = vec!["docker".to_string(), "compose".to_string(), "up".to_string()];
+        let terms = vec![
+            "docker".to_string(),
+            "compose".to_string(),
+            "up".to_string(),
+        ];
         let score = relevance_score("hand-write migration files", &terms, &[])
             .expect("no command verb in rule → keep, score 0");
         assert_eq!(score, 0, "no overlap should score 0 — got {score}");
@@ -1034,7 +1115,10 @@ mod tests {
         );
         // Multiple phrases in one rule are deduplicated and sorted.
         let phrases = extract_rule_phrases("prefer cargo test over cargo run");
-        assert_eq!(phrases, vec!["cargo run".to_string(), "cargo test".to_string()]);
+        assert_eq!(
+            phrases,
+            vec!["cargo run".to_string(), "cargo test".to_string()]
+        );
     }
 
     #[test]
@@ -1086,8 +1170,14 @@ mod tests {
         // each can contribute its own phrase.
         let input = serde_json::json!({"command": "git status && docker run -it ubuntu"});
         let phrases = extract_command_phrases("Bash", &input);
-        assert!(phrases.contains(&"git status".to_string()), "got {phrases:?}");
-        assert!(phrases.contains(&"docker run".to_string()), "got {phrases:?}");
+        assert!(
+            phrases.contains(&"git status".to_string()),
+            "got {phrases:?}"
+        );
+        assert!(
+            phrases.contains(&"docker run".to_string()),
+            "got {phrases:?}"
+        );
     }
 
     #[test]
@@ -1120,7 +1210,10 @@ mod tests {
             &["npm".to_string(), "test".to_string()],
             &["npm test".to_string()],
         );
-        assert!(result.is_none(), "npm install rule must drop on npm test — got {result:?}");
+        assert!(
+            result.is_none(),
+            "npm install rule must drop on npm test — got {result:?}"
+        );
 
         // cargo test rule vs cargo build command
         let result = relevance_score(
@@ -1128,7 +1221,10 @@ mod tests {
             &["cargo".to_string(), "build".to_string()],
             &["cargo build".to_string()],
         );
-        assert!(result.is_none(), "cargo test rule must drop on cargo build — got {result:?}");
+        assert!(
+            result.is_none(),
+            "cargo test rule must drop on cargo build — got {result:?}"
+        );
 
         // Same rules survive against the matching command.
         assert!(
@@ -1172,12 +1268,18 @@ mod tests {
         // Single-token subject only matches an exact token in the command terms,
         // never a substring or hyphen-fragment.
         let subj = "git";
-        assert!(subject_matches_terms(subj, &["git".to_string(), "status".to_string()]));
+        assert!(subject_matches_terms(
+            subj,
+            &["git".to_string(), "status".to_string()]
+        ));
         // The actual term "git-level" was produced by `gh issue create --title
         // "...git-level..."` in issue #86; subject "git" must NOT match it.
         assert!(!subject_matches_terms(subj, &["git-level".to_string()]));
         // A rule subject "github" must not match a `git ...` command via substring.
-        assert!(!subject_matches_terms("github", &["git".to_string(), "status".to_string()]));
+        assert!(!subject_matches_terms(
+            "github",
+            &["git".to_string(), "status".to_string()]
+        ));
         // Multi-word subject — any constituent word can match.
         assert!(subject_matches_terms("force-push", &["force".to_string()]));
         assert!(subject_matches_terms("git push", &["push".to_string()]));
@@ -1187,7 +1289,10 @@ mod tests {
     fn test_relevance_percentage() {
         // High overlap: 3 of 4 terms match → high percentage
         let pct = relevance_percentage(3, 4, 0.92);
-        assert!(pct >= 70, "3/4 overlap + 0.92 confidence should be >= 70% — got {pct}%");
+        assert!(
+            pct >= 70,
+            "3/4 overlap + 0.92 confidence should be >= 70% — got {pct}%"
+        );
 
         // Low overlap: 1 of 4 terms match → lower percentage
         let pct = relevance_percentage(1, 4, 0.92);
@@ -1195,12 +1300,18 @@ mod tests {
 
         // Zero terms → falls back to base confidence
         let pct = relevance_percentage(0, 0, 0.90);
-        assert_eq!(pct, 90, "zero terms should use base confidence — got {pct}%");
+        assert_eq!(
+            pct, 90,
+            "zero terms should use base confidence — got {pct}%"
+        );
 
         // High overlap should always beat low overlap at same confidence
         let high = relevance_percentage(3, 4, 0.90);
         let low = relevance_percentage(1, 4, 0.90);
-        assert!(high > low, "high overlap ({high}%) should beat low overlap ({low}%)");
+        assert!(
+            high > low,
+            "high overlap ({high}%) should beat low overlap ({low}%)"
+        );
     }
 
     #[test]
@@ -1250,25 +1361,45 @@ mod tests {
         let guardrails = store.load_guardrails().unwrap();
 
         // "git push origin main" should ONLY fire the push rule
-        let terms = vec!["git".to_string(), "push".to_string(), "origin".to_string(), "main".to_string()];
+        let terms = vec![
+            "git".to_string(),
+            "push".to_string(),
+            "origin".to_string(),
+            "main".to_string(),
+        ];
         let phrases = vec!["git push".to_string()];
         let matched = match_guardrails(&guardrails, &terms, &phrases, "Bash", "PreToolUse");
         assert_eq!(matched.len(), 1, "only the relevant rule should fire");
-        assert!(matched[0].0.object.contains("push"), "push rule should fire, got: {}", matched[0].0.object);
+        assert!(
+            matched[0].0.object.contains("push"),
+            "push rule should fire, got: {}",
+            matched[0].0.object
+        );
 
         // "git commit -m test" should ONLY fire the commit rule
         let terms = vec!["git".to_string(), "commit".to_string(), "test".to_string()];
         let phrases = vec!["git commit".to_string()];
         let matched = match_guardrails(&guardrails, &terms, &phrases, "Bash", "PreToolUse");
         assert_eq!(matched.len(), 1, "only the relevant rule should fire");
-        assert!(matched[0].0.object.contains("commit"), "commit rule should fire, got: {}", matched[0].0.object);
+        assert!(
+            matched[0].0.object.contains("commit"),
+            "commit rule should fire, got: {}",
+            matched[0].0.object
+        );
 
         // "git pull origin main" — both rules should be suppressed (pull ≠ push, pull ≠ commit)
-        let terms = vec!["git".to_string(), "pull".to_string(), "origin".to_string(), "main".to_string()];
+        let terms = vec![
+            "git".to_string(),
+            "pull".to_string(),
+            "origin".to_string(),
+            "main".to_string(),
+        ];
         let phrases = vec!["git pull".to_string()];
         let matched = match_guardrails(&guardrails, &terms, &phrases, "Bash", "PreToolUse");
-        assert!(matched.is_empty(),
-            "neither push nor commit rule should fire for pull command — got {matched:?}");
+        assert!(
+            matched.is_empty(),
+            "neither push nor commit rule should fire for pull command — got {matched:?}"
+        );
 
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -1296,9 +1427,18 @@ mod tests {
         let seen: std::collections::HashSet<i64> = std::collections::HashSet::new();
         let ctx = format_context(&matched, &seen);
         // Full form carries the source trace.
-        assert!(ctx.contains("CLAUDE.md:42"), "full form should cite source: {ctx:?}");
-        assert!(ctx.contains("layer-1"), "full form should cite layer: {ctx:?}");
-        assert!(!ctx.contains("still:"), "first injection should NOT use compact prefix");
+        assert!(
+            ctx.contains("CLAUDE.md:42"),
+            "full form should cite source: {ctx:?}"
+        );
+        assert!(
+            ctx.contains("layer-1"),
+            "full form should cite layer: {ctx:?}"
+        );
+        assert!(
+            !ctx.contains("still:"),
+            "first injection should NOT use compact prefix"
+        );
     }
 
     #[test]
@@ -1307,9 +1447,18 @@ mod tests {
         let seen: std::collections::HashSet<i64> = [7i64].iter().copied().collect();
         let ctx = format_context(&matched, &seen);
         // Compact form drops source/layer trace; uses "still:" prefix.
-        assert!(ctx.contains("still:"), "repeat injection should use compact prefix");
-        assert!(!ctx.contains("CLAUDE.md:42"), "compact form should NOT re-cite source");
-        assert!(!ctx.contains("layer-1"), "compact form should NOT re-cite layer");
+        assert!(
+            ctx.contains("still:"),
+            "repeat injection should use compact prefix"
+        );
+        assert!(
+            !ctx.contains("CLAUDE.md:42"),
+            "compact form should NOT re-cite source"
+        );
+        assert!(
+            !ctx.contains("layer-1"),
+            "compact form should NOT re-cite layer"
+        );
         // Compact form is shorter — the whole point.
         let unseen_ctx = format_context(&matched, &std::collections::HashSet::new());
         assert!(
@@ -1325,7 +1474,10 @@ mod tests {
         // Two rules, only one already seen — output should have one full
         // line and one compact line.
         let matched = vec![
-            (mk_guardrail(1, "alembic", "must_not", "hand-write migrations"), 90u8),
+            (
+                mk_guardrail(1, "alembic", "must_not", "hand-write migrations"),
+                90u8,
+            ),
             (mk_guardrail(2, "git", "never", "force-push to main"), 95u8),
         ];
         let seen: std::collections::HashSet<i64> = [1i64].iter().copied().collect();

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -108,11 +108,7 @@ pub struct HookMatch {
 /// caller owns stdout, audit log, and telemetry.  Used by the hook handler
 /// *and* by the `arai test` scenario runner — both paths see the same
 /// matching logic so scenarios stay faithful to production.
-pub fn match_hook(
-    hook: &Value,
-    cfg: &Config,
-    db: &Store,
-) -> Result<HookMatch, String> {
+pub fn match_hook(hook: &Value, cfg: &Config, db: &Store) -> Result<HookMatch, String> {
     let event = hook
         .get("hook_event_name")
         .and_then(|v| v.as_str())
@@ -291,16 +287,13 @@ fn handle_stdin_impl(event_hint: &mut String) -> Result<(), String> {
             "Hook input exceeded {MAX_HOOK_INPUT_BYTES}-byte cap"
         ));
     }
-    let input = String::from_utf8(buf)
-        .map_err(|e| format!("Hook input was not valid UTF-8: {e}"))?;
+    let input =
+        String::from_utf8(buf).map_err(|e| format!("Hook input was not valid UTF-8: {e}"))?;
 
-    let hook: Value = serde_json::from_str(&input)
-        .map_err(|e| format!("Invalid hook JSON: {e}"))?;
+    let hook: Value =
+        serde_json::from_str(&input).map_err(|e| format!("Invalid hook JSON: {e}"))?;
 
-    let tool_name = hook
-        .get("tool_name")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let tool_name = hook.get("tool_name").and_then(|v| v.as_str()).unwrap_or("");
     let event = hook
         .get("hook_event_name")
         .and_then(|v| v.as_str())
@@ -338,9 +331,9 @@ fn handle_stdin_impl(event_hint: &mut String) -> Result<(), String> {
             // correlate "Arai was off but stats has no bypass entry".  The
             // hook still exits 0 — the user explicitly chose `ARAI_DISABLED`
             // so the model must proceed.
-            Err(e) => eprintln!(
-                "arai: ARAI_DISABLED set but could not load config to record bypass: {e}"
-            ),
+            Err(e) => {
+                eprintln!("arai: ARAI_DISABLED set but could not load config to record bypass: {e}")
+            }
         }
         return Ok(());
     }
@@ -393,7 +386,11 @@ fn handle_stdin_impl(event_hint: &mut String) -> Result<(), String> {
         if result.domain_rules.is_empty() {
             return Ok(());
         }
-        let mut subjects: Vec<String> = result.domain_rules.iter().map(|g| g.subject.clone()).collect();
+        let mut subjects: Vec<String> = result
+            .domain_rules
+            .iter()
+            .map(|g| g.subject.clone())
+            .collect();
         subjects.sort();
         subjects.dedup();
         let summary = format!(
@@ -407,7 +404,10 @@ fn handle_stdin_impl(event_hint: &mut String) -> Result<(), String> {
                 "additionalContext": summary
             }
         });
-        println!("{}", serde_json::to_string(&response).map_err(|e| e.to_string())?);
+        println!(
+            "{}",
+            serde_json::to_string(&response).map_err(|e| e.to_string())?
+        );
         return Ok(());
     }
 
@@ -460,11 +460,8 @@ fn handle_stdin_impl(event_hint: &mut String) -> Result<(), String> {
     // and avoids attention dilution from repeat re-reads.  Empty session_id
     // means we can't track, so all matches behave as first-time injections.
     let triple_ids: Vec<i64> = result.matched.iter().map(|(g, _)| g.triple_id).collect();
-    let (unseen, seen) = session::partition_seen_rules(
-        &cfg.arai_base_dir,
-        &result.session_id,
-        &triple_ids,
-    );
+    let (unseen, seen) =
+        session::partition_seen_rules(&cfg.arai_base_dir, &result.session_id, &triple_ids);
     let seen_set: std::collections::HashSet<i64> = seen.iter().copied().collect();
 
     audit::record_firing(
@@ -514,7 +511,10 @@ fn handle_stdin_impl(event_hint: &mut String) -> Result<(), String> {
         }),
     };
 
-    println!("{}", serde_json::to_string(&response).map_err(|e| e.to_string())?);
+    println!(
+        "{}",
+        serde_json::to_string(&response).map_err(|e| e.to_string())?
+    );
     Ok(())
 }
 
@@ -529,7 +529,11 @@ fn deny_reason(matched: &[(Guardrail, u8)]) -> String {
             .map(|i| i.severity)
             .unwrap_or_else(|| Severity::from_predicate(&g.predicate));
         if sev == Severity::Block {
-            let src = if g.file_path.is_empty() { &*g.source_file } else { &*g.file_path };
+            let src = if g.file_path.is_empty() {
+                &*g.source_file
+            } else {
+                &*g.file_path
+            };
             // Append `:N` when we know the line — saves the user a manual
             // search to the rule that just blocked their action.
             let line_suffix = g.line_start.map(|l| format!(":{l}")).unwrap_or_default();
@@ -568,11 +572,12 @@ fn is_arai_self_command(tool_input: &Value) -> bool {
         .unwrap_or(cmd)
         .trim();
     let first_token = first_segment.split_whitespace().next().unwrap_or("");
-    let basename = first_token.rsplit(['/', '\\']).next().unwrap_or(first_token);
+    let basename = first_token
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(first_token);
     // Strip an optional Windows `.exe` so cross-platform invocations match.
-    let stripped = basename
-        .strip_suffix(".exe")
-        .unwrap_or(basename);
+    let stripped = basename.strip_suffix(".exe").unwrap_or(basename);
     stripped.eq_ignore_ascii_case("arai")
 }
 
@@ -615,7 +620,8 @@ mod tests {
 
     fn temp_db() -> (Store, PathBuf) {
         let id = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
-        let dir = std::env::temp_dir().join(format!("arai_hooks_test_{}_{}", std::process::id(), id));
+        let dir =
+            std::env::temp_dir().join(format!("arai_hooks_test_{}_{}", std::process::id(), id));
         std::fs::create_dir_all(&dir).unwrap();
         let db_path = dir.join("test.db");
         let store = Store::open(&db_path).unwrap();
@@ -660,14 +666,20 @@ mod tests {
             );
         }
         std::env::remove_var(DENY_MODE_ENV);
-        assert!(deny_mode_enabled(), "unset ARAI_DENY_MODE should enable deny mode");
+        assert!(
+            deny_mode_enabled(),
+            "unset ARAI_DENY_MODE should enable deny mode"
+        );
     }
 
     #[test]
     fn known_hook_event_accepts_canonical_three() {
         assert_eq!(known_hook_event("PreToolUse"), Some("PreToolUse"));
         assert_eq!(known_hook_event("PostToolUse"), Some("PostToolUse"));
-        assert_eq!(known_hook_event("UserPromptSubmit"), Some("UserPromptSubmit"));
+        assert_eq!(
+            known_hook_event("UserPromptSubmit"),
+            Some("UserPromptSubmit")
+        );
     }
 
     #[test]
@@ -677,7 +689,11 @@ mod tests {
         // Substring / prefix variants — none should slip through.
         assert_eq!(known_hook_event("PreToolUse "), None);
         assert_eq!(known_hook_event(" PreToolUse"), None);
-        assert_eq!(known_hook_event("pretooluse"), None, "case-sensitive on purpose");
+        assert_eq!(
+            known_hook_event("pretooluse"),
+            None,
+            "case-sensitive on purpose"
+        );
         assert_eq!(known_hook_event(""), None);
         assert_eq!(known_hook_event("PreToolUse\nPostToolUse"), None);
         assert_eq!(known_hook_event("../../../etc/passwd"), None);
@@ -709,7 +725,10 @@ mod tests {
         let matched = vec![
             (mk_guardrail(1, "alembic", "prefers", "autogenerate"), 90u8),
             (mk_guardrail(2, "git", "never", "force-push to main"), 100u8),
-            (mk_guardrail(3, "cargo", "always", "test before commit"), 80u8),
+            (
+                mk_guardrail(3, "cargo", "always", "test before commit"),
+                80u8,
+            ),
         ];
         // No rule_intent rows → falls back to predicate-derived severity.
         assert_eq!(highest_severity(&matched), Severity::Block);
@@ -734,7 +753,9 @@ mod tests {
             expires_at: None,
             noenrich: false,
         };
-        store.upsert_file("CLAUDE.md", "x", &[triple], "test").unwrap();
+        store
+            .upsert_file("CLAUDE.md", "x", &[triple], "test")
+            .unwrap();
         let tid = store.load_guardrails().unwrap()[0].triple_id;
 
         let intent = RuleIntent {
@@ -767,11 +788,23 @@ mod tests {
         let (_store, dir) = temp_db();
         let matched = vec![(mk_guardrail(1, "git", "never", "force-push to main"), 100u8)];
         let reason = deny_reason(&matched);
-        assert!(reason.contains("never"), "reason should quote the predicate: {reason:?}");
-        assert!(reason.contains("force-push"), "reason should quote the object: {reason:?}");
-        assert!(reason.contains("CLAUDE.md"), "reason should cite source: {reason:?}");
+        assert!(
+            reason.contains("never"),
+            "reason should quote the predicate: {reason:?}"
+        );
+        assert!(
+            reason.contains("force-push"),
+            "reason should quote the object: {reason:?}"
+        );
+        assert!(
+            reason.contains("CLAUDE.md"),
+            "reason should cite source: {reason:?}"
+        );
         // Line number is included when present — `mk_guardrail` sets line 42.
-        assert!(reason.contains(":42"), "reason should include :line_number: {reason:?}");
+        assert!(
+            reason.contains(":42"),
+            "reason should include :line_number: {reason:?}"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -781,7 +814,10 @@ mod tests {
         g.line_start = None;
         let matched = vec![(g, 100u8)];
         let reason = deny_reason(&matched);
-        assert!(reason.contains("CLAUDE.md"), "still cites source: {reason:?}");
+        assert!(
+            reason.contains("CLAUDE.md"),
+            "still cites source: {reason:?}"
+        );
         // No line:N suffix.  Look specifically for a colon followed by a
         // digit inside the source citation rather than rejecting any colon
         // (the `Arai:` prefix is fine).
@@ -800,8 +836,14 @@ mod tests {
         ];
         let reason = deny_reason(&matched);
         // Should pick the `never` rule, not the `prefers` rule.
-        assert!(reason.contains("force-push"), "picked wrong rule: {reason:?}");
-        assert!(!reason.contains("small commits"), "non-block rule leaked: {reason:?}");
+        assert!(
+            reason.contains("force-push"),
+            "picked wrong rule: {reason:?}"
+        );
+        assert!(
+            !reason.contains("small commits"),
+            "non-block rule leaked: {reason:?}"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -824,7 +866,9 @@ mod tests {
             expires_at: None,
             noenrich: false,
         };
-        store.upsert_file("CLAUDE.md", "x", &[triple], "test").unwrap();
+        store
+            .upsert_file("CLAUDE.md", "x", &[triple], "test")
+            .unwrap();
 
         // Pre-classification: intent should be None on every guardrail.
         let pre = store.load_guardrails().unwrap();
@@ -857,24 +901,44 @@ mod tests {
     #[test]
     fn arai_self_command_recognised_by_first_token() {
         // Bare invocations
-        assert!(is_arai_self_command(&serde_json::json!({ "command": "arai why \"git push\"" })));
-        assert!(is_arai_self_command(&serde_json::json!({ "command": "arai severity \"git push\" block" })));
-        assert!(is_arai_self_command(&serde_json::json!({ "command": "arai status" })));
-        assert!(is_arai_self_command(&serde_json::json!({ "command": "arai" })));
+        assert!(is_arai_self_command(
+            &serde_json::json!({ "command": "arai why \"git push\"" })
+        ));
+        assert!(is_arai_self_command(
+            &serde_json::json!({ "command": "arai severity \"git push\" block" })
+        ));
+        assert!(is_arai_self_command(
+            &serde_json::json!({ "command": "arai status" })
+        ));
+        assert!(is_arai_self_command(
+            &serde_json::json!({ "command": "arai" })
+        ));
 
         // Path-prefixed invocations
-        assert!(is_arai_self_command(&serde_json::json!({ "command": "/usr/local/bin/arai why x" })));
-        assert!(is_arai_self_command(&serde_json::json!({ "command": "./arai add 'Never X'" })));
+        assert!(is_arai_self_command(
+            &serde_json::json!({ "command": "/usr/local/bin/arai why x" })
+        ));
+        assert!(is_arai_self_command(
+            &serde_json::json!({ "command": "./arai add 'Never X'" })
+        ));
         // Windows-style separator + .exe suffix
-        assert!(is_arai_self_command(&serde_json::json!({ "command": "C:\\bin\\arai.exe status" })));
+        assert!(is_arai_self_command(
+            &serde_json::json!({ "command": "C:\\bin\\arai.exe status" })
+        ));
 
         // Negatives
-        assert!(!is_arai_self_command(&serde_json::json!({ "command": "git push --force origin main" })));
-        assert!(!is_arai_self_command(&serde_json::json!({ "command": "echo arai" })));
+        assert!(!is_arai_self_command(
+            &serde_json::json!({ "command": "git push --force origin main" })
+        ));
+        assert!(!is_arai_self_command(
+            &serde_json::json!({ "command": "echo arai" })
+        ));
         // Compose with arai in the middle of a pipeline — only the first
         // segment counts.  `git status && arai why` is still a `git`
         // command from the rule-engine's point of view.
-        assert!(!is_arai_self_command(&serde_json::json!({ "command": "git status && arai why x" })));
+        assert!(!is_arai_self_command(
+            &serde_json::json!({ "command": "git status && arai why x" })
+        ));
         assert!(!is_arai_self_command(&serde_json::json!({ "command": "" })));
         assert!(!is_arai_self_command(&serde_json::json!({})));
     }
@@ -901,7 +965,9 @@ mod tests {
             expires_at: None,
             noenrich: false,
         };
-        store.upsert_file("manual", "x", &[triple], "manual").unwrap();
+        store
+            .upsert_file("manual", "x", &[triple], "manual")
+            .unwrap();
         store.classify_all_guardrails().unwrap();
         let rules = store.load_guardrails().unwrap();
 
@@ -914,7 +980,8 @@ mod tests {
             "main".to_string(),
         ];
         let push_phrases = vec!["git push".to_string()];
-        let matched = guardrails::match_guardrails(&rules, &push_terms, &push_phrases, "Bash", "PreToolUse");
+        let matched =
+            guardrails::match_guardrails(&rules, &push_terms, &push_phrases, "Bash", "PreToolUse");
         assert_eq!(matched.len(), 1, "push rule must fire on the push command");
 
         // Read-only subcommands MUST NOT fire it.
@@ -924,7 +991,8 @@ mod tests {
             (vec!["git".to_string(), "log".to_string()], "git log"),
         ] {
             let phrases = vec![phrase.to_string()];
-            let matched = guardrails::match_guardrails(&rules, &read_only, &phrases, "Bash", "PreToolUse");
+            let matched =
+                guardrails::match_guardrails(&rules, &read_only, &phrases, "Bash", "PreToolUse");
             assert!(
                 matched.is_empty(),
                 "git push rule must not fire on read-only `{read_only:?}` (issue #86)"
@@ -942,7 +1010,8 @@ mod tests {
             "scope".to_string(),
         ];
         let gh_phrases = vec!["gh issue".to_string()];
-        let matched = guardrails::match_guardrails(&rules, &gh_terms, &gh_phrases, "Bash", "PreToolUse");
+        let matched =
+            guardrails::match_guardrails(&rules, &gh_terms, &gh_phrases, "Bash", "PreToolUse");
         assert!(
             matched.is_empty(),
             "git push rule must not fire on a `gh issue create` whose title contains `git-level` (issue #86)"

--- a/src/init.rs
+++ b/src/init.rs
@@ -14,7 +14,11 @@ pub fn run() -> Result<(), String> {
 
     for f in &files {
         let line_count = f.content.lines().count();
-        println!("    \u{2713} {} ({line_count} lines, {})", display_path(&f.path, &cfg), f.source_type);
+        println!(
+            "    \u{2713} {} ({line_count} lines, {})",
+            display_path(&f.path, &cfg),
+            f.source_type
+        );
     }
 
     println!("\n  Extracting guardrails...");
@@ -60,14 +64,20 @@ pub fn run() -> Result<(), String> {
     db.upsert_code_graph(&imports).map_err(|e| e.to_string())?;
     let tool_count = db.code_graph_tool_count().map_err(|e| e.to_string())?;
     let file_count = db.code_graph_file_count().map_err(|e| e.to_string())?;
-    println!("    \u{2713} {import_count} imports from {file_count} files, {tool_count} unique tools");
+    println!(
+        "    \u{2713} {import_count} imports from {file_count} files, {tool_count} unique tools"
+    );
 
     println!("\n  Setting up hooks...");
     inject_hooks(&cfg)?;
     println!("    \u{2713} .claude/settings.json updated");
 
     // Track init event + flush queued telemetry
-    let enrichment = if model_dir.join("model.onnx").exists() { "model" } else { "taxonomy" };
+    let enrichment = if model_dir.join("model.onnx").exists() {
+        "model"
+    } else {
+        "taxonomy"
+    };
     crate::telemetry::track_init(
         &cfg.arai_base_dir,
         total_rules,
@@ -147,8 +157,7 @@ fn inject_hooks(cfg: &config::Config) -> Result<(), String> {
     let mut settings: Value = if settings_path.exists() {
         let content = std::fs::read_to_string(&settings_path)
             .map_err(|e| format!("Failed to read settings.json: {e}"))?;
-        serde_json::from_str(&content)
-            .map_err(|e| format!("Failed to parse settings.json: {e}"))?
+        serde_json::from_str(&content).map_err(|e| format!("Failed to parse settings.json: {e}"))?
     } else {
         serde_json::json!({})
     };
@@ -159,9 +168,7 @@ fn inject_hooks(cfg: &config::Config) -> Result<(), String> {
         .entry("hooks")
         .or_insert_with(|| serde_json::json!({}));
 
-    let hooks_obj = hooks
-        .as_object_mut()
-        .ok_or("hooks is not an object")?;
+    let hooks_obj = hooks.as_object_mut().ok_or("hooks is not an object")?;
 
     // Inject arai hook into relevant hook events
     for event in &["PreToolUse", "PostToolUse", "UserPromptSubmit"] {

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -391,7 +391,11 @@ pub fn classify_rule(predicate: &str, object: &str) -> RuleIntent {
     classify_rule_with_subject(predicate, object, None)
 }
 
-pub fn classify_rule_with_subject(predicate: &str, object: &str, subject: Option<&str>) -> RuleIntent {
+pub fn classify_rule_with_subject(
+    predicate: &str,
+    object: &str,
+    subject: Option<&str>,
+) -> RuleIntent {
     let lower = object.to_lowercase();
     let full_text = if let Some(s) = subject {
         format!("{} {}", s.to_lowercase(), lower)
@@ -488,11 +492,10 @@ fn contains_phrase_bounded(text: &str, phrase: &str) -> bool {
 
     // For single words, check word boundaries
     for (idx, _) in text.match_indices(phrase) {
-        let before_ok = idx == 0
-            || !text.as_bytes()[idx - 1].is_ascii_alphanumeric();
+        let before_ok = idx == 0 || !text.as_bytes()[idx - 1].is_ascii_alphanumeric();
         let after_idx = idx + phrase.len();
-        let after_ok = after_idx >= text.len()
-            || !text.as_bytes()[after_idx].is_ascii_alphanumeric();
+        let after_ok =
+            after_idx >= text.len() || !text.as_bytes()[after_idx].is_ascii_alphanumeric();
         if before_ok && after_ok {
             return true;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,21 +268,50 @@ fn main() {
                 cmd_guardrails(json)
             }
         }
-        Commands::Scan { code, enrich, enrich_llm, enrich_api, enrich_file } => cmd_scan(code, enrich, enrich_llm, enrich_api, enrich_file),
+        Commands::Scan {
+            code,
+            enrich,
+            enrich_llm,
+            enrich_api,
+            enrich_file,
+        } => cmd_scan(code, enrich, enrich_llm, enrich_api, enrich_file),
         Commands::Add { rule } => cmd_add(&rule),
         Commands::Upgrade { full, lean } => upgrade::run(full, lean),
-        Commands::Audit { since, tool, event, outcome, rule, limit, json } => cmd_audit(since, tool, event, outcome, rule, limit, json),
+        Commands::Audit {
+            since,
+            tool,
+            event,
+            outcome,
+            rule,
+            limit,
+            json,
+        } => cmd_audit(since, tool, event, outcome, rule, limit, json),
         Commands::Mcp => mcp::run(),
         Commands::Lint { file, json } => cmd_lint(&file, json),
         Commands::Trust { add, remove } => cmd_trust(add, remove),
         Commands::Test { file, json } => scenarios::run(std::path::Path::new(&file), json),
         Commands::Record { since, tool, limit } => cmd_record(since, tool, limit),
-        Commands::Stats { since, top, by_rule, json } => cmd_stats(since, top, by_rule, json),
-        Commands::Severity { pattern, level, reset, json } => cmd_severity(pattern, level, reset, json),
+        Commands::Stats {
+            since,
+            top,
+            by_rule,
+            json,
+        } => cmd_stats(since, top, by_rule, json),
+        Commands::Severity {
+            pattern,
+            level,
+            reset,
+            json,
+        } => cmd_severity(pattern, level, reset, json),
         Commands::Diff { file, json } => cmd_diff(&file, json),
         Commands::Disable { triple_id } => cmd_disable(triple_id),
         Commands::Enable { triple_id } => cmd_enable(triple_id),
-        Commands::Why { input, tool, event, json } => cmd_why(input, tool, event, json),
+        Commands::Why {
+            input,
+            tool,
+            event,
+            json,
+        } => cmd_why(input, tool, event, json),
     };
 
     if let Err(e) = result {
@@ -324,10 +353,7 @@ fn cmd_status() -> Result<(), String> {
         if !issues.duplicates.is_empty() {
             println!("  Duplicate rules ({}):", issues.duplicates.len());
             for d in issues.duplicates.iter().take(10) {
-                println!(
-                    "    - {} {}: {}",
-                    d.subject, d.predicate, d.object,
-                );
+                println!("    - {} {}: {}", d.subject, d.predicate, d.object,);
                 for src in &d.sources {
                     println!("        from {src}");
                 }
@@ -373,7 +399,13 @@ fn cmd_guardrails(json: bool) -> Result<(), String> {
     Ok(())
 }
 
-fn cmd_scan(code: bool, do_enrich: bool, enrich_llm: bool, enrich_api: bool, enrich_file: Option<String>) -> Result<(), String> {
+fn cmd_scan(
+    code: bool,
+    do_enrich: bool,
+    enrich_llm: bool,
+    enrich_api: bool,
+    enrich_file: Option<String>,
+) -> Result<(), String> {
     let cfg = config::Config::load()?;
     let files = discovery::discover(&cfg)?;
     let db = store::Store::open(&cfg.db_path())?;
@@ -391,7 +423,8 @@ fn cmd_scan(code: bool, do_enrich: bool, enrich_llm: bool, enrich_api: bool, enr
     }
 
     db.classify_all_guardrails().map_err(|e| e.to_string())?;
-    db.set_meta("last_scan", &chrono_now()).map_err(|e| e.to_string())?;
+    db.set_meta("last_scan", &chrono_now())
+        .map_err(|e| e.to_string())?;
     println!("\n  {total_rules} rule(s) from {} file(s)", files.len());
 
     if code {
@@ -444,7 +477,9 @@ fn scan_code_graph(cfg: &config::Config, db: &store::Store) -> Result<(), String
 
     let tool_count = db.code_graph_tool_count().map_err(|e| e.to_string())?;
     let file_count = db.code_graph_file_count().map_err(|e| e.to_string())?;
-    println!("    \u{2713} {import_count} imports from {file_count} files, {tool_count} unique tools");
+    println!(
+        "    \u{2713} {import_count} imports from {file_count} files, {tool_count} unique tools"
+    );
     Ok(())
 }
 
@@ -452,11 +487,7 @@ fn cmd_add(rule: &str) -> Result<(), String> {
     let cfg = config::Config::load()?;
     let db = store::Store::open(&cfg.db_path())?;
 
-    let triples = parser::extract_rules(
-        &format!("- {rule}"),
-        "manual",
-        0.95,
-    );
+    let triples = parser::extract_rules(&format!("- {rule}"), "manual", 0.95);
 
     if triples.is_empty() {
         return Err(format!(
@@ -470,7 +501,11 @@ fn cmd_add(rule: &str) -> Result<(), String> {
         let mut h = Sha256::new();
         h.update(rule.as_bytes());
         let hash_bytes = h.finalize();
-        let short: String = hash_bytes.iter().take(4).map(|b| format!("{b:02x}")).collect();
+        let short: String = hash_bytes
+            .iter()
+            .take(4)
+            .map(|b| format!("{b:02x}"))
+            .collect();
         format!("manual://arai-add/{short}")
     };
     db.upsert_file(&manual_path, rule, &triples, "manual")
@@ -526,7 +561,11 @@ fn cmd_audit(
         since_epoch,
         tool.as_deref(),
         effective_event.as_deref(),
-        if needs_post_filter { limit.saturating_mul(4) } else { limit },
+        if needs_post_filter {
+            limit.saturating_mul(4)
+        } else {
+            limit
+        },
     )?;
 
     // Apply outcome filter in-process: an entry passes if any item in
@@ -538,7 +577,10 @@ fn cmd_audit(
                 e.get("payload")
                     .and_then(|p| p.get("rules"))
                     .and_then(|r| r.as_array())
-                    .map(|rs| rs.iter().any(|r| r.get("outcome").and_then(|o| o.as_str()) == Some(target)))
+                    .map(|rs| {
+                        rs.iter()
+                            .any(|r| r.get("outcome").and_then(|o| o.as_str()) == Some(target))
+                    })
                     .unwrap_or(false)
             })
             .collect()
@@ -579,41 +621,56 @@ fn cmd_audit(
     }
 
     // Table view: one line per firing, rule names condensed.
-    println!("{:<20} {:<13} {:<8} {:<7} summary", "time", "event", "tool", "rules");
+    println!(
+        "{:<20} {:<13} {:<8} {:<7} summary",
+        "time", "event", "tool", "rules"
+    );
     println!("{}", "─".repeat(80));
     for e in &entries {
         let ts = e.get("ts").and_then(|v| v.as_str()).unwrap_or("");
         let ev = e.get("event").and_then(|v| v.as_str()).unwrap_or("");
         let tool = e.get("tool").and_then(|v| v.as_str()).unwrap_or("");
-        let rule_count = e.get("rules").and_then(|v| v.as_array()).map(|a| a.len()).unwrap_or(0);
-        let preview = e.get("prompt_preview").and_then(|v| v.as_str()).unwrap_or("");
+        let rule_count = e
+            .get("rules")
+            .and_then(|v| v.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0);
+        let preview = e
+            .get("prompt_preview")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
         let preview_short: String = preview.chars().take(50).collect();
-        println!("{:<20} {:<13} {:<8} {:<7} {}", ts, ev, tool, rule_count, preview_short);
+        println!(
+            "{:<20} {:<13} {:<8} {:<7} {}",
+            ts, ev, tool, rule_count, preview_short
+        );
     }
-    println!("\n  {} firing(s) shown.  Log at {}/audit/{}/", entries.len(), cfg.arai_base_dir.display(), cfg.project_slug());
+    println!(
+        "\n  {} firing(s) shown.  Log at {}/audit/{}/",
+        entries.len(),
+        cfg.arai_base_dir.display(),
+        cfg.project_slug()
+    );
     Ok(())
 }
 
-fn cmd_record(
-    since: Option<String>,
-    tool: Option<String>,
-    limit: usize,
-) -> Result<(), String> {
+fn cmd_record(since: Option<String>, tool: Option<String>, limit: usize) -> Result<(), String> {
     let cfg = config::Config::load()?;
     let since_epoch = since.as_deref().map(parse_since).transpose()?;
     scenarios::record(&cfg, since_epoch, tool, limit)
 }
 
 fn cmd_lint(path: &str, json: bool) -> Result<(), String> {
-    let content = std::fs::read_to_string(path)
-        .map_err(|e| format!("Failed to read {path}: {e}"))?;
+    let content =
+        std::fs::read_to_string(path).map_err(|e| format!("Failed to read {path}: {e}"))?;
     let triples = parser::extract_rules(&content, "lint", 0.90);
 
     if json {
         let out: Vec<serde_json::Value> = triples
             .iter()
             .map(|t| {
-                let intent = intent::classify_rule_with_subject(&t.predicate, &t.object, Some(&t.subject));
+                let intent =
+                    intent::classify_rule_with_subject(&t.predicate, &t.object, Some(&t.subject));
                 serde_json::json!({
                     "subject": t.subject,
                     "predicate": t.predicate,
@@ -626,7 +683,10 @@ fn cmd_lint(path: &str, json: bool) -> Result<(), String> {
                 })
             })
             .collect();
-        println!("{}", serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?
+        );
         return Ok(());
     }
 
@@ -641,10 +701,7 @@ fn cmd_lint(path: &str, json: bool) -> Result<(), String> {
     for t in &triples {
         let intent = intent::classify_rule_with_subject(&t.predicate, &t.object, Some(&t.subject));
         let timing = format!("{:?}", intent.timing);
-        let line_info = t
-            .line_start
-            .map(|l| format!(" L{l}"))
-            .unwrap_or_default();
+        let line_info = t.line_start.map(|l| format!(" L{l}")).unwrap_or_default();
         println!(
             "  [{:<7}] {}{}\n    subject:   {}\n    predicate: {}\n    object:    {}\n    action:    {}  timing: {}  tools: {}\n",
             intent.action.as_str(),
@@ -702,12 +759,7 @@ fn cmd_trust(add: Option<String>, remove: Option<String>) -> Result<(), String> 
     Ok(())
 }
 
-fn cmd_stats(
-    since: Option<String>,
-    top: usize,
-    by_rule: bool,
-    json: bool,
-) -> Result<(), String> {
+fn cmd_stats(since: Option<String>, top: usize, by_rule: bool, json: bool) -> Result<(), String> {
     let cfg = config::Config::load()?;
     let since_epoch = since.as_deref().map(parse_since).transpose()?;
     stats::run(&cfg, since_epoch, top, by_rule, json)
@@ -762,7 +814,10 @@ fn cmd_severity(
     if pattern.is_none() && level.is_none() && !reset {
         let overrides = db.list_severity_overrides().map_err(|e| e.to_string())?;
         if json {
-            println!("{}", serde_json::to_string_pretty(&overrides).map_err(|e| e.to_string())?);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&overrides).map_err(|e| e.to_string())?
+            );
             return Ok(());
         }
         if overrides.is_empty() {
@@ -793,9 +848,14 @@ fn cmd_severity(
     }
 
     if reset {
-        let cleared = db.clear_severity_override(&pattern).map_err(|e| e.to_string())?;
+        let cleared = db
+            .clear_severity_override(&pattern)
+            .map_err(|e| e.to_string())?;
         if json {
-            println!("{}", serde_json::to_string_pretty(&cleared).map_err(|e| e.to_string())?);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&cleared).map_err(|e| e.to_string())?
+            );
             return Ok(());
         }
         if cleared.is_empty() {
@@ -823,7 +883,11 @@ fn cmd_severity(
         "block" => intent::Severity::Block,
         "warn" => intent::Severity::Warn,
         "inform" => intent::Severity::Inform,
-        other => return Err(format!("invalid severity `{other}` (expected block/warn/inform)")),
+        other => {
+            return Err(format!(
+                "invalid severity `{other}` (expected block/warn/inform)"
+            ))
+        }
     };
 
     let changed = db
@@ -831,14 +895,21 @@ fn cmd_severity(
         .map_err(|e| e.to_string())?;
 
     if json {
-        println!("{}", serde_json::to_string_pretty(&changed).map_err(|e| e.to_string())?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&changed).map_err(|e| e.to_string())?
+        );
         return Ok(());
     }
     if changed.is_empty() {
         println!("No rules matched `{pattern}`.  Run `arai guardrails` to see active rules.");
         return Ok(());
     }
-    println!("Pinned severity \u{2192} {} on {} rule(s):", severity.as_str(), changed.len());
+    println!(
+        "Pinned severity \u{2192} {} on {} rule(s):",
+        severity.as_str(),
+        changed.len()
+    );
     for c in &changed {
         println!(
             "  [{:>6} \u{2192} {:<6}] {} {}: {}",
@@ -863,8 +934,8 @@ fn cmd_diff(path: &str, json: bool) -> Result<(), String> {
     }
     let db = store::Store::open(&db_path)?;
 
-    let content = std::fs::read_to_string(path)
-        .map_err(|e| format!("Failed to read {path}: {e}"))?;
+    let content =
+        std::fs::read_to_string(path).map_err(|e| format!("Failed to read {path}: {e}"))?;
 
     // Extract from the candidate content.  Use the same "lint" source-type
     // tag the lint command does so domain bookkeeping stays consistent.
@@ -921,32 +992,38 @@ fn cmd_diff(path: &str, json: bool) -> Result<(), String> {
     if json {
         let added_json: Vec<serde_json::Value> = added
             .iter()
-            .map(|t| serde_json::json!({
-                "subject": t.subject,
-                "predicate": t.predicate,
-                "object": t.object,
-                "line": t.line_start,
-                "layer": t.layer,
-            }))
+            .map(|t| {
+                serde_json::json!({
+                    "subject": t.subject,
+                    "predicate": t.predicate,
+                    "object": t.object,
+                    "line": t.line_start,
+                    "layer": t.layer,
+                })
+            })
             .collect();
         let removed_json: Vec<serde_json::Value> = removed
             .iter()
-            .map(|g| serde_json::json!({
-                "subject": g.subject,
-                "predicate": g.predicate,
-                "object": g.object,
-                "line": g.line_start,
-            }))
+            .map(|g| {
+                serde_json::json!({
+                    "subject": g.subject,
+                    "predicate": g.predicate,
+                    "object": g.object,
+                    "line": g.line_start,
+                })
+            })
             .collect();
         let moved_json: Vec<serde_json::Value> = moved
             .iter()
-            .map(|(g, t)| serde_json::json!({
-                "subject": g.subject,
-                "predicate": g.predicate,
-                "object": g.object,
-                "from_line": g.line_start,
-                "to_line": t.line_start,
-            }))
+            .map(|(g, t)| {
+                serde_json::json!({
+                    "subject": g.subject,
+                    "predicate": g.predicate,
+                    "object": g.object,
+                    "from_line": g.line_start,
+                    "to_line": t.line_start,
+                })
+            })
             .collect();
         let out = serde_json::json!({
             "file": path,
@@ -959,13 +1036,18 @@ fn cmd_diff(path: &str, json: bool) -> Result<(), String> {
                 "moved": moved.len(),
             },
         });
-        println!("{}", serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?
+        );
         return Ok(());
     }
 
     if added.is_empty() && removed.is_empty() && moved.is_empty() {
         println!("Diff: {path}");
-        println!("  No rule changes — file content differs only outside rule lines (or not at all).");
+        println!(
+            "  No rule changes — file content differs only outside rule lines (or not at all)."
+        );
         return Ok(());
     }
 
@@ -1066,18 +1148,11 @@ fn cmd_enable(triple_id: i64) -> Result<(), String> {
 
 /// Explain which guardrails would fire on a hypothetical tool call — same
 /// matching pipeline the live hook uses, but read-only and no audit write.
-fn cmd_why(
-    input: Vec<String>,
-    tool: String,
-    event: String,
-    json: bool,
-) -> Result<(), String> {
+fn cmd_why(input: Vec<String>, tool: String, event: String, json: bool) -> Result<(), String> {
     let cfg = config::Config::load()?;
     let db_path = cfg.db_path();
     if !db_path.exists() {
-        return Err(
-            "No guardrail database found.  Run `arai init` first.".to_string(),
-        );
+        return Err("No guardrail database found.  Run `arai init` first.".to_string());
     }
     let db = store::Store::open(&db_path)?;
 
@@ -1108,7 +1183,11 @@ fn cmd_why(
                 let severity = intent
                     .as_ref()
                     .map(|i| i.severity.as_str().to_string())
-                    .unwrap_or_else(|| intent::Severity::from_predicate(&g.predicate).as_str().to_string());
+                    .unwrap_or_else(|| {
+                        intent::Severity::from_predicate(&g.predicate)
+                            .as_str()
+                            .to_string()
+                    });
                 serde_json::json!({
                     "triple_id": g.triple_id,
                     "subject": g.subject,
@@ -1129,7 +1208,10 @@ fn cmd_why(
             "terms": result.terms,
             "matched": entries,
         });
-        println!("{}", serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?
+        );
         return Ok(());
     }
 
@@ -1164,10 +1246,7 @@ fn cmd_why(
         } else {
             &g.file_path
         };
-        let line_suffix = g
-            .line_start
-            .map(|l| format!(":{l}"))
-            .unwrap_or_default();
+        let line_suffix = g.line_start.map(|l| format!(":{l}")).unwrap_or_default();
         let layer_suffix = g
             .layer
             .map(|l| format!("  [{}]", audit::layer_label(l)))
@@ -1277,4 +1356,3 @@ mod tests {
         assert!(!rule_matches_pattern(&r, "git"));
     }
 }
-

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -83,7 +83,11 @@ pub fn run() -> Result<(), String> {
                 let _ = other;
                 None
             }
-            other => Some(error_response(id, -32601, &format!("Method not found: {other}"))),
+            other => Some(error_response(
+                id,
+                -32601,
+                &format!("Method not found: {other}"),
+            )),
         };
 
         if let Some(r) = resp {
@@ -447,7 +451,10 @@ fn tool_check_action(args: &Value) -> Result<Value, String> {
 /// see what Arai has just denied / injected / reviewed.  Pure read — no
 /// audit write, no telemetry.
 fn tool_recent_decisions(args: &Value) -> Result<Value, String> {
-    let session_id = args.get("session_id").and_then(|v| v.as_str()).unwrap_or("");
+    let session_id = args
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
     let limit = args
         .get("limit")
         .and_then(|v| v.as_u64())
@@ -508,7 +515,10 @@ fn tool_recent_decisions(args: &Value) -> Result<Value, String> {
         let ts = entry.get("ts").and_then(|v| v.as_str()).unwrap_or("?");
         let event = entry.get("event").and_then(|v| v.as_str()).unwrap_or("?");
         let tool = entry.get("tool").and_then(|v| v.as_str()).unwrap_or("?");
-        let decision = entry.get("decision").and_then(|v| v.as_str()).unwrap_or("?");
+        let decision = entry
+            .get("decision")
+            .and_then(|v| v.as_str())
+            .unwrap_or("?");
         let preview = entry
             .get("prompt_preview")
             .and_then(|v| v.as_str())
@@ -636,8 +646,8 @@ mod tests {
 
     #[test]
     fn check_action_rejects_non_object_tool_input() {
-        let err = tool_check_action(&json!({"tool": "Bash", "tool_input": "not an obj"}))
-            .unwrap_err();
+        let err =
+            tool_check_action(&json!({"tool": "Bash", "tool_input": "not an obj"})).unwrap_err();
         assert!(err.contains("must be an object"), "got: {err}");
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -44,15 +44,75 @@ fn is_false(b: &bool) -> bool {
 
 /// Known tool names for subject extraction, "use X" two-signal gate, and content sniffing.
 pub const KNOWN_TOOLS: &[&str] = &[
-    "alembic", "cargo", "npm", "yarn", "pnpm", "pip", "uv", "poetry",
-    "docker", "git", "gh", "pytest", "jest", "vitest", "mocha", "rspec",
-    "go", "rustc", "gcc", "make", "cmake", "webpack", "vite", "eslint",
-    "prettier", "black", "ruff", "mypy", "pyright", "tsc", "terraform",
-    "ansible", "kubectl", "helm", "gradle", "maven", "sbt", "mix",
-    "bundle", "composer", "apt", "brew", "dnf", "yum", "pacman", "snap",
-    "flatpak", "nix", "tmux", "sed", "awk", "grep", "curl", "wget",
-    "ruby", "python", "node", "deno", "bun", "java", "dotnet", "swift",
-    "clang", "bazel", "nx", "turbo", "pnpm", "pipenv", "conda",
+    "alembic",
+    "cargo",
+    "npm",
+    "yarn",
+    "pnpm",
+    "pip",
+    "uv",
+    "poetry",
+    "docker",
+    "git",
+    "gh",
+    "pytest",
+    "jest",
+    "vitest",
+    "mocha",
+    "rspec",
+    "go",
+    "rustc",
+    "gcc",
+    "make",
+    "cmake",
+    "webpack",
+    "vite",
+    "eslint",
+    "prettier",
+    "black",
+    "ruff",
+    "mypy",
+    "pyright",
+    "tsc",
+    "terraform",
+    "ansible",
+    "kubectl",
+    "helm",
+    "gradle",
+    "maven",
+    "sbt",
+    "mix",
+    "bundle",
+    "composer",
+    "apt",
+    "brew",
+    "dnf",
+    "yum",
+    "pacman",
+    "snap",
+    "flatpak",
+    "nix",
+    "tmux",
+    "sed",
+    "awk",
+    "grep",
+    "curl",
+    "wget",
+    "ruby",
+    "python",
+    "node",
+    "deno",
+    "bun",
+    "java",
+    "dotnet",
+    "swift",
+    "clang",
+    "bazel",
+    "nx",
+    "turbo",
+    "pnpm",
+    "pipenv",
+    "conda",
 ];
 
 /// Extract guardrail rules from markdown content.
@@ -92,8 +152,7 @@ pub fn extract_rules(content: &str, source_type: &str, base_confidence: f64) -> 
 pub fn extract_expiry(object: &str) -> (String, Option<String>) {
     static EXPIRY_RE: OnceLock<Regex> = OnceLock::new();
     let re = EXPIRY_RE.get_or_init(|| {
-        Regex::new(r"(?i)\s*\((?:expires?|until)\s+(\d{4}-\d{2}-\d{2})\)\s*$")
-            .expect("valid regex")
+        Regex::new(r"(?i)\s*\((?:expires?|until)\s+(\d{4}-\d{2}-\d{2})\)\s*$").expect("valid regex")
     });
     if let Some(caps) = re.captures(object) {
         let date = caps.get(1).map(|m| m.as_str().to_string());
@@ -110,9 +169,8 @@ pub fn extract_expiry(object: &str) -> (String, Option<String>) {
 /// without disabling the feature globally.
 pub fn extract_noenrich(object: &str) -> (String, bool) {
     static NOENRICH_RE: OnceLock<Regex> = OnceLock::new();
-    let re = NOENRICH_RE.get_or_init(|| {
-        Regex::new(r"(?i)\s*\(noenrich\)\s*$").expect("valid regex")
-    });
+    let re =
+        NOENRICH_RE.get_or_init(|| Regex::new(r"(?i)\s*\(noenrich\)\s*$").expect("valid regex"));
     if re.is_match(object) {
         let cleaned = re.replace(object, "").trim().to_string();
         (cleaned, true)
@@ -215,8 +273,17 @@ fn extract_list_items(body: &str) -> Vec<ListItem> {
             let header = trimmed.trim_start_matches('#').trim().to_string();
             // Strip leading numbered prefix like "4. " and trailing formatting like " (§3)"
             let header = strip_list_prefix(&header);
-            let header = header.split('(').next().unwrap_or(&header).trim().to_string();
-            current_section = if header.is_empty() { None } else { Some(header) };
+            let header = header
+                .split('(')
+                .next()
+                .unwrap_or(&header)
+                .trim()
+                .to_string();
+            current_section = if header.is_empty() {
+                None
+            } else {
+                Some(header)
+            };
             // Flush any pending item — emit only if we're not inside an
             // active skip after this heading-level adjustment.
             if let Some((text, start)) = current_item.take() {
@@ -316,24 +383,18 @@ fn extract_list_items(body: &str) -> Vec<ListItem> {
 /// and whitespace-tolerant: `<!--arai:skip-->`, `<!-- ARAI:SKIP -->`, etc.
 fn line_contains_skip_marker(line: &str) -> bool {
     static MARKER: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
-    let re = MARKER.get_or_init(|| {
-        Regex::new(r"(?i)<!--\s*arai\s*:\s*skip\s*-->").expect("valid regex")
-    });
+    let re = MARKER
+        .get_or_init(|| Regex::new(r"(?i)<!--\s*arai\s*:\s*skip\s*-->").expect("valid regex"));
     re.is_match(line)
 }
 
 fn is_list_start(trimmed: &str) -> bool {
-    if trimmed.starts_with("- ")
-        || trimmed.starts_with("* ")
-        || trimmed.starts_with("+ ")
-    {
+    if trimmed.starts_with("- ") || trimmed.starts_with("* ") || trimmed.starts_with("+ ") {
         return true;
     }
     // Numbered list: "1. ", "2. ", etc.
     static NUMBERED_LIST_RE: OnceLock<Regex> = OnceLock::new();
-    let re = NUMBERED_LIST_RE.get_or_init(|| {
-        Regex::new(r"^\d+\.\s").expect("valid regex")
-    });
+    let re = NUMBERED_LIST_RE.get_or_init(|| Regex::new(r"^\d+\.\s").expect("valid regex"));
     re.is_match(trimmed)
 }
 
@@ -342,9 +403,7 @@ fn strip_list_prefix(trimmed: &str) -> String {
         return trimmed[2..].to_string();
     }
     static NUMBERED_PREFIX_RE: OnceLock<Regex> = OnceLock::new();
-    let re = NUMBERED_PREFIX_RE.get_or_init(|| {
-        Regex::new(r"^\d+\.\s+").expect("valid regex")
-    });
+    let re = NUMBERED_PREFIX_RE.get_or_init(|| Regex::new(r"^\d+\.\s+").expect("valid regex"));
     re.replace(trimmed, "").to_string()
 }
 
@@ -353,15 +412,10 @@ fn strip_markdown(text: &str) -> String {
     static BOLD_RE: OnceLock<Regex> = OnceLock::new();
     static CODE_RE: OnceLock<Regex> = OnceLock::new();
     static LINK_RE: OnceLock<Regex> = OnceLock::new();
-    let re_bold = BOLD_RE.get_or_init(|| {
-        Regex::new(r"\*\*(.+?)\*\*|__(.+?)__").expect("valid regex")
-    });
-    let re_code = CODE_RE.get_or_init(|| {
-        Regex::new(r"`([^`]+)`").expect("valid regex")
-    });
-    let re_link = LINK_RE.get_or_init(|| {
-        Regex::new(r"\[([^]]+)]\([^)]+\)").expect("valid regex")
-    });
+    let re_bold =
+        BOLD_RE.get_or_init(|| Regex::new(r"\*\*(.+?)\*\*|__(.+?)__").expect("valid regex"));
+    let re_code = CODE_RE.get_or_init(|| Regex::new(r"`([^`]+)`").expect("valid regex"));
+    let re_link = LINK_RE.get_or_init(|| Regex::new(r"\[([^]]+)]\([^)]+\)").expect("valid regex"));
     // Strip bold **text** and __text__
     let s = re_bold.replace_all(text, "$1$2").to_string();
     // Strip inline code `text`
@@ -376,7 +430,10 @@ fn strip_markdown(text: &str) -> String {
 /// Returns (subject, predicate, object, layer) or None.  `layer` is the 1-based
 /// index of the pattern family that fired, surfaced in the audit log + hook
 /// output so a reviewer can trace the derivation without reading this file.
-fn match_imperative(text: &str, section_context: &Option<String>) -> Option<(String, String, String, u8)> {
+fn match_imperative(
+    text: &str,
+    section_context: &Option<String>,
+) -> Option<(String, String, String, u8)> {
     // Skip items that look like pure code references
     if is_code_reference(text) {
         return None;
@@ -395,9 +452,8 @@ fn match_imperative(text: &str, section_context: &Option<String>) -> Option<(Str
     // Catches the colon-inside-bold case the previous trailing-separator
     // regex missed.
     static BOLD_LABEL_RE: OnceLock<Regex> = OnceLock::new();
-    let bold_label_re = BOLD_LABEL_RE.get_or_init(|| {
-        Regex::new(r"^\*\*[^*]+\s[^*]*\*\*").expect("valid regex")
-    });
+    let bold_label_re =
+        BOLD_LABEL_RE.get_or_init(|| Regex::new(r"^\*\*[^*]+\s[^*]*\*\*").expect("valid regex"));
     let is_bold_label = bold_label_re.is_match(text.trim_start());
 
     // Strip markdown formatting before matching
@@ -457,7 +513,11 @@ fn match_imperative(text: &str, section_context: &Option<String>) -> Option<(Str
         ];
         raw.iter()
             .map(|(p, pred)| {
-                (Regex::new(p).expect("valid regex"), *pred, p.contains("consider"))
+                (
+                    Regex::new(p).expect("valid regex"),
+                    *pred,
+                    p.contains("consider"),
+                )
             })
             .collect()
     });
@@ -484,9 +544,7 @@ fn match_imperative(text: &str, section_context: &Option<String>) -> Option<(Str
     // is feature-absence description, not a rule.
     if !is_bold_label {
         static NO_RE: OnceLock<Regex> = OnceLock::new();
-        let no_re = NO_RE.get_or_init(|| {
-            Regex::new(r"(?i)^no\s+(.+)").expect("valid regex")
-        });
+        let no_re = NO_RE.get_or_init(|| Regex::new(r"(?i)^no\s+(.+)").expect("valid regex"));
         if let Some(caps) = no_re.captures(&cleaned) {
             if let Some(obj_match) = caps.get(1) {
                 let object = obj_match.as_str().trim().to_string();
@@ -527,19 +585,56 @@ fn match_imperative(text: &str, section_context: &Option<String>) -> Option<(Str
             let after_lower = after_colon.to_lowercase();
             // Check if the part after colon starts with an imperative
             let colon_imperatives = [
-                "never", "always", "don't", "do not", "must", "avoid", "ensure",
-                "make", "find", "keep", "use", "run", "check", "add", "write",
-                "update", "mark", "set", "get", "put", "send", "stop", "start",
-                "enter", "exit", "verify", "test", "review", "demonstrate",
-                "offload", "throw", "challenge", "pause", "ask", "diff",
-                "ruthlessly", "zero", "no ", "only",
+                "never",
+                "always",
+                "don't",
+                "do not",
+                "must",
+                "avoid",
+                "ensure",
+                "make",
+                "find",
+                "keep",
+                "use",
+                "run",
+                "check",
+                "add",
+                "write",
+                "update",
+                "mark",
+                "set",
+                "get",
+                "put",
+                "send",
+                "stop",
+                "start",
+                "enter",
+                "exit",
+                "verify",
+                "test",
+                "review",
+                "demonstrate",
+                "offload",
+                "throw",
+                "challenge",
+                "pause",
+                "ask",
+                "diff",
+                "ruthlessly",
+                "zero",
+                "no ",
+                "only",
             ];
-            if colon_imperatives.iter().any(|imp| after_lower.starts_with(imp)) {
+            if colon_imperatives
+                .iter()
+                .any(|imp| after_lower.starts_with(imp))
+            {
                 let label = cleaned[..colon_pos].trim();
                 let subject = if !label.is_empty() {
                     // Use the label as subject if it's meaningful
                     let label_lower = label.to_lowercase();
-                    if let Some(tool) = KNOWN_TOOLS.iter().find(|t| contains_word(&label_lower, t)) {
+                    if let Some(tool) = KNOWN_TOOLS.iter().find(|t| contains_word(&label_lower, t))
+                    {
                         capitalize(tool)
                     } else {
                         label.to_string()
@@ -547,7 +642,12 @@ fn match_imperative(text: &str, section_context: &Option<String>) -> Option<(Str
                 } else {
                     extract_subject(&after_lower, section_context)
                 };
-                return Some((subject, "requires".to_string(), clean_object(after_colon), 3));
+                return Some((
+                    subject,
+                    "requires".to_string(),
+                    clean_object(after_colon),
+                    3,
+                ));
             }
         }
     }
@@ -581,17 +681,73 @@ fn match_imperative(text: &str, section_context: &Option<String>) -> Option<(Str
         let condition = caps.get(1)?.as_str().trim().to_lowercase();
         let allowed_verbs = [
             // From Layer 6
-            "enter", "exit", "run", "check", "test", "write", "read", "review",
-            "update", "delete", "add", "remove", "set", "get", "keep", "find",
-            "fix", "verify", "demonstrate", "prove", "show", "deploy", "build",
-            "install", "configure", "enable", "disable", "start", "stop",
-            "offload", "throw", "challenge", "pause", "diff", "ask",
-            "point", "create", "implement", "document", "define", "store",
-            "state", "share", "explain", "describe", "connect", "apply",
+            "enter",
+            "exit",
+            "run",
+            "check",
+            "test",
+            "write",
+            "read",
+            "review",
+            "update",
+            "delete",
+            "add",
+            "remove",
+            "set",
+            "get",
+            "keep",
+            "find",
+            "fix",
+            "verify",
+            "demonstrate",
+            "prove",
+            "show",
+            "deploy",
+            "build",
+            "install",
+            "configure",
+            "enable",
+            "disable",
+            "start",
+            "stop",
+            "offload",
+            "throw",
+            "challenge",
+            "pause",
+            "diff",
+            "ask",
+            "point",
+            "create",
+            "implement",
+            "document",
+            "define",
+            "store",
+            "state",
+            "share",
+            "explain",
+            "describe",
+            "connect",
+            "apply",
             // Layer 1 leaders
-            "never", "always", "don't", "dont", "do", "must", "should",
-            "shouldn't", "shouldnt", "avoid", "ensure", "use", "prefer",
-            "consider", "recommend", "make", "be", "no", "only",
+            "never",
+            "always",
+            "don't",
+            "dont",
+            "do",
+            "must",
+            "should",
+            "shouldn't",
+            "shouldnt",
+            "avoid",
+            "ensure",
+            "use",
+            "prefer",
+            "consider",
+            "recommend",
+            "make",
+            "be",
+            "no",
+            "only",
         ];
         if allowed_verbs.contains(&verb.as_str()) {
             // Decide predicate based on the inner verb.  Bias toward
@@ -657,13 +813,12 @@ fn match_imperative(text: &str, section_context: &Option<String>) -> Option<(Str
     // where the writer means the section's framing, not a generic verb
     // call-out.
     static USE_RE: OnceLock<Regex> = OnceLock::new();
-    let use_re = USE_RE.get_or_init(|| {
-        Regex::new(r"(?i)^use\s+(.+)").expect("valid regex")
-    });
+    let use_re = USE_RE.get_or_init(|| Regex::new(r"(?i)^use\s+(.+)").expect("valid regex"));
     if let Some(caps) = use_re.captures(&cleaned) {
         let object = caps.get(1)?.as_str().trim();
         let has_known_tool = contains_known_tool(&lower);
-        let has_co_imperative = lower.contains("always") || lower.contains("must") || lower.contains("never");
+        let has_co_imperative =
+            lower.contains("always") || lower.contains("must") || lower.contains("never");
         let in_rules_section = is_rules_section(section_context);
 
         if has_known_tool || has_co_imperative || in_rules_section {
@@ -675,20 +830,59 @@ fn match_imperative(text: &str, section_context: &Option<String>) -> Option<(Str
     // Layer 6: Catch-all — any list item with a verb-like start is a candidate rule
     // These get lower confidence (handled by the caller via source_type)
     let verb_starts = [
-        "enter", "exit", "run", "check", "test", "write", "read", "review",
-        "update", "delete", "add", "remove", "set", "get", "keep", "find",
-        "fix", "verify", "demonstrate", "prove", "show", "deploy", "build",
-        "install", "configure", "enable", "disable", "start", "stop",
-        "offload", "throw", "challenge", "pause", "diff", "ask",
+        "enter",
+        "exit",
+        "run",
+        "check",
+        "test",
+        "write",
+        "read",
+        "review",
+        "update",
+        "delete",
+        "add",
+        "remove",
+        "set",
+        "get",
+        "keep",
+        "find",
+        "fix",
+        "verify",
+        "demonstrate",
+        "prove",
+        "show",
+        "deploy",
+        "build",
+        "install",
+        "configure",
+        "enable",
+        "disable",
+        "start",
+        "stop",
+        "offload",
+        "throw",
+        "challenge",
+        "pause",
+        "diff",
+        "ask",
         "point",
         // v0.2.11 additions — measured against the broadened public corpus
         // (~80 additional rule extractions; see CHANGELOG).
-        "create", "implement", "document", "define", "store",
+        "create",
+        "implement",
+        "document",
+        "define",
+        "store",
         // Common imperatives observed in instruction prose (kraken,
         // arai, public corpora).  Each unambiguous in list-item-leading
         // position; low false-positive risk.  Also referenced by Layer 7's
         // allowed_verbs whitelist.
-        "state", "share", "explain", "describe", "connect", "apply",
+        "state",
+        "share",
+        "explain",
+        "describe",
+        "connect",
+        "apply",
     ];
 
     let first_word = lower.split_whitespace().next().unwrap_or("");
@@ -704,7 +898,9 @@ fn match_imperative(text: &str, section_context: &Option<String>) -> Option<(Str
 /// canonical "rules-shaped" section names so an unrelated `## Use Cases`
 /// section doesn't accidentally promote every `use X` bullet.
 fn is_rules_section(section_context: &Option<String>) -> bool {
-    let Some(section) = section_context else { return false; };
+    let Some(section) = section_context else {
+        return false;
+    };
     let lower = section.to_lowercase();
     [
         "convention",
@@ -733,9 +929,7 @@ fn is_code_reference(text: &str) -> bool {
     }
     // file:line reference
     static FILE_LINE_RE: OnceLock<Regex> = OnceLock::new();
-    let re = FILE_LINE_RE.get_or_init(|| {
-        Regex::new(r"^[\w./\\-]+:\d+$").expect("valid regex")
-    });
+    let re = FILE_LINE_RE.get_or_init(|| Regex::new(r"^[\w./\\-]+:\d+$").expect("valid regex"));
     if re.is_match(trimmed) {
         return true;
     }
@@ -766,10 +960,9 @@ fn extract_subject(lower_text: &str, section_context: &Option<String>) -> String
 
 fn extract_first_noun(text: &str) -> String {
     let skip_words = [
-        "the", "a", "an", "all", "any", "every", "each", "this", "that",
-        "your", "my", "our", "their", "its", "for", "to", "in", "on",
-        "with", "from", "of", "and", "or", "not", "no", "is", "are",
-        "was", "were", "be", "been", "being",
+        "the", "a", "an", "all", "any", "every", "each", "this", "that", "your", "my", "our",
+        "their", "its", "for", "to", "in", "on", "with", "from", "of", "and", "or", "not", "no",
+        "is", "are", "was", "were", "be", "been", "being",
     ];
 
     let words: Vec<&str> = text.split_whitespace().collect();
@@ -790,12 +983,18 @@ fn extract_first_noun(text: &str) -> String {
 /// Ambiguous tool names that need context to confirm they mean the tool.
 /// "go" can mean "go ahead" or the Go language — only match if followed by
 /// a subcommand like "test", "build", "run", "fmt", "mod", "get".
-const AMBIGUOUS_TOOLS: &[(&str, &[&str])] = &[
-    ("go", &["test", "build", "run", "fmt", "mod", "get", "install", "vet", "generate"]),
-];
+const AMBIGUOUS_TOOLS: &[(&str, &[&str])] = &[(
+    "go",
+    &[
+        "test", "build", "run", "fmt", "mod", "get", "install", "vet", "generate",
+    ],
+)];
 
 fn find_earliest_tool(text: &str) -> Option<&'static str> {
-    let words: Vec<&str> = text.split(|c: char| !c.is_alphanumeric()).filter(|w| !w.is_empty()).collect();
+    let words: Vec<&str> = text
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .collect();
     for (i, word) in words.iter().enumerate() {
         for tool in KNOWN_TOOLS {
             if *word == *tool {
@@ -823,7 +1022,9 @@ fn contains_word(text: &str, word: &str) -> bool {
 }
 
 fn contains_known_tool(lower_text: &str) -> bool {
-    KNOWN_TOOLS.iter().any(|tool| contains_word(lower_text, tool))
+    KNOWN_TOOLS
+        .iter()
+        .any(|tool| contains_word(lower_text, tool))
 }
 
 fn capitalize(s: &str) -> String {
@@ -895,9 +1096,18 @@ mod tests {
 ";
         let rules = extract_rules(md, "test", 0.9);
         let objects: Vec<&str> = rules.iter().map(|r| r.object.as_str()).collect();
-        assert!(objects.iter().any(|o| o.contains("Z")), "Z should fire: {objects:?}");
-        assert!(!objects.iter().any(|o| o.contains("X")), "X should be skipped: {objects:?}");
-        assert!(!objects.iter().any(|o| o.contains("Y")), "Y should be skipped: {objects:?}");
+        assert!(
+            objects.iter().any(|o| o.contains("Z")),
+            "Z should fire: {objects:?}"
+        );
+        assert!(
+            !objects.iter().any(|o| o.contains("X")),
+            "X should be skipped: {objects:?}"
+        );
+        assert!(
+            !objects.iter().any(|o| o.contains("Y")),
+            "Y should be skipped: {objects:?}"
+        );
     }
 
     #[test]
@@ -963,7 +1173,11 @@ mod tests {
 - Never real
 ";
         let rules = extract_rules(md, "test", 0.9);
-        assert_eq!(rules.len(), 1, "only the post-heading rule survives: {rules:?}");
+        assert_eq!(
+            rules.len(),
+            1,
+            "only the post-heading rule survives: {rules:?}"
+        );
         assert!(rules[0].object.contains("real"));
     }
 
@@ -984,42 +1198,34 @@ mod tests {
 
     #[test]
     fn test_expiry_is_extracted_and_stripped() {
-        let rules = extract_rules(
-            "- Never skip tests (expires 2026-12-31)",
-            "test",
-            0.9,
-        );
+        let rules = extract_rules("- Never skip tests (expires 2026-12-31)", "test", 0.9);
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].expires_at.as_deref(), Some("2026-12-31"));
         // Object should no longer contain the annotation.
-        assert!(!rules[0].object.contains("expires"), "object still carries annotation: {}", rules[0].object);
-        assert!(rules[0].object.contains("skip tests"), "object missing rule body: {}", rules[0].object);
+        assert!(
+            !rules[0].object.contains("expires"),
+            "object still carries annotation: {}",
+            rules[0].object
+        );
+        assert!(
+            rules[0].object.contains("skip tests"),
+            "object missing rule body: {}",
+            rules[0].object
+        );
     }
 
     #[test]
     fn test_expiry_variants() {
         // "until" variant
-        let rules = extract_rules(
-            "- Always use autogenerate (until 2027-01-15)",
-            "test",
-            0.9,
-        );
+        let rules = extract_rules("- Always use autogenerate (until 2027-01-15)", "test", 0.9);
         assert_eq!(rules[0].expires_at.as_deref(), Some("2027-01-15"));
 
         // "expire" (no s) also accepted
-        let rules = extract_rules(
-            "- Avoid direct sql writes (expire 2026-06-01)",
-            "test",
-            0.9,
-        );
+        let rules = extract_rules("- Avoid direct sql writes (expire 2026-06-01)", "test", 0.9);
         assert_eq!(rules[0].expires_at.as_deref(), Some("2026-06-01"));
 
         // No annotation → None
-        let rules = extract_rules(
-            "- Never force-push to main",
-            "test",
-            0.9,
-        );
+        let rules = extract_rules("- Never force-push to main", "test", 0.9);
         assert_eq!(rules[0].expires_at, None);
     }
 
@@ -1172,7 +1378,11 @@ mod tests {
 
     fn extract_one(line: &str) -> Triple {
         let rules = extract_rules(line, "test", 0.9);
-        assert_eq!(rules.len(), 1, "expected exactly 1 rule from {line:?}, got {rules:#?}");
+        assert_eq!(
+            rules.len(),
+            1,
+            "expected exactly 1 rule from {line:?}, got {rules:#?}"
+        );
         rules.into_iter().next().unwrap()
     }
 
@@ -1415,7 +1625,8 @@ mod tests {
 
     #[test]
     fn test_conditional_for_use() {
-        let r = extract_one("- For tasks that need more compute, use subagents to work in parallel");
+        let r =
+            extract_one("- For tasks that need more compute, use subagents to work in parallel");
         assert_eq!(r.layer, Some(7));
     }
 

--- a/src/scenarios.rs
+++ b/src/scenarios.rs
@@ -87,8 +87,8 @@ pub struct ScenarioResult {
 pub fn run_file(path: &Path, cfg: &Config, db: &Store) -> Result<Vec<ScenarioResult>, String> {
     let content = std::fs::read_to_string(path)
         .map_err(|e| format!("Failed to read scenario file {}: {e}", path.display()))?;
-    let file: ScenarioFile = serde_json::from_str(&content)
-        .map_err(|e| format!("Invalid scenario JSON: {e}"))?;
+    let file: ScenarioFile =
+        serde_json::from_str(&content).map_err(|e| format!("Invalid scenario JSON: {e}"))?;
 
     let mut results = Vec::with_capacity(file.scenarios.len());
     for scenario in file.scenarios {
@@ -127,40 +127,26 @@ fn run_one(scenario: &Scenario, cfg: &Config, db: &Store) -> ScenarioResult {
     }
 }
 
-fn check_expectations(
-    expect: &Expect,
-    matched: &[(Guardrail, u8)],
-    failures: &mut Vec<String>,
-) {
+fn check_expectations(expect: &Expect, matched: &[(Guardrail, u8)], failures: &mut Vec<String>) {
     let count = matched.len();
     if let Some(min) = expect.min_matches {
         if count < min {
-            failures.push(format!(
-                "expected at least {min} matches, got {count}"
-            ));
+            failures.push(format!("expected at least {min} matches, got {count}"));
         }
     }
     if let Some(max) = expect.max_matches {
         if count > max {
-            failures.push(format!(
-                "expected at most {max} matches, got {count}"
-            ));
+            failures.push(format!("expected at most {max} matches, got {count}"));
         }
     }
     for needle in &expect.matches_subject {
-        let hit = matched
-            .iter()
-            .any(|(g, _)| g.subject.contains(needle));
+        let hit = matched.iter().any(|(g, _)| g.subject.contains(needle));
         if !hit {
-            failures.push(format!(
-                "no matched rule subject contained {needle:?}"
-            ));
+            failures.push(format!("no matched rule subject contained {needle:?}"));
         }
     }
     for needle in &expect.does_not_match_subject {
-        let hit = matched
-            .iter()
-            .find(|(g, _)| g.subject.contains(needle));
+        let hit = matched.iter().find(|(g, _)| g.subject.contains(needle));
         if let Some((g, _)) = hit {
             failures.push(format!(
                 "rule {:?} {} {:?} matched but was excluded by does_not_match_subject={needle:?}",
@@ -195,7 +181,10 @@ pub fn run(path: &Path, json: bool) -> Result<(), String> {
                 })
             })
             .collect();
-        println!("{}", serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?
+        );
     } else {
         print_results(&results);
     }
@@ -237,9 +226,7 @@ fn reconstruct_tool_input(tool: &str, preview: &str) -> Value {
     match tool {
         "Bash" => json!({ "command": preview }),
         "Edit" | "Write" | "MultiEdit" => {
-            let path = preview
-                .strip_prefix(&format!("{tool} "))
-                .unwrap_or(preview);
+            let path = preview.strip_prefix(&format!("{tool} ")).unwrap_or(preview);
             json!({ "file_path": path })
         }
         _ => json!({ "preview": preview }),
@@ -380,7 +367,11 @@ mod tests {
             min_matches: Some(2),
             ..Default::default()
         };
-        check_expectations(&expect, &[gr(1, "git", "never", "force-push")], &mut failures);
+        check_expectations(
+            &expect,
+            &[gr(1, "git", "never", "force-push")],
+            &mut failures,
+        );
         assert_eq!(failures.len(), 1);
         assert!(failures[0].contains("at least 2"));
     }
@@ -394,10 +385,7 @@ mod tests {
         };
         check_expectations(
             &expect,
-            &[
-                gr(1, "git", "never", "a"),
-                gr(2, "git", "never", "b"),
-            ],
+            &[gr(1, "git", "never", "a"), gr(2, "git", "never", "b")],
             &mut failures,
         );
         assert_eq!(failures.len(), 1);

--- a/src/session.rs
+++ b/src/session.rs
@@ -10,7 +10,8 @@ use std::path::{Path, PathBuf};
 pub fn valid_session_id(s: &str) -> bool {
     !s.is_empty()
         && s.len() <= 128
-        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
 /// A record of a tool call within a session.
@@ -42,7 +43,9 @@ struct SessionState {
 /// sessions directory regardless, but this is enforced one layer up at the
 /// hook entry point so callers don't have to redo the check on every read.
 fn session_path(arai_base: &Path, session_id: &str) -> PathBuf {
-    arai_base.join("sessions").join(format!("{session_id}.json"))
+    arai_base
+        .join("sessions")
+        .join(format!("{session_id}.json"))
 }
 
 /// Load session state from disk.
@@ -67,12 +70,7 @@ fn save_session(arai_base: &Path, session_id: &str, state: &SessionState) {
 }
 
 /// Record a tool call in the session state (called from PostToolUse).
-pub fn record_tool_call(
-    arai_base: &Path,
-    session_id: &str,
-    tool_name: &str,
-    terms: &[String],
-) {
+pub fn record_tool_call(arai_base: &Path, session_id: &str, tool_name: &str, terms: &[String]) {
     let mut state = load_session(arai_base, session_id);
     state.tool_calls.push(ToolCallRecord {
         tool_name: tool_name.to_string(),
@@ -89,11 +87,7 @@ pub fn record_tool_call(
 
 /// Check if prerequisite terms have been satisfied in the session.
 /// Returns true if ALL prerequisite terms appear in at least one past tool call.
-pub fn prerequisite_met(
-    arai_base: &Path,
-    session_id: &str,
-    prerequisite_terms: &[String],
-) -> bool {
+pub fn prerequisite_met(arai_base: &Path, session_id: &str, prerequisite_terms: &[String]) -> bool {
     if prerequisite_terms.is_empty() {
         return false; // No prerequisite → not met (fire the rule)
     }
@@ -102,9 +96,9 @@ pub fn prerequisite_met(
 
     // Check if any past tool call contains ALL prerequisite terms
     state.tool_calls.iter().any(|record| {
-        prerequisite_terms.iter().all(|req| {
-            record.terms.iter().any(|t| t == req)
-        })
+        prerequisite_terms
+            .iter()
+            .all(|req| record.terms.iter().any(|t| t == req))
     })
 }
 
@@ -190,7 +184,8 @@ pub fn extract_prerequisite(object: &str) -> Vec<String> {
                 .split_whitespace()
                 .filter(|w| {
                     let w = w.trim_matches(|c: char| !c.is_alphanumeric());
-                    w.len() >= 2 && !matches!(w, "the" | "a" | "an" | "all" | "and" | "or" | "to" | "in")
+                    w.len() >= 2
+                        && !matches!(w, "the" | "a" | "an" | "all" | "and" | "or" | "to" | "in")
                 })
                 .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_string())
                 .collect();
@@ -219,9 +214,7 @@ mod tests {
     fn valid_session_id_accepts_uuid_shapes_and_short_tokens() {
         assert!(valid_session_id("abc123"));
         assert!(valid_session_id("01HXYZ_AB-CD"));
-        assert!(valid_session_id(
-            "550e8400-e29b-41d4-a716-446655440000"
-        ));
+        assert!(valid_session_id("550e8400-e29b-41d4-a716-446655440000"));
         // Boundary: exactly 128 chars allowed.
         let max = "a".repeat(128);
         assert!(valid_session_id(&max));
@@ -371,7 +364,12 @@ mod tests {
         std::fs::create_dir_all(&dir).ok();
 
         // Record cargo test
-        record_tool_call(&dir, "sess1", "Bash", &["cargo".to_string(), "test".to_string()]);
+        record_tool_call(
+            &dir,
+            "sess1",
+            "Bash",
+            &["cargo".to_string(), "test".to_string()],
+        );
 
         // Check if prerequisite is met
         let prereqs = vec!["cargo".to_string(), "test".to_string()];

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -12,8 +12,8 @@
 //! number for a maintainer evaluating Arai on a real project — it tells
 //! you which rules the model honours and which ones it routes around.
 
-use crate::config::Config;
 use crate::audit;
+use crate::config::Config;
 use serde_json::Value;
 use std::collections::HashMap;
 
@@ -242,7 +242,10 @@ pub fn compute(entries: &[Value]) -> Stats {
                 // payload.  Older audit entries don't carry the field —
                 // treat absent as `false` (first-time injection, no
                 // saving claimed).
-                if r.get("seen_before").and_then(|v| v.as_bool()).unwrap_or(false) {
+                if r.get("seen_before")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+                {
                     suppressed_repeats += 1;
                 }
 
@@ -303,10 +306,8 @@ pub fn compute(entries: &[Value]) -> Stats {
         .into_iter()
         .map(|(triple_id, (subject, predicate, object))| {
             let fires = *fires_by_id.get(&triple_id).unwrap_or(&0);
-            let (obeyed, ignored, unclear) = outcomes_by_id
-                .get(&triple_id)
-                .copied()
-                .unwrap_or((0, 0, 0));
+            let (obeyed, ignored, unclear) =
+                outcomes_by_id.get(&triple_id).copied().unwrap_or((0, 0, 0));
             let denom = obeyed + ignored;
             let ratio = if denom > 0 {
                 Some(obeyed as f64 / denom as f64)
@@ -412,7 +413,10 @@ pub fn run(
                     .collect(),
             );
         }
-        println!("{}", serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?
+        );
         return Ok(());
     }
 
@@ -512,7 +516,9 @@ fn print_compliance_section(rows: &[RuleCompliance], top: usize) {
     let any_outcomes = rows.iter().any(|r| r.obeyed + r.ignored + r.unclear > 0);
     println!("Per-rule compliance");
     if !any_outcomes {
-        println!("  (no Compliance events yet — Pre/Post correlation produces these on PostToolUse)");
+        println!(
+            "  (no Compliance events yet — Pre/Post correlation produces these on PostToolUse)"
+        );
     }
     println!(
         "  {:>5} {:>6} {:>7} {:>7} {:>7}  rule",
@@ -530,8 +536,7 @@ fn print_compliance_section(rows: &[RuleCompliance], top: usize) {
         };
         println!(
             "  {:>5} {:>6} {:>7} {:>7} {:>7}  {} {}: {}{}",
-            r.fires, r.obeyed, r.ignored, r.unclear, ratio,
-            r.subject, r.predicate, r.object, flag,
+            r.fires, r.obeyed, r.ignored, r.unclear, ratio, r.subject, r.predicate, r.object, flag,
         );
     }
     if rows.len() > top {
@@ -545,7 +550,14 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    fn pre_firing(ts: &str, tool: &str, triple_id: i64, subj: &str, pred: &str, obj: &str) -> Value {
+    fn pre_firing(
+        ts: &str,
+        tool: &str,
+        triple_id: i64,
+        subj: &str,
+        pred: &str,
+        obj: &str,
+    ) -> Value {
         json!({
             "ts": ts,
             "tool": tool,
@@ -599,9 +611,30 @@ mod tests {
     #[test]
     fn test_rule_count_aggregation() {
         let entries = vec![
-            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "git", "never", "force-push"),
-            pre_firing("2026-04-20T11:00:00Z", "Bash", 1, "git", "never", "force-push"),
-            pre_firing("2026-04-20T12:00:00Z", "Write", 2, "alembic", "never", "hand-write"),
+            pre_firing(
+                "2026-04-20T10:00:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+            ),
+            pre_firing(
+                "2026-04-20T11:00:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+            ),
+            pre_firing(
+                "2026-04-20T12:00:00Z",
+                "Write",
+                2,
+                "alembic",
+                "never",
+                "hand-write",
+            ),
         ];
         let stats = compute(&entries);
         assert_eq!(stats.total_firings, 3);
@@ -625,7 +658,15 @@ mod tests {
         let stats = compute(&entries);
         assert_eq!(stats.by_tool[0], ("Bash".to_string(), 2));
         assert_eq!(stats.by_tool[1], ("Write".to_string(), 1));
-        assert_eq!(stats.by_event.iter().find(|(k, _)| k == "PreToolUse").unwrap().1, 2);
+        assert_eq!(
+            stats
+                .by_event
+                .iter()
+                .find(|(k, _)| k == "PreToolUse")
+                .unwrap()
+                .1,
+            2
+        );
     }
 
     #[test]
@@ -660,12 +701,51 @@ mod tests {
         // 3 distinct Pre firings of rule 1 (different pre_ts), each
         // correlated with one definitive Post: 2 obeyed + 1 ignored.
         let entries = vec![
-            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "git", "never", "force-push"),
-            pre_firing("2026-04-20T10:01:00Z", "Bash", 1, "git", "never", "force-push"),
-            pre_firing("2026-04-20T10:02:00Z", "Bash", 1, "git", "never", "force-push"),
-            compliance_event("2026-04-20T10:00:30Z", "Bash", 1, "obeyed", "2026-04-20T10:00:00Z"),
-            compliance_event("2026-04-20T10:01:30Z", "Bash", 1, "obeyed", "2026-04-20T10:01:00Z"),
-            compliance_event("2026-04-20T10:02:30Z", "Bash", 1, "ignored", "2026-04-20T10:02:00Z"),
+            pre_firing(
+                "2026-04-20T10:00:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+            ),
+            pre_firing(
+                "2026-04-20T10:01:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+            ),
+            pre_firing(
+                "2026-04-20T10:02:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+            ),
+            compliance_event(
+                "2026-04-20T10:00:30Z",
+                "Bash",
+                1,
+                "obeyed",
+                "2026-04-20T10:00:00Z",
+            ),
+            compliance_event(
+                "2026-04-20T10:01:30Z",
+                "Bash",
+                1,
+                "obeyed",
+                "2026-04-20T10:01:00Z",
+            ),
+            compliance_event(
+                "2026-04-20T10:02:30Z",
+                "Bash",
+                1,
+                "ignored",
+                "2026-04-20T10:02:00Z",
+            ),
         ];
         let stats = compute(&entries);
 
@@ -690,9 +770,14 @@ mod tests {
     #[test]
     fn test_compliance_rollup_no_outcomes_yields_none_ratio() {
         // Pre firings only, no Compliance events: ratio is None.
-        let entries = vec![
-            pre_firing("2026-04-20T10:00:00Z", "Bash", 7, "alembic", "never", "hand-write"),
-        ];
+        let entries = vec![pre_firing(
+            "2026-04-20T10:00:00Z",
+            "Bash",
+            7,
+            "alembic",
+            "never",
+            "hand-write",
+        )];
         let stats = compute(&entries);
         assert_eq!(stats.by_rule_compliance.len(), 1);
         assert_eq!(stats.by_rule_compliance[0].fires, 1);
@@ -731,8 +816,20 @@ mod tests {
             pre_firing("2026-04-20T10:01:00Z", "Bash", 1, "a", "never", "x"),
             pre_firing("2026-04-20T10:02:00Z", "Bash", 1, "a", "never", "x"),
             pre_firing("2026-04-20T10:03:00Z", "Bash", 2, "b", "never", "y"),
-            compliance_event("2026-04-20T10:00:30Z", "Bash", 1, "obeyed", "2026-04-20T10:00:00Z"),
-            compliance_event("2026-04-20T10:03:30Z", "Bash", 2, "ignored", "2026-04-20T10:03:00Z"),
+            compliance_event(
+                "2026-04-20T10:00:30Z",
+                "Bash",
+                1,
+                "obeyed",
+                "2026-04-20T10:00:00Z",
+            ),
+            compliance_event(
+                "2026-04-20T10:03:30Z",
+                "Bash",
+                2,
+                "ignored",
+                "2026-04-20T10:03:00Z",
+            ),
         ];
         let stats = compute(&entries);
         assert_eq!(stats.by_rule_compliance[0].triple_id, 1);
@@ -826,7 +923,10 @@ mod tests {
         ];
         let stats = compute(&entries);
         let rc = &stats.by_rule_compliance[0];
-        assert_eq!(rc.ignored, 1, "first definitive wins, even if preceded by unclear");
+        assert_eq!(
+            rc.ignored, 1,
+            "first definitive wins, even if preceded by unclear"
+        );
         assert_eq!(rc.obeyed, 0);
         assert_eq!(rc.unclear, 0);
     }
@@ -888,10 +988,42 @@ mod tests {
         // 4 firings of rule 1: first is fresh, next 3 are seen_before.
         // Suppression count is 3; tokens saved = 3 * 50 = 150.
         let entries = vec![
-            pre_firing_seen("2026-04-20T10:00:00Z", "Bash", 1, "git", "never", "force-push", false),
-            pre_firing_seen("2026-04-20T10:01:00Z", "Bash", 1, "git", "never", "force-push", true),
-            pre_firing_seen("2026-04-20T10:02:00Z", "Bash", 1, "git", "never", "force-push", true),
-            pre_firing_seen("2026-04-20T10:03:00Z", "Bash", 1, "git", "never", "force-push", true),
+            pre_firing_seen(
+                "2026-04-20T10:00:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+                false,
+            ),
+            pre_firing_seen(
+                "2026-04-20T10:01:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+                true,
+            ),
+            pre_firing_seen(
+                "2026-04-20T10:02:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+                true,
+            ),
+            pre_firing_seen(
+                "2026-04-20T10:03:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+                true,
+            ),
         ];
         let stats = compute(&entries);
         let t = &stats.token_economics;
@@ -905,16 +1037,86 @@ mod tests {
     fn test_token_economics_weights_blocked_vs_advisory() {
         // 2 obeyed-block + 3 obeyed-warn → 2*2000 + 3*500 = 5500.
         let entries = vec![
-            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "git", "never", "force-push"),
-            pre_firing("2026-04-20T10:01:00Z", "Bash", 1, "git", "never", "force-push"),
-            pre_firing("2026-04-20T10:02:00Z", "Bash", 2, "cargo", "always", "test before commit"),
-            pre_firing("2026-04-20T10:03:00Z", "Bash", 2, "cargo", "always", "test before commit"),
-            pre_firing("2026-04-20T10:04:00Z", "Bash", 2, "cargo", "always", "test before commit"),
-            compliance_event_with_severity("2026-04-20T10:00:30Z", "Bash", 1, "obeyed", "2026-04-20T10:00:00Z", "block"),
-            compliance_event_with_severity("2026-04-20T10:01:30Z", "Bash", 1, "obeyed", "2026-04-20T10:01:00Z", "block"),
-            compliance_event_with_severity("2026-04-20T10:02:30Z", "Bash", 2, "obeyed", "2026-04-20T10:02:00Z", "warn"),
-            compliance_event_with_severity("2026-04-20T10:03:30Z", "Bash", 2, "obeyed", "2026-04-20T10:03:00Z", "warn"),
-            compliance_event_with_severity("2026-04-20T10:04:30Z", "Bash", 2, "obeyed", "2026-04-20T10:04:00Z", "warn"),
+            pre_firing(
+                "2026-04-20T10:00:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+            ),
+            pre_firing(
+                "2026-04-20T10:01:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+            ),
+            pre_firing(
+                "2026-04-20T10:02:00Z",
+                "Bash",
+                2,
+                "cargo",
+                "always",
+                "test before commit",
+            ),
+            pre_firing(
+                "2026-04-20T10:03:00Z",
+                "Bash",
+                2,
+                "cargo",
+                "always",
+                "test before commit",
+            ),
+            pre_firing(
+                "2026-04-20T10:04:00Z",
+                "Bash",
+                2,
+                "cargo",
+                "always",
+                "test before commit",
+            ),
+            compliance_event_with_severity(
+                "2026-04-20T10:00:30Z",
+                "Bash",
+                1,
+                "obeyed",
+                "2026-04-20T10:00:00Z",
+                "block",
+            ),
+            compliance_event_with_severity(
+                "2026-04-20T10:01:30Z",
+                "Bash",
+                1,
+                "obeyed",
+                "2026-04-20T10:01:00Z",
+                "block",
+            ),
+            compliance_event_with_severity(
+                "2026-04-20T10:02:30Z",
+                "Bash",
+                2,
+                "obeyed",
+                "2026-04-20T10:02:00Z",
+                "warn",
+            ),
+            compliance_event_with_severity(
+                "2026-04-20T10:03:30Z",
+                "Bash",
+                2,
+                "obeyed",
+                "2026-04-20T10:03:00Z",
+                "warn",
+            ),
+            compliance_event_with_severity(
+                "2026-04-20T10:04:30Z",
+                "Bash",
+                2,
+                "obeyed",
+                "2026-04-20T10:04:00Z",
+                "warn",
+            ),
         ];
         let stats = compute(&entries);
         let t = &stats.token_economics;
@@ -928,8 +1130,22 @@ mod tests {
         // An `ignored` verdict means the model ran the action despite the
         // rule.  No tokens saved — we don't claim retroactive credit.
         let entries = vec![
-            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "git", "never", "force-push"),
-            compliance_event_with_severity("2026-04-20T10:00:30Z", "Bash", 1, "ignored", "2026-04-20T10:00:00Z", "block"),
+            pre_firing(
+                "2026-04-20T10:00:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+            ),
+            compliance_event_with_severity(
+                "2026-04-20T10:00:30Z",
+                "Bash",
+                1,
+                "ignored",
+                "2026-04-20T10:00:00Z",
+                "block",
+            ),
         ];
         let stats = compute(&entries);
         let t = &stats.token_economics;
@@ -944,7 +1160,14 @@ mod tests {
         // severity field shouldn't blow up or attribute tokens.  Older
         // audit entries (pre-severity tracking) take this path.
         let entries = vec![
-            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "git", "never", "force-push"),
+            pre_firing(
+                "2026-04-20T10:00:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+            ),
             json!({
                 "ts": "2026-04-20T10:00:30Z",
                 "tool": "Bash",
@@ -973,9 +1196,30 @@ mod tests {
         // suppression credit) — never as `seen_before: true`.
         let entries = vec![
             // Vanilla pre_firing helper omits seen_before.
-            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "git", "never", "force-push"),
-            pre_firing("2026-04-20T10:01:00Z", "Bash", 1, "git", "never", "force-push"),
-            pre_firing("2026-04-20T10:02:00Z", "Bash", 1, "git", "never", "force-push"),
+            pre_firing(
+                "2026-04-20T10:00:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+            ),
+            pre_firing(
+                "2026-04-20T10:01:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+            ),
+            pre_firing(
+                "2026-04-20T10:02:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+            ),
         ];
         let stats = compute(&entries);
         assert_eq!(stats.token_economics.suppressed_repeats, 0);
@@ -988,14 +1232,52 @@ mod tests {
         // multiple firings of the same rule are still independent
         // observations.
         let entries = vec![
-            pre_firing("2026-04-20T10:00:00Z", "Bash", 1, "git", "never", "force-push"),
-            pre_firing("2026-04-20T11:00:00Z", "Bash", 1, "git", "never", "force-push"),
+            pre_firing(
+                "2026-04-20T10:00:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+            ),
+            pre_firing(
+                "2026-04-20T11:00:00Z",
+                "Bash",
+                1,
+                "git",
+                "never",
+                "force-push",
+            ),
             // Pre #1: lots of correlated obeyed, dedupes to 1 obeyed.
-            compliance_event("2026-04-20T10:00:30Z", "Bash", 1, "obeyed", "2026-04-20T10:00:00Z"),
-            compliance_event("2026-04-20T10:01:00Z", "Bash", 1, "obeyed", "2026-04-20T10:00:00Z"),
-            compliance_event("2026-04-20T10:01:30Z", "Bash", 1, "obeyed", "2026-04-20T10:00:00Z"),
+            compliance_event(
+                "2026-04-20T10:00:30Z",
+                "Bash",
+                1,
+                "obeyed",
+                "2026-04-20T10:00:00Z",
+            ),
+            compliance_event(
+                "2026-04-20T10:01:00Z",
+                "Bash",
+                1,
+                "obeyed",
+                "2026-04-20T10:00:00Z",
+            ),
+            compliance_event(
+                "2026-04-20T10:01:30Z",
+                "Bash",
+                1,
+                "obeyed",
+                "2026-04-20T10:00:00Z",
+            ),
             // Pre #2: ignored.
-            compliance_event("2026-04-20T11:00:30Z", "Bash", 1, "ignored", "2026-04-20T11:00:00Z"),
+            compliance_event(
+                "2026-04-20T11:00:30Z",
+                "Bash",
+                1,
+                "ignored",
+                "2026-04-20T11:00:00Z",
+            ),
         ];
         let stats = compute(&entries);
         let rc = &stats.by_rule_compliance[0];

--- a/src/store.rs
+++ b/src/store.rs
@@ -23,8 +23,8 @@ impl Store {
                 .map_err(|e| format!("Failed to create DB directory: {e}"))?;
         }
 
-        let conn = Connection::open(db_path)
-            .map_err(|e| format!("Failed to open database: {e}"))?;
+        let conn =
+            Connection::open(db_path).map_err(|e| format!("Failed to open database: {e}"))?;
 
         // Connection PRAGMAs.  journal_mode=WAL and synchronous=NORMAL are
         // persistent (set on the database file once); temp_store=MEMORY and
@@ -204,9 +204,9 @@ impl Store {
     /// List currently disabled rules `(s, p, o, disabled_at)` — surfaced by
     /// `arai disable` (no args) so users can audit what's been silenced.
     pub fn list_disabled_rules(&self) -> rusqlite::Result<Vec<(String, String, String, String)>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT s, p, o, disabled_at FROM disabled_rules ORDER BY disabled_at DESC",
-        )?;
+        let mut stmt = self
+            .conn
+            .prepare("SELECT s, p, o, disabled_at FROM disabled_rules ORDER BY disabled_at DESC")?;
         let rows = stmt
             .query_map([], |row| {
                 Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
@@ -219,7 +219,10 @@ impl Store {
     /// resolve a stable display id to the (s,p,o) tuple that
     /// `disable_rule` stores.  Includes disabled rules so `arai enable <id>`
     /// can find them.
-    pub fn rule_by_triple_id(&self, triple_id: i64) -> rusqlite::Result<Option<(String, String, String)>> {
+    pub fn rule_by_triple_id(
+        &self,
+        triple_id: i64,
+    ) -> rusqlite::Result<Option<(String, String, String)>> {
         match self.conn.query_row(
             "SELECT s, p, o FROM triples WHERE id = ?1",
             params![triple_id],
@@ -308,9 +311,9 @@ impl Store {
 
     /// Query what tools are imported by files in a given directory.
     pub fn query_tools_for_directory(&self, directory: &str) -> rusqlite::Result<Vec<String>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT DISTINCT tool_name FROM code_graph WHERE directory = ?1",
-        )?;
+        let mut stmt = self
+            .conn
+            .prepare("SELECT DISTINCT tool_name FROM code_graph WHERE directory = ?1")?;
         let tools = stmt
             .query_map(params![directory], |row| row.get(0))?
             .collect::<Result<Vec<String>, _>>()?;
@@ -367,7 +370,8 @@ impl Store {
         triple_id: i64,
         intent: &crate::intent::RuleIntent,
     ) -> rusqlite::Result<()> {
-        let tools_json = serde_json::to_string(&intent.tools).unwrap_or_else(|_| "[\"*\"]".to_string());
+        let tools_json =
+            serde_json::to_string(&intent.tools).unwrap_or_else(|_| "[\"*\"]".to_string());
         self.conn.execute(
             "INSERT INTO rule_intent (triple_id, action, timing, tools, allow_inverse, enriched_by, enriched_at, severity)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'), ?7)
@@ -391,7 +395,10 @@ impl Store {
     /// If a `severity_override` row is present, it takes precedence over the
     /// classified severity — that's the surface `arai severity` writes to so
     /// re-running `arai scan` doesn't stomp a manual rollout decision.
-    pub fn get_rule_intent(&self, triple_id: i64) -> rusqlite::Result<Option<crate::intent::RuleIntent>> {
+    pub fn get_rule_intent(
+        &self,
+        triple_id: i64,
+    ) -> rusqlite::Result<Option<crate::intent::RuleIntent>> {
         match self.conn.query_row(
             "SELECT action, timing, tools, allow_inverse, enriched_by, severity, severity_override FROM rule_intent WHERE triple_id = ?1",
             params![triple_id],
@@ -652,7 +659,10 @@ impl Store {
             }
         }
 
-        Ok(RuleIssues { duplicates, opposing })
+        Ok(RuleIssues {
+            duplicates,
+            opposing,
+        })
     }
 
     /// Classify all existing guardrails using the taxonomy.
@@ -660,7 +670,11 @@ impl Store {
         let guardrails = self.load_guardrails()?;
         let mut count = 0;
         for g in &guardrails {
-            let intent = crate::intent::classify_rule_with_subject(&g.predicate, &g.object, Some(&g.subject));
+            let intent = crate::intent::classify_rule_with_subject(
+                &g.predicate,
+                &g.object,
+                Some(&g.subject),
+            );
             self.upsert_rule_intent(g.triple_id, &intent)?;
             count += 1;
         }
@@ -757,7 +771,9 @@ fn parse_intent_from_row(
     start: usize,
 ) -> rusqlite::Result<Option<crate::intent::RuleIntent>> {
     let action_str: Option<String> = row.get(start)?;
-    let Some(action_str) = action_str else { return Ok(None) };
+    let Some(action_str) = action_str else {
+        return Ok(None);
+    };
     let timing_str: String = row.get(start + 1)?;
     let tools_json: String = row.get(start + 2)?;
     let allow_inverse: i32 = row.get(start + 3)?;
@@ -977,7 +993,12 @@ fn migrate_v1(conn: &Connection) -> rusqlite::Result<()> {
     // statements above, so on a fresh DB the helper is a no-op.  On an
     // upgrading DB whose tables predate one or more of these columns, the
     // helper backfills them once.
-    add_column_if_missing(conn, "rule_intent", "severity", "TEXT NOT NULL DEFAULT 'warn'")?;
+    add_column_if_missing(
+        conn,
+        "rule_intent",
+        "severity",
+        "TEXT NOT NULL DEFAULT 'warn'",
+    )?;
     add_column_if_missing(conn, "rule_intent", "severity_override", "TEXT")?;
     add_column_if_missing(conn, "triples", "layer", "INTEGER")?;
     add_column_if_missing(conn, "triples", "expires_at", "TEXT")?;
@@ -1047,7 +1068,14 @@ mod tests {
             noenrich: false,
         }];
 
-        let changed = store.upsert_file("CLAUDE.md", "- Never force-push to main", &triples, "claude_md_project").unwrap();
+        let changed = store
+            .upsert_file(
+                "CLAUDE.md",
+                "- Never force-push to main",
+                &triples,
+                "claude_md_project",
+            )
+            .unwrap();
         assert!(changed);
 
         let guardrails = store.load_guardrails().unwrap();
@@ -1056,7 +1084,14 @@ mod tests {
         assert_eq!(guardrails[0].predicate, "never");
 
         // Upsert again with same content — should skip
-        let changed = store.upsert_file("CLAUDE.md", "- Never force-push to main", &triples, "claude_md_project").unwrap();
+        let changed = store
+            .upsert_file(
+                "CLAUDE.md",
+                "- Never force-push to main",
+                &triples,
+                "claude_md_project",
+            )
+            .unwrap();
         assert!(!changed);
 
         std::fs::remove_dir_all(&dir).ok();
@@ -1079,13 +1114,20 @@ mod tests {
             expires_at: None,
             noenrich: false,
         };
-        store.upsert_file("CLAUDE.md", "- a", &[t.clone()], "claude_md_project").unwrap();
-        store.upsert_file(
-            "global.md",
-            "- a",
-            &[Triple { source_file: "global.md".to_string(), ..t.clone() }],
-            "claude_md_global",
-        ).unwrap();
+        store
+            .upsert_file("CLAUDE.md", "- a", &[t.clone()], "claude_md_project")
+            .unwrap();
+        store
+            .upsert_file(
+                "global.md",
+                "- a",
+                &[Triple {
+                    source_file: "global.md".to_string(),
+                    ..t.clone()
+                }],
+                "claude_md_global",
+            )
+            .unwrap();
 
         let issues = store.find_rule_issues().unwrap();
         assert_eq!(issues.duplicates.len(), 1);
@@ -1126,13 +1168,22 @@ mod tests {
             expires_at: None,
             noenrich: false,
         };
-        store.upsert_file("CLAUDE.md", "- a\n- b", &[never, always], "claude_md_project").unwrap();
+        store
+            .upsert_file(
+                "CLAUDE.md",
+                "- a\n- b",
+                &[never, always],
+                "claude_md_project",
+            )
+            .unwrap();
 
         let issues = store.find_rule_issues().unwrap();
         assert_eq!(issues.opposing.len(), 1);
         assert_eq!(issues.opposing[0].subject, "alembic");
         assert!(issues.opposing[0].predicates.contains(&"never".to_string()));
-        assert!(issues.opposing[0].predicates.contains(&"always".to_string()));
+        assert!(issues.opposing[0]
+            .predicates
+            .contains(&"always".to_string()));
 
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -1167,7 +1218,9 @@ mod tests {
             expires_at: None,
             noenrich: false,
         };
-        store.upsert_file("CLAUDE.md", "- a\n- b", &[t1, t2], "claude_md_project").unwrap();
+        store
+            .upsert_file("CLAUDE.md", "- a\n- b", &[t1, t2], "claude_md_project")
+            .unwrap();
 
         let issues = store.find_rule_issues().unwrap();
         assert!(issues.duplicates.is_empty());
@@ -1182,7 +1235,10 @@ mod tests {
 
         assert_eq!(store.get_meta("last_scan").unwrap(), None);
         store.set_meta("last_scan", "12345").unwrap();
-        assert_eq!(store.get_meta("last_scan").unwrap(), Some("12345".to_string()));
+        assert_eq!(
+            store.get_meta("last_scan").unwrap(),
+            Some("12345".to_string())
+        );
 
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -1203,13 +1259,19 @@ mod tests {
             expires_at: None,
             noenrich: false,
         };
-        store.upsert_file("CLAUDE.md", "x", &[t], "claude_md_project").unwrap();
+        store
+            .upsert_file("CLAUDE.md", "x", &[t], "claude_md_project")
+            .unwrap();
         store.classify_all_guardrails().unwrap();
 
         // Predicate-derived: prefers → Inform.
         let g = &store.load_guardrails().unwrap()[0];
         assert_eq!(
-            store.get_rule_intent(g.triple_id).unwrap().unwrap().severity,
+            store
+                .get_rule_intent(g.triple_id)
+                .unwrap()
+                .unwrap()
+                .severity,
             crate::intent::Severity::Inform
         );
 
@@ -1221,7 +1283,11 @@ mod tests {
         assert_eq!(changed[0].from, crate::intent::Severity::Inform);
         assert_eq!(changed[0].to, crate::intent::Severity::Block);
         assert_eq!(
-            store.get_rule_intent(g.triple_id).unwrap().unwrap().severity,
+            store
+                .get_rule_intent(g.triple_id)
+                .unwrap()
+                .unwrap()
+                .severity,
             crate::intent::Severity::Block,
             "override should win over classified severity"
         );
@@ -1229,7 +1295,11 @@ mod tests {
         // Re-classify: must NOT stomp the override.
         store.classify_all_guardrails().unwrap();
         assert_eq!(
-            store.get_rule_intent(g.triple_id).unwrap().unwrap().severity,
+            store
+                .get_rule_intent(g.triple_id)
+                .unwrap()
+                .unwrap()
+                .severity,
             crate::intent::Severity::Block,
             "classify_all_guardrails should preserve manual overrides"
         );
@@ -1245,7 +1315,11 @@ mod tests {
         assert_eq!(cleared.len(), 1);
         assert!(store.list_severity_overrides().unwrap().is_empty());
         assert_eq!(
-            store.get_rule_intent(g.triple_id).unwrap().unwrap().severity,
+            store
+                .get_rule_intent(g.triple_id)
+                .unwrap()
+                .unwrap()
+                .severity,
             crate::intent::Severity::Inform,
             "after clear, severity should fall back to classification"
         );
@@ -1270,7 +1344,12 @@ mod tests {
             noenrich: false,
         };
         store
-            .upsert_file("CLAUDE.md", "x", &[mk("alembic", 1), mk("git", 2), mk("cargo", 3)], "claude_md_project")
+            .upsert_file(
+                "CLAUDE.md",
+                "x",
+                &[mk("alembic", 1), mk("git", 2), mk("cargo", 3)],
+                "claude_md_project",
+            )
             .unwrap();
         store.classify_all_guardrails().unwrap();
 
@@ -1306,10 +1385,20 @@ mod tests {
             noenrich: false,
         };
         store
-            .upsert_file("CLAUDE.md", "a", &[mk_in("CLAUDE.md", 1)], "claude_md_project")
+            .upsert_file(
+                "CLAUDE.md",
+                "a",
+                &[mk_in("CLAUDE.md", 1)],
+                "claude_md_project",
+            )
             .unwrap();
         store
-            .upsert_file("memory/feedback.md", "b", &[mk_in("memory/feedback.md", 1)], "memory")
+            .upsert_file(
+                "memory/feedback.md",
+                "b",
+                &[mk_in("memory/feedback.md", 1)],
+                "memory",
+            )
             .unwrap();
 
         let claude_rules = store.rules_for_file("CLAUDE.md").unwrap();
@@ -1355,12 +1444,20 @@ mod tests {
             expires_at: Some("2000-01-01".to_string()), // long past
             noenrich: false,
         };
-        store.upsert_file("CLAUDE.md", "x", &[alive, dead], "claude_md_project").unwrap();
+        store
+            .upsert_file("CLAUDE.md", "x", &[alive, dead], "claude_md_project")
+            .unwrap();
 
         let rails = store.load_guardrails().unwrap();
         let subjects: Vec<_> = rails.iter().map(|g| g.subject.clone()).collect();
-        assert!(subjects.iter().any(|s| s == "git"), "unexpired rule should load");
-        assert!(!subjects.iter().any(|s| s == "legacy"), "expired rule should NOT load");
+        assert!(
+            subjects.iter().any(|s| s == "git"),
+            "unexpired rule should load"
+        );
+        assert!(
+            !subjects.iter().any(|s| s == "legacy"),
+            "expired rule should NOT load"
+        );
 
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -1393,7 +1490,8 @@ mod tests {
     fn test_reopen_skips_migrations_when_at_target() {
         // First open runs migration v1 and bumps user_version.
         let id = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
-        let dir = std::env::temp_dir().join(format!("arai_test_reopen_{}_{}", std::process::id(), id));
+        let dir =
+            std::env::temp_dir().join(format!("arai_test_reopen_{}_{}", std::process::id(), id));
         std::fs::create_dir_all(&dir).unwrap();
         let db_path = dir.join("test.db");
 
@@ -1441,13 +1539,17 @@ mod tests {
                 noenrich: false,
             },
         ];
-        store.upsert_file("CLAUDE.md", "x", &triples, "test").unwrap();
+        store
+            .upsert_file("CLAUDE.md", "x", &triples, "test")
+            .unwrap();
 
         // Both rules visible initially.
         assert_eq!(store.load_guardrails().unwrap().len(), 2);
 
         // Disable one — load_guardrails drops it; rules_for_file keeps it.
-        let inserted = store.disable_rule("git", "never", "force-push to main").unwrap();
+        let inserted = store
+            .disable_rule("git", "never", "force-push to main")
+            .unwrap();
         assert!(inserted, "disable should insert a new row");
         let rails = store.load_guardrails().unwrap();
         assert_eq!(rails.len(), 1);
@@ -1462,12 +1564,16 @@ mod tests {
         assert!(!inserted_again);
 
         // Enable restores.
-        let removed = store.enable_rule("git", "never", "force-push to main").unwrap();
+        let removed = store
+            .enable_rule("git", "never", "force-push to main")
+            .unwrap();
         assert!(removed);
         assert_eq!(store.load_guardrails().unwrap().len(), 2);
 
         // Listing reports disabled rows in newest-first order.
-        store.disable_rule("cargo", "always", "run tests before commit").unwrap();
+        store
+            .disable_rule("cargo", "always", "run tests before commit")
+            .unwrap();
         let listed = store.list_disabled_rules().unwrap();
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].0, "cargo");
@@ -1494,13 +1600,19 @@ mod tests {
             expires_at: None,
             noenrich: false,
         };
-        store.upsert_file("CLAUDE.md", "x", &[t.clone()], "test").unwrap();
-        store.disable_rule("git", "never", "force-push to main").unwrap();
+        store
+            .upsert_file("CLAUDE.md", "x", &[t.clone()], "test")
+            .unwrap();
+        store
+            .disable_rule("git", "never", "force-push to main")
+            .unwrap();
         assert_eq!(store.load_guardrails().unwrap().len(), 0);
 
         // Simulate a re-scan: same content → upsert short-circuits, but force
         // a re-insert by changing the file content checksum.
-        store.upsert_file("CLAUDE.md", "x changed", &[t], "test").unwrap();
+        store
+            .upsert_file("CLAUDE.md", "x changed", &[t], "test")
+            .unwrap();
         assert_eq!(
             store.load_guardrails().unwrap().len(),
             0,
@@ -1517,7 +1629,8 @@ mod tests {
         // user_version=0.  Open via Store and verify migration v1 backfills
         // the missing columns idempotently.
         let id = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
-        let dir = std::env::temp_dir().join(format!("arai_test_bridge_{}_{}", std::process::id(), id));
+        let dir =
+            std::env::temp_dir().join(format!("arai_test_bridge_{}_{}", std::process::id(), id));
         std::fs::create_dir_all(&dir).unwrap();
         let db_path = dir.join("test.db");
 
@@ -1563,7 +1676,11 @@ mod tests {
         let v: i64 = conn
             .query_row("PRAGMA user_version", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(v, MIGRATIONS.len() as i64, "user_version should advance to target");
+        assert_eq!(
+            v,
+            MIGRATIONS.len() as i64,
+            "user_version should advance to target"
+        );
 
         let columns_for = |table: &str| -> Vec<String> {
             let mut stmt = conn
@@ -1577,11 +1694,17 @@ mod tests {
 
         let ri = columns_for("rule_intent");
         assert!(ri.contains(&"severity".to_string()), "severity backfilled");
-        assert!(ri.contains(&"severity_override".to_string()), "severity_override backfilled");
+        assert!(
+            ri.contains(&"severity_override".to_string()),
+            "severity_override backfilled"
+        );
 
         let tr = columns_for("triples");
         assert!(tr.contains(&"layer".to_string()), "layer backfilled");
-        assert!(tr.contains(&"expires_at".to_string()), "expires_at backfilled");
+        assert!(
+            tr.contains(&"expires_at".to_string()),
+            "expires_at backfilled"
+        );
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -19,10 +19,16 @@ pub fn is_enabled() -> bool {
     }
 
     // Standard opt-out env vars
-    if std::env::var("ARAI_TELEMETRY").map(|v| v == "off" || v == "0" || v == "false").unwrap_or(false) {
+    if std::env::var("ARAI_TELEMETRY")
+        .map(|v| v == "off" || v == "0" || v == "false")
+        .unwrap_or(false)
+    {
         return false;
     }
-    if std::env::var("DO_NOT_TRACK").map(|v| v == "1" || v == "true").unwrap_or(false) {
+    if std::env::var("DO_NOT_TRACK")
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false)
+    {
         return false;
     }
 
@@ -93,32 +99,50 @@ pub fn track_rule_fired(
     match_pct: u8,
     severity: &str,
 ) {
-    track(arai_base, "rule_fired", serde_json::json!({
-        "rule_hash": rule_hash(subject, predicate),
-        "tool_name": tool_name,
-        "hook_event": hook_event,
-        "match_pct": match_pct,
-        "severity": severity,
-    }));
+    track(
+        arai_base,
+        "rule_fired",
+        serde_json::json!({
+            "rule_hash": rule_hash(subject, predicate),
+            "tool_name": tool_name,
+            "hook_event": hook_event,
+            "match_pct": match_pct,
+            "severity": severity,
+        }),
+    );
 }
 
 /// Track an arai init event.
-pub fn track_init(arai_base: &Path, rule_count: usize, file_count: usize, tool_count: i64, enrichment: &str) {
-    track(arai_base, "arai_init", serde_json::json!({
-        "rule_count": rule_count,
-        "file_count": file_count,
-        "code_graph_tools": tool_count,
-        "enrichment_tier": enrichment,
-    }));
+pub fn track_init(
+    arai_base: &Path,
+    rule_count: usize,
+    file_count: usize,
+    tool_count: i64,
+    enrichment: &str,
+) {
+    track(
+        arai_base,
+        "arai_init",
+        serde_json::json!({
+            "rule_count": rule_count,
+            "file_count": file_count,
+            "code_graph_tools": tool_count,
+            "enrichment_tier": enrichment,
+        }),
+    );
 }
 
 /// Track hook latency.
 pub fn track_hook_latency(arai_base: &Path, hook_event: &str, latency_ms: u128, matched: bool) {
-    track(arai_base, "hook_latency", serde_json::json!({
-        "hook_event": hook_event,
-        "latency_ms": latency_ms,
-        "matched": matched,
-    }));
+    track(
+        arai_base,
+        "hook_latency",
+        serde_json::json!({
+            "hook_event": hook_event,
+            "latency_ms": latency_ms,
+            "matched": matched,
+        }),
+    );
 }
 
 /// Flush queued events to PostHog (called from non-hook commands like `arai init`).
@@ -152,12 +176,21 @@ pub fn flush(arai_base: &Path) {
     let batch: Vec<serde_json::Value> = events
         .iter()
         .map(|e| {
-            let mut props = e.get("properties").cloned().unwrap_or(serde_json::json!({}));
+            let mut props = e
+                .get("properties")
+                .cloned()
+                .unwrap_or(serde_json::json!({}));
             if let Some(obj) = props.as_object_mut() {
                 obj.insert("distinct_id".to_string(), serde_json::json!(distinct_id));
-                obj.insert("arai_version".to_string(), serde_json::json!(env!("CARGO_PKG_VERSION")));
+                obj.insert(
+                    "arai_version".to_string(),
+                    serde_json::json!(env!("CARGO_PKG_VERSION")),
+                );
                 obj.insert("os".to_string(), serde_json::json!(std::env::consts::OS));
-                obj.insert("arch".to_string(), serde_json::json!(std::env::consts::ARCH));
+                obj.insert(
+                    "arch".to_string(),
+                    serde_json::json!(std::env::consts::ARCH),
+                );
             }
             serde_json::json!({
                 "event": e.get("event").and_then(|v| v.as_str()).unwrap_or("unknown"),
@@ -181,10 +214,14 @@ pub fn flush(arai_base: &Path) {
     // Use curl in background to avoid adding HTTP deps to non-enrich builds
     std::process::Command::new("curl")
         .args([
-            "-sS", "-X", "POST",
+            "-sS",
+            "-X",
+            "POST",
             &format!("{POSTHOG_HOST}/batch/"),
-            "-H", "Content-Type: application/json",
-            "-d", &payload_str,
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            &payload_str,
         ])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -9,7 +9,11 @@ pub fn is_full_binary() -> bool {
 
 /// Get the current binary's variant name.
 pub fn current_variant() -> &'static str {
-    if is_full_binary() { "full" } else { "lean" }
+    if is_full_binary() {
+        "full"
+    } else {
+        "lean"
+    }
 }
 
 /// Run the upgrade flow.
@@ -37,9 +41,7 @@ pub fn run(full: bool, lean: bool) -> Result<(), String> {
     let current_exe = std::env::current_exe()
         .map_err(|e| format!("Could not determine current binary path: {e}"))?;
 
-    let url = format!(
-        "https://github.com/{REPO}/releases/download/{version}/{binary_name}"
-    );
+    let url = format!("https://github.com/{REPO}/releases/download/{version}/{binary_name}");
 
     let tmp_path = current_exe.with_extension("tmp");
 
@@ -135,7 +137,10 @@ fn detect_platform() -> Result<String, String> {
 
 fn fetch_latest_version() -> Result<String, String> {
     let output = std::process::Command::new("curl")
-        .args(["-sSf", &format!("https://api.github.com/repos/{REPO}/releases/latest")])
+        .args([
+            "-sSf",
+            &format!("https://api.github.com/repos/{REPO}/releases/latest"),
+        ])
         .output()
         .map_err(|e| format!("Failed to fetch version: {e}"))?;
 
@@ -166,8 +171,7 @@ fn download_file(url: &str, dest: &PathBuf) -> Result<(), String> {
         return Err(format!("Download failed: {stderr}"));
     }
 
-    let meta = std::fs::metadata(dest)
-        .map_err(|e| format!("Downloaded file not found: {e}"))?;
+    let meta = std::fs::metadata(dest).map_err(|e| format!("Downloaded file not found: {e}"))?;
 
     if meta.len() < 10000 {
         return Err(format!(

--- a/tests/hooks_safety.rs
+++ b/tests/hooks_safety.rs
@@ -62,9 +62,13 @@ fn run_hook(payload: &str, env: &[(&str, &str)]) -> (String, String, i32) {
 /// the bypass we explicitly closed in commit 15dcb96.
 #[test]
 fn pretooluse_malformed_json_produces_deny() {
-    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"x"#; // truncated
+    let payload =
+        r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"x"#; // truncated
     let (stdout, _stderr, code) = run_hook(payload, &[]);
-    assert_eq!(code, 0, "hook must exit 0 even on error so Claude Code reads stdout");
+    assert_eq!(
+        code, 0,
+        "hook must exit 0 even on error so Claude Code reads stdout"
+    );
     assert!(
         stdout.contains("\"permissionDecision\":\"deny\""),
         "expected deny in stdout, got: {stdout:?}"
@@ -85,7 +89,9 @@ fn spoofed_event_name_does_not_defeat_fail_closed() {
     // 1 MiB + 1 byte = oversize per MAX_HOOK_INPUT_BYTES; the hook errors
     // before it ever decides what to do.  The "event" claim in the JSON
     // is bogus on purpose.
-    let mut payload = String::from(r#"{"hook_event_name":"PreToolUseFOO","tool_name":"Bash","tool_input":{"command":""#);
+    let mut payload = String::from(
+        r#"{"hook_event_name":"PreToolUseFOO","tool_name":"Bash","tool_input":{"command":""#,
+    );
     payload.push_str(&"A".repeat(1024 * 1024));
     payload.push_str(r#""}}"#);
     let (stdout, _stderr, code) = run_hook(&payload, &[]);

--- a/tests/parser_coverage.rs
+++ b/tests/parser_coverage.rs
@@ -52,8 +52,9 @@ fn run_lint() -> Vec<Value> {
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let parsed: Value = serde_json::from_str(&stdout)
-        .unwrap_or_else(|e| panic!("arai lint --json output not valid JSON: {e}\n--- stdout ---\n{stdout}\n"));
+    let parsed: Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("arai lint --json output not valid JSON: {e}\n--- stdout ---\n{stdout}\n")
+    });
     parsed
         .as_array()
         .expect("expected top-level JSON array")

--- a/tests/verifier_base_directory_resolution.rs
+++ b/tests/verifier_base_directory_resolution.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 /// Verifier tests for the `base-directory-resolution` module.
 ///
 /// Contract: .taniwha/kupu/orchestrator/handoff/01KR8598KXT557344N231648RT/inputs/contract.md
@@ -21,9 +22,7 @@
 /// mutual exclusivity) are in `src/config.rs` and are run as part of `cargo test`.
 /// The verifier has independently reviewed those tests against the contract and
 /// confirmed their correctness; findings are in the verifier report.
-
 use std::process::Command;
-use std::path::PathBuf;
 
 /// Helper: find the arai binary (prefer debug build).
 fn arai_bin() -> PathBuf {
@@ -49,7 +48,8 @@ fn smoke_binary_handles_arai_base_dir_env_var() {
 
     // Use a temporary directory as ARAI_BASE_DIR to avoid touching the real home.
     let tmp = std::env::temp_dir().join(format!(
-        "arai_verifier_{}_{}", std::process::id(),
+        "arai_verifier_{}_{}",
+        std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()


### PR DESCRIPTION
## Summary

Two commits:

1. **\`style: cargo fmt sweep across the crate\`** — pure mechanical run of \`cargo fmt --all\` against v0.2.16. 23 files touched, +1995/-762, every diff is rustfmt's default decision. No semantic changes.
2. **\`ci: add \`cargo fmt --check\` gate to CI\`** — small parallel \`Rustfmt\` job in \`.github/workflows/ci.yml\` that runs \`cargo fmt --all -- --check\` so future PRs can't drift back into the unformatted state.

## Why now

The crate has been growing without an enforced format. Pre-sweep, \`cargo fmt --check\` reported 290+ diff blocks across all 20 source files. That accretion makes review noisier (you can't easily tell intent-changes from style-changes in a PR diff) and it never gets cheaper to catch up.

Pairs with the existing \`cargo clippy -- -D warnings\` step. Clippy already caught one issue locally I missed (the \`iter().any() vs contains()\` hit on PR #91 only surfaced in CI). \`cargo fmt --check\` closes the equivalent style channel.

## Reviewing

Look at commit 2 (\`ci: add cargo fmt --check gate\`) — that's the intentional change, 10 lines.

Commit 1 is the mechanical sweep — it's safe to scroll-and-rubber-stamp. Tools used:
- \`cargo fmt --all\` (no custom \`rustfmt.toml\` so all defaults)
- \`cargo test\` post-sweep: 283/284 passes (the one failure is the preexisting \`enrich::tests::test_resolve_api_config_no_config\` Ollama-env quirk, unaffected by formatting)

## Test plan

- [x] \`cargo fmt --all -- --check\` passes (exit 0)
- [x] \`cargo test\` — 283/284 passed (preexisting Ollama failure)
- [x] No source-file changes outside what \`cargo fmt\` produced (verified \`git diff --stat\` between the two commits — commit 2 is just \`.github/workflows/ci.yml\`)

## Coordinating with #101

[#101](https://github.com/taniwhaai/arai/pull/101) is the Cargo.toml profile-tweak PR. The two PRs touch disjoint files — no conflicts. Either merge order works. If both are merged, the new \`Rustfmt\` CI job will start running on every subsequent PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)