### PR TITLE
feat(audit): arai audit --purge for retention / deletion controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- *(audit)* **`arai audit --purge` for retention / deletion controls.**
+  Drops day-bucket files (and their `.head.` sidecars) under
+  `~/.taniwha/arai/audit/<project>/`. Two scoping forms:
+  `--older=N` (age-based retention; `--older=0` keeps only today) and
+  `--project=<slug>` (full project wipe — offboarding / decommission).
+  Today's day-bucket is always preserved so the live hook chain isn't
+  disturbed, and whole files are deleted (never individual lines) so the
+  hash chain on retained days stays valid. `--dry-run` + `--json` for a
+  pre-purge review. Refuses to run without an explicit scope so a bare
+  `arai audit --purge` can't accidentally nuke history. Closes the
+  deletion-on-demand gap flagged in #95 (item 5).
+
 ## [0.2.19] - 2026-05-14
 
 ### Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,9 @@ cargo run -- audit --json      # JSONL stream
 cargo run -- audit --event=Compliance   # Compliance verdicts (Pre/Post correlation)
 cargo run -- audit --outcome=ignored    # Rules the model ran despite a Pre-firing
 cargo run -- audit --rule alembic       # Filter audit by rule subject/predicate/object
+cargo run -- audit --verify             # Walk hash chain across every day-bucket
+cargo run -- audit --purge --older=90 --dry-run   # Plan a 90-day retention sweep
+cargo run -- audit --purge --project=old-proj     # Full wipe of one project's audit
 cargo run -- stats             # Aggregate the audit log (top rules, tools, days, compliance)
 cargo run -- stats --by-rule   # Just the per-rule compliance ratios
 cargo run -- severity          # List active severity overrides

--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ the enforcement.
   a `.head.YYYYMMDD` sidecar. `arai audit --verify` walks the chain across
   every day-bucket and exits non-zero on any tamper / reorder / deletion —
   drop it in a cron or pre-archive job to gate evidence integrity.
+- **Retention controls** — `arai audit --purge --older=90` drops day-buckets
+  older than 90 days; `arai audit --purge --project=<slug>` wipes a specific
+  project (offboarding / decommission). Today's bucket is always preserved
+  and whole files are deleted (never individual lines), so the hash chain on
+  retained days stays valid. Pair with `--dry-run` (and `--json`) for a
+  pre-purge review, or wire into a scheduled job for time-based retention
+  policy.
 - **Derivation trace per firing** — each rule entry records source file,
   line number, and parser layer (`from CLAUDE.md:42, layer-1 imperative`).
   Auditors can answer "why did this rule fire?" without code spelunking.

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -562,6 +562,151 @@ pub fn verify_chain(arai_base: &Path, project_slug: &str) -> Result<Vec<VerifyIs
     Ok(issues)
 }
 
