### PR TITLE
chore: release v0.2.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.20] - 2026-05-15
+
+### Added
+
+- *(audit)* Arai audit --purge for retention / deletion controls ([#108](https://github.com/taniwhaai/arai/pull/108))
+
+
 ### Added
 
 - *(audit)* **`arai audit --purge` for retention / deletion controls.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "0.2.19"
+version = "0.2.20"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 0.2.19 -> 0.2.20

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.20] - 2026-05-15

### Added

- *(audit)* Arai audit --purge for retention / deletion controls ([#108](https://github.com/taniwhaai/arai/pull/108))


### Added

- *(audit)* **`arai audit --purge` for retention / deletion controls.**
  Drops day-bucket files (and their `.head.` sidecars) under
  `~/.taniwha/arai/audit/<project>/`. Two scoping forms:
  `--older=N` (age-based retention; `--older=0` keeps only today) and
  `--project=<slug>` (full project wipe — offboarding / decommission).
  Today's day-bucket is always preserved so the live hook chain isn't
  disturbed, and whole files are deleted (never individual lines) so the
  hash chain on retained days stays valid. `--dry-run` + `--json` for a
  pre-purge review. Refuses to run without an explicit scope so a bare
  `arai audit --purge` can't accidentally nuke history. Closes the
  deletion-on-demand gap flagged in #95 (item 5).
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).