### PR TITLE
chore: release v0.2.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.19] - 2026-05-14
+
+### Documentation
+
+- Surface hash-chain / MCP auth / cache sig + SOC 2 TSC mapping ([#106](https://github.com/taniwhaai/arai/pull/106))
+
+
 ### Documentation
 
 - *(compliance)* Surface the hash chain + `arai audit --verify`, MCP auth

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "0.2.18"
+version = "0.2.19"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 0.2.18 -> 0.2.19

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.19] - 2026-05-14

### Documentation

- Surface hash-chain / MCP auth / cache sig + SOC 2 TSC mapping ([#106](https://github.com/taniwhaai/arai/pull/106))


### Documentation

- *(compliance)* Surface the hash chain + `arai audit --verify`, MCP auth
  via `ARAI_MCP_AUTH_TOKEN`, `arai:extends` cache-at-rest signature,
  Windows ACL pin, and telemetry queue cap in the README, marketing site,
  and the procurement deliverable. Add an explicit SOC 2 Trust Service
  Criteria mapping (CC6.1 / CC6.6 / CC7.2 / CC7.3 / CC8.1 / CC9.2) to
  `docs/arai-compliance-features.docx` + PDF so a reviewer doesn't have
  to do the mapping themselves.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).