+/// Plan/result of a single `purge` invocation against one project's audit
+/// directory.  When `dry_run` was passed, `removed_files` is the list the
+/// run *would* have deleted; otherwise it's what was actually deleted.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PurgeReport {
+    pub project_slug: String,
+    pub removed_files: Vec<PathBuf>,
+    pub removed_bytes: u64,
+    /// Whether today's day-bucket existed in the directory and was
+    /// preserved.  Today's file is always kept — it's the one a live hook
+    /// is currently appending to.
+    pub kept_today: bool,
+    pub dry_run: bool,
+}
+
+/// Delete audit-log day-buckets (and their `.head.YYYYMMDD` sidecars) for
+/// a single project.  Today's day-bucket is *always* preserved — the
+/// running `arai` hook is appending to it, and the hash chain head is
+/// cached in the sidecar.  Whole files are deleted; never individual
+/// lines, so the chain integrity of any retained file is undisturbed.
+///
+/// Arguments:
+/// - `arai_base`: state root (e.g. `~/.taniwha/arai`).
+/// - `target_slug`: project slug whose audit dir to walk (under
+///   `{arai_base}/audit/{target_slug}/`).
+/// - `older_than_days`: when `Some(n)`, only delete day-buckets whose
+///   `YYYYMMDD` date is strictly older than today minus `n` days.
+///   `Some(0)` deletes every day-bucket older than today (today itself
+///   still preserved).  `None` is "no age filter" — every non-today
+///   file in the dir is removed (full project wipe, e.g. for offboarding
+///   or project decommission).
+/// - `dry_run`: when true, return the planned removals without touching
+///   the filesystem.
+///
+/// Returns a `PurgeReport` regardless of whether the project's audit
+/// directory existed (an absent directory yields an empty report — not
+/// an error, because a nothing-to-do purge should succeed quietly).
+pub fn purge(
+    arai_base: &Path,
+    target_slug: &str,
+    older_than_days: Option<u32>,
+    dry_run: bool,
+) -> Result<PurgeReport, String> {
+    let dir = arai_base.join("audit").join(target_slug);
+    if !dir.exists() {
+        return Ok(PurgeReport {
+            project_slug: target_slug.to_string(),
+            removed_files: Vec::new(),
+            removed_bytes: 0,
+            kept_today: false,
+            dry_run,
+        });
+    }
+
+    let today = today_yyyymmdd();
+    let cutoff: Option<String> = older_than_days.map(yyyymmdd_n_days_ago);
+
+    let mut removed_files: Vec<PathBuf> = Vec::new();
+    let mut removed_bytes: u64 = 0;
+    let mut kept_today = false;
+
+    for entry in fs::read_dir(&dir).map_err(|e| format!("read audit dir: {e}"))? {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let path = entry.path();
+        let name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+
+        // Two filename shapes carry the YYYYMMDD date: `YYYYMMDD.jsonl`
+        // (log) and `.head.YYYYMMDD` (sidecar).  Anything else
+        // (`.arai_acl_set` on Windows, future markers, stray garbage) is
+        // left alone — `purge` is not a recursive `rm`.
+        let day = if let Some(stem) = name.strip_suffix(".jsonl") {
+            stem.to_string()
+        } else if let Some(rest) = name.strip_prefix(".head.") {
+            rest.to_string()
+        } else {
+            continue;
+        };
+
+        // Validate it parses as YYYYMMDD (8 ASCII digits) before treating
+        // it as a date.  A non-conforming name is left untouched — same
+        // principle as the file-type filter above.
+        if day.len() != 8 || !day.chars().all(|c| c.is_ascii_digit()) {
+            continue;
+        }
+
+        if day == today {
+            kept_today = true;
+            continue;
+        }
+
+        // String comparison on YYYYMMDD is correct lexicographically
+        // because the format is zero-padded and ordered.  `day < cutoff`
+        // means "this bucket is older than the cutoff date" — delete.
+        // `day >= cutoff` means "this bucket is the cutoff date or newer"
+        // — keep.
+        if let Some(cut) = &cutoff {
+            if day.as_str() >= cut.as_str() {
+                continue;
+            }
+        }
+
+        let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+        removed_bytes += size;
+        removed_files.push(path.clone());
+
+        if !dry_run {
+            // Best-effort: a removal that fails (read-only mount, race
+            // with another process) is surfaced in the report only as a
+            // path that's still on disk afterwards.  We don't unwind on
+            // partial failure — purging is idempotent and the next run
+            // will retry.
+            let _ = fs::remove_file(&path);
+        }
+    }
+
+    // Sort for deterministic output (and so tests don't need to sort).
+    removed_files.sort();
+
+    Ok(PurgeReport {
+        project_slug: target_slug.to_string(),
+        removed_files,
+        removed_bytes,
+        kept_today,
+        dry_run,
+    })
+}
+
+/// YYYYMMDD string for the calendar date `n` days before today (UTC).
+/// `n == 0` returns today's date.  Used by `purge` to compute the cutoff.
+fn yyyymmdd_n_days_ago(n: u32) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let then = now.saturating_sub((n as u64) * 86_400);
+    let (y, m, d, _, _, _) = epoch_to_civil(then);
+    format!("{:04}{:02}{:02}", y, m, d)
+}
+
 fn short(hash: &str) -> String {
     hash.chars().take(12).collect()
 }
