### PR TITLE
chore: release v0.2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.17] - 2026-05-11
+
+### Performance
+
+- *(release)* Panic=abort + codegen-units=1 — 4.3% smaller binary ([#101](https://github.com/taniwhaai/arai/pull/101))
+
+### Style+ci
+
+- Cargo fmt sweep + CI gate ([#102](https://github.com/taniwhaai/arai/pull/102))
+
+
 ## [0.2.16] - 2026-05-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "0.2.16"
+version = "0.2.17"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 0.2.16 -> 0.2.17

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.17] - 2026-05-11

### Performance

- *(release)* Panic=abort + codegen-units=1 — 4.3% smaller binary ([#101](https://github.com/taniwhaai/arai/pull/101))

### Style+ci

- Cargo fmt sweep + CI gate ([#102](https://github.com/taniwhaai/arai/pull/102))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).