@@ -857,6 +1002,179 @@ mod tests {
             mode, 0o700,
             "audit dir should be 0700 on Unix (got {mode:o})"
         );
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    /// Build a fresh audit dir under a unique temp base with the supplied
+    /// list of YYYYMMDD day-bucket dates (each as both `.jsonl` log and
+    /// `.head.` sidecar).  Returns the base path the caller hands to
+    /// `purge`.  Caller is responsible for cleanup.
+    fn make_purge_fixture(label: &str, slug: &str, days: &[&str]) -> std::path::PathBuf {
+        let base = fresh_tmp_base(label);
+        let dir = base.join("audit").join(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        for day in days {
+            std::fs::write(dir.join(format!("{day}.jsonl")), b"{}\n").unwrap();
+            std::fs::write(dir.join(format!(".head.{day}")), b"deadbeef\n").unwrap();
+        }
+        base
+    }
+
+    #[test]
+    fn test_purge_with_age_filter_keeps_recent_and_today() {
+        let today = today_yyyymmdd();
+        let yesterday = yyyymmdd_n_days_ago(1);
+        let ancient = yyyymmdd_n_days_ago(120);
+        let base = make_purge_fixture(
+            "purge_age",
+            "proj-x",
+            &[today.as_str(), yesterday.as_str(), ancient.as_str()],
+        );
+
+        // 90-day retention: today + yesterday survive, the 120-day-old
+        // bucket and its sidecar go.  Two files removed total.
+        let report = purge(&base, "proj-x", Some(90), false).unwrap();
+
+        assert!(report.kept_today, "today's bucket must always be preserved");
+        assert_eq!(
+            report.removed_files.len(),
+            2,
+            "expected log+sidecar for the ancient day, got {:?}",
+            report.removed_files
+        );
+        let dir = base.join("audit").join("proj-x");
+        assert!(dir.join(format!("{today}.jsonl")).exists());
+        assert!(dir.join(format!("{yesterday}.jsonl")).exists());
+        assert!(!dir.join(format!("{ancient}.jsonl")).exists());
+        assert!(!dir.join(format!(".head.{ancient}")).exists());
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn test_purge_dry_run_does_not_delete() {
+        let today = today_yyyymmdd();
+        let ancient = yyyymmdd_n_days_ago(200);
+        let base = make_purge_fixture(
+            "purge_dryrun",
+            "proj-y",
+            &[today.as_str(), ancient.as_str()],
+        );
+
+        let report = purge(&base, "proj-y", Some(30), true).unwrap();
+        assert!(report.dry_run);
+        assert_eq!(
+            report.removed_files.len(),
+            2,
+            "dry-run still reports the plan"
+        );
+
+        let dir = base.join("audit").join("proj-y");
+        assert!(
+            dir.join(format!("{ancient}.jsonl")).exists(),
+            "dry-run must not delete the file"
+        );
+        assert!(
+            dir.join(format!(".head.{ancient}")).exists(),
+            "dry-run must not delete the sidecar"
+        );
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn test_purge_without_age_filter_full_wipes_except_today() {
+        // Offboarding / decommission shape: no age filter, every
+        // day-bucket except today's goes.
+        let today = today_yyyymmdd();
+        let day_a = yyyymmdd_n_days_ago(3);
+        let day_b = yyyymmdd_n_days_ago(45);
+        let day_c = yyyymmdd_n_days_ago(400);
+        let base = make_purge_fixture(
+            "purge_wipe",
+            "old-employee",
+            &[
+                today.as_str(),
+                day_a.as_str(),
+                day_b.as_str(),
+                day_c.as_str(),
+            ],
+        );
+
+        let report = purge(&base, "old-employee", None, false).unwrap();
+        assert!(report.kept_today);
+        // 3 day-buckets * 2 files each = 6 paths removed.
+        assert_eq!(
+            report.removed_files.len(),
+            6,
+            "expected 3 logs + 3 sidecars; got {:?}",
+            report.removed_files
+        );
+        let dir = base.join("audit").join("old-employee");
+        assert!(dir.join(format!("{today}.jsonl")).exists());
+        for d in [&day_a, &day_b, &day_c] {
+            assert!(!dir.join(format!("{d}.jsonl")).exists());
+            assert!(!dir.join(format!(".head.{d}")).exists());
+        }
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn test_purge_ignores_non_audit_files_in_dir() {
+        // The Windows ACL marker (`.arai_acl_set`) and any stray file
+        // that doesn't match YYYYMMDD.jsonl or .head.YYYYMMDD must be
+        // left alone — purge is not a recursive `rm`.
+        let today = today_yyyymmdd();
+        let ancient = yyyymmdd_n_days_ago(500);
+        let base = make_purge_fixture(
+            "purge_ignores",
+            "proj-z",
+            &[today.as_str(), ancient.as_str()],
+        );
+        let dir = base.join("audit").join("proj-z");
+        std::fs::write(dir.join(".arai_acl_set"), b"").unwrap();
+        std::fs::write(dir.join("notes.txt"), b"keep me").unwrap();
+
+        let _ = purge(&base, "proj-z", None, false).unwrap();
+
+        assert!(dir.join(".arai_acl_set").exists(), "ACL marker must survive");
+        assert!(dir.join("notes.txt").exists(), "stray file must survive");
+        assert!(!dir.join(format!("{ancient}.jsonl")).exists());
+        assert!(dir.join(format!("{today}.jsonl")).exists());
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn test_purge_on_missing_project_dir_returns_empty_report() {
+        // Purging a project that has no audit dir at all is a no-op,
+        // not an error — covers fresh installs and slugs that were
+        // never written to.
+        let base = fresh_tmp_base("purge_missing");
+        let report = purge(&base, "nobody-here", None, false).unwrap();
+        assert!(report.removed_files.is_empty());
+        assert!(!report.kept_today);
+        assert_eq!(report.removed_bytes, 0);
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn test_purge_older_zero_keeps_only_today() {
+        // `--older=0` semantics: cutoff = today, so any day strictly
+        // less than today goes; today itself preserved.
+        let today = today_yyyymmdd();
+        let yesterday = yyyymmdd_n_days_ago(1);
+        let base = make_purge_fixture(
+            "purge_zero",
+            "proj-zero",
+            &[today.as_str(), yesterday.as_str()],
+        );
+        let report = purge(&base, "proj-zero", Some(0), false).unwrap();
+        assert!(report.kept_today);
+        assert_eq!(report.removed_files.len(), 2, "yesterday log + sidecar");
+        let dir = base.join("audit").join("proj-zero");
+        assert!(dir.join(format!("{today}.jsonl")).exists());
+        assert!(!dir.join(format!("{yesterday}.jsonl")).exists());
         std::fs::remove_dir_all(&base).ok();
     }
 }

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1137,7 +1137,10 @@ mod tests {
 
         let _ = purge(&base, "proj-z", None, false).unwrap();
 
-        assert!(dir.join(".arai_acl_set").exists(), "ACL marker must survive");
+        assert!(
+            dir.join(".arai_acl_set").exists(),
+            "ACL marker must survive"
+        );
         assert!(dir.join("notes.txt").exists(), "stray file must survive");
         assert!(!dir.join(format!("{ancient}.jsonl")).exists());
         assert!(dir.join(format!("{today}.jsonl")).exists());

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,33 @@ enum Commands {
         /// query.
         #[arg(long)]
         verify: bool,
+        /// Delete audit-log day-bucket files (and their `.head.` sidecars)
+        /// to support retention policy / GDPR-style deletion requests.
+        /// Refuses to run without either `--older` or `--project` scoping
+        /// — purging without an explicit scope is too easy to misfire.
+        /// Today's day-bucket is always preserved (the live hook is
+        /// appending to it).  Mutually exclusive with `--verify` and the
+        /// query filters.
+        #[arg(long)]
+        purge: bool,
+        /// With `--purge`: only delete day-buckets older than this many
+        /// days.  `--older=90` keeps the last 90 days; `--older=0` keeps
+        /// only today.  Without `--project`, scopes to the current
+        /// project (derived from CWD).
+        #[arg(long, value_name = "DAYS")]
+        older: Option<u32>,
+        /// With `--purge`: scope to this project slug instead of the
+        /// current project.  Combine with `--older` to limit by age;
+        /// without `--older`, performs a full audit wipe for that
+        /// project (offboarding / decommission).  See
+        /// `~/.taniwha/arai/audit/` for the slug list.
+        #[arg(long, value_name = "SLUG")]
+        project: Option<String>,
+        /// With `--purge`: list what would be removed without removing
+        /// anything.  Pair with `--json` for machine-readable output a
+        /// pre-purge review can diff against.
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Run the Ārai MCP server on stdio (for integration into Claude Code or
     /// any MCP-capable client).  Exposes `arai_add_guard` + `arai_list_guards`
@@ -293,7 +320,13 @@ fn main() {
             limit,
             json,
             verify,
-        } => cmd_audit(since, tool, event, outcome, rule, limit, json, verify),
+            purge,
+            older,
+            project,
+            dry_run,
+        } => cmd_audit(
+            since, tool, event, outcome, rule, limit, json, verify, purge, older, project, dry_run,
+        ),
         Commands::Mcp => mcp::run(),
         Commands::Lint { file, json } => cmd_lint(&file, json),
         Commands::Trust { add, remove } => cmd_trust(add, remove),
@@ -549,8 +582,62 @@ fn cmd_audit(
     limit: usize,
     json: bool,
     verify: bool,
+    purge: bool,
+    older: Option<u32>,
+    project: Option<String>,
+    dry_run: bool,
 ) -> Result<(), String> {
     let cfg = config::Config::load()?;
+
+    if verify && purge {
+        return Err("`--verify` and `--purge` are mutually exclusive".to_string());
+    }
+
+    // `--purge` is the second administrative subcommand alongside
+    // `--verify`.  Requires explicit scope (`--older` or `--project`)
+    // to avoid a bare `arai audit --purge` deleting everything.
+    if purge {
+        if older.is_none() && project.is_none() {
+            return Err(
+                "`--purge` requires `--older` and/or `--project` — refusing to purge \
+                 the current project's entire audit log without an explicit scope. \
+                 Use `--older=0` to delete every day-bucket except today's; use \
+                 `--project=<slug>` to target a specific project."
+                    .to_string(),
+            );
+        }
+        let target_slug = project.unwrap_or_else(|| cfg.project_slug());
+        let report = audit::purge(&cfg.arai_base_dir, &target_slug, older, dry_run)?;
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string(&report).map_err(|e| e.to_string())?
+            );
+        } else {
+            let verb = if dry_run { "would remove" } else { "removed" };
+            if report.removed_files.is_empty() {
+                println!(
+                    "{} 0 files from {} (nothing matched the scope)",
+                    verb, report.project_slug
+                );
+            } else {
+                println!(
+                    "{} {} file(s) ({} bytes) from {}",
+                    verb,
+                    report.removed_files.len(),
+                    report.removed_bytes,
+                    report.project_slug
+                );
+                for path in &report.removed_files {
+                    println!("  {}", path.display());
+                }
+            }
+            if report.kept_today {
+                println!("  (today's day-bucket preserved — live hook is appending to it)");
+            }
+        }
+        return Ok(());
+    }
 
     // `--verify` is an administrative subcommand — it doesn't care about
     // query filters, and short-circuits cmd_audit before the regular


### PR DESCRIPTION
## Summary

Closes the deletion-on-demand gap flagged in [#95](https://github.com/taniwhaai/arai/issues/95) item 5. Adds `arai audit --purge` so operators can implement retention policy (SOC 2 CC6.5 / CC7.2) and respond to GDPR / offboarding deletion requests against the local audit log.

Surface:

```
arai audit --purge --older=90              # 90-day retention (current project)
arai audit --purge --older=90 --dry-run    # plan-only
arai audit --purge --older=90 --dry-run --json
arai audit --purge --project=<slug>        # full wipe (offboarding / decommission)
arai audit --purge --project=<slug> --older=30
```

## Invariants

- **Today's day-bucket is always preserved.** The live hook is appending to it and the hash-chain head is cached in the `.head.YYYYMMDD` sidecar — deleting it mid-session would break the chain.
- **Whole files only — never individual lines.** The per-day SHA-256 chain integrity of any *retained* file is undisturbed, so [`arai audit --verify`](https://github.com/taniwhaai/arai/pull/104) still passes after a purge.
- **Refuses bare `--purge`.** Without `--older` and/or `--project`, the command returns a non-zero exit with guidance. Purging without an explicit scope is too easy to misfire.
- **Non-audit files left alone.** The Windows `.arai_acl_set` ACL marker and any stray files in the audit dir are not touched — `purge` is not a recursive `rm`.

## Tests

Six unit tests in `src/audit.rs`:

- `test_purge_with_age_filter_keeps_recent_and_today` — 90-day retention over today / yesterday / 120-days-ago fixture.
- `test_purge_dry_run_does_not_delete` — `--dry-run` plans but leaves the FS alone.
- `test_purge_without_age_filter_full_wipes_except_today` — offboarding shape.
- `test_purge_ignores_non_audit_files_in_dir` — `.arai_acl_set` and stray files survive.
- `test_purge_on_missing_project_dir_returns_empty_report` — no-op on absent project.
- `test_purge_older_zero_keeps_only_today` — `--older=0` edge case.

CLI-level scope validation (refuse bare `--purge`) lives in `cmd_audit` in `src/main.rs`.

## Background

This is one of the items from [the review #95](https://github.com/taniwhaai/arai/issues/95) — the audit log was unbounded JSONL with prompt previews and tool inputs. SOC 2 / privacy controls require both retention and the ability to delete on demand; the memory note ([feedback_arai_audit_retention](https://github.com/taniwhaai/arai/blob/main/CLAUDE.md)) confirms day-buckets stay the segmentation invariant — no auto-prune. Manual scoped purge is the right shape.

Pairs with the kete#1 / Arai scope re-check from the same review: the per-machine retention surface belongs in Arai; the org-level retention *policy enforcement* (push the policy down, observe compliance) is fleet-layer and stays in Kete.

## Test plan

- [ ] `cargo test audit` passes on CI (Linux runners — local Windows build environment is broken, see PR notes below).
- [ ] `cargo run -- audit --purge` (no scope) exits non-zero with the scope-required guidance.
- [ ] `cargo run -- audit --purge --older=0 --dry-run` lists every non-today day-bucket without deleting.
- [ ] After running with `--older=0` (non-dry-run) on a project with multiple days: `arai audit --verify` still passes for today.

## Notes

Local `cargo build` couldn't be run against this commit — the dev machine's MSVC linker is missing (only `link.exe` from Git Bash is on PATH). Code was self-reviewed against the existing `verify_chain` pattern in the same file; the public-surface types and existing helpers (`today_yyyymmdd`, `epoch_to_civil`, `fresh_tmp_base`) are reused. CI on Linux is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)