### PR TITLE
Close four open issues: arai migrate, intent/compliance integration tests, rules-file spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ cargo run -- scan --enrich-llm # Enrich rules via LLM
 cargo run -- add "Never X"     # Add a manual rule
 cargo run -- audit             # Tail the local firing log (today)
 cargo run -- audit --json      # JSONL stream
+cargo run -- audit --verify    # Verify SHA-256 hash chain across all day-buckets
 cargo run -- audit --event=Compliance   # Compliance verdicts (Pre/Post correlation)
 cargo run -- audit --outcome=ignored    # Rules the model ran despite a Pre-firing
 cargo run -- audit --rule alembic       # Filter audit by rule subject/predicate/object
@@ -34,6 +35,8 @@ cargo run -- lint CLAUDE.md    # Parse a file and preview extracted rules, no DB
 cargo run -- test scenarios/alembic-migration.json  # Replay the canonical scenario
 cargo run -- record --since=1h # Build scenarios from recent audit entries
 cargo run -- trust --add <url> # Approve a URL for arai:extends
+cargo run -- migrate           # Move legacy ~/.arai → ~/.taniwha/arai (prompted, default no)
+cargo run -- migrate --yes     # Non-interactive migration (for scripts)
 cargo run -- mcp               # Run the MCP server on stdio (blocks on stdin)
 echo '{"tool_name":"Bash","tool_input":{"command":"git push"}}' | cargo run -- guardrails --match-stdin
 ARAI_DENY_MODE=off cargo run -- guardrails --match-stdin  # Advise-only (no deny)
@@ -52,6 +55,7 @@ src/
 ├── hooks.rs              # Hook protocol — PreToolUse/PostToolUse/UserPromptSubmit + FileChanged/InstructionsLoaded auto-rescan; severity → deny/allow
 ├── init.rs               # `arai init` flow — discover → extract → classify → scan → hook inject
 ├── intent.rs             # Intent classification — action, timing, tool scope, severity
+├── migrate.rs            # `arai migrate` — move legacy ~/.arai → ~/.taniwha/arai (prompted)
 ├── session.rs            # Session state — prerequisite tracking across tool calls
 ├── code_scanner.rs       # tree-sitter AST parsing — import extraction for 7 languages
 ├── enrich.rs             # Tier 2 (ONNX sentence transformer) + Tier 3 (LLM shell-out)

--- a/docs/rules-file-spec.md
+++ b/docs/rules-file-spec.md
@@ -1,0 +1,265 @@
+# Canonical rules-file spec (v1)
+
+**Status:** draft for review.
+**Scope:** resolves [#75](https://github.com/taniwhaai/arai/issues/75) (format spike), [#76](https://github.com/taniwhaai/arai/issues/76) (schema design), and [#79](https://github.com/taniwhaai/arai/issues/79) (rule-pack accommodation).
+**Out of scope:** `arai migrate` (#78), `arai sync` (#77), rule-pack publication.
+
+---
+
+## Why a canonical file
+
+Today, Arai reads rules from whatever instruction file each tool happens to use — `CLAUDE.md`, `.cursorrules`, `.windsurfrules`, `.github/copilot-instructions.md`. Each format has its own conventions, and the rules drift: a `should not` added to `CLAUDE.md` to fix a Claude misbehaviour never makes it to Cursor, because the maintainer forgot the second file existed.
+
+A canonical `arai.toml` (the *one* file you commit, version-controlled, schema-checked) becomes the source of truth. `arai sync` (#77) writes the per-tool files. `arai migrate` (#78) bootstraps the canonical file from whatever rules Arai's parser can already extract.
+
+This document fixes the file's format and schema so those two pieces of work can begin.
+
+---
+
+## Part 1 — Format spike (resolves #75)
+
+The brief recommended TOML; the spike confirms it. Below are the same four rules authored in both formats so a reader can judge.
+
+### Sample rule set: alembic + git push + secrets + test-before-commit
+
+**TOML:**
+
+```toml
+[meta]
+schema_version = 1
+
+[[rule]]
+id = "alembic-no-handwrite"
+description = "Never hand-write Alembic migrations — let `alembic revision --autogenerate` produce them"
+when.tool = ["Write"]
+when.path = ["**/migrations/versions/*.py", "**/alembic/versions/*.py"]
+then.action = "block"
+then.message = "Hand-writing migrations bypasses schema-drift detection. Use `alembic revision --autogenerate -m <slug>` instead."
+severity = "block"
+
+[[rule]]
+id = "git-force-push-main"
+description = "Refuse force-pushes targeting main or master"
+when.tool = ["Bash"]
+when.command_pattern = "^git push.*--force.*\\b(main|master)\\b"
+then.action = "block"
+then.message = "Force-pushing to a protected branch overwrites peer history. If you really mean it, run the command yourself outside the agent."
+severity = "block"
+
+[[rule]]
+id = "no-committed-secrets"
+description = "Block any Write that looks like it contains an AWS access key"
+when.tool = ["Write", "Edit"]
+when.content_pattern = "AKIA[0-9A-Z]{16}"
+then.action = "block"
+then.message = "That looks like an AWS access key. Move it to environment variables or a secret manager."
+severity = "block"
+
+[[rule]]
+id = "test-before-push"
+description = "Encourage running tests before pushing"
+when.tool = ["Bash"]
+when.command_pattern = "^git push"
+when.session_lacks = ["cargo test", "pytest", "npm test"]
+then.action = "warn"
+then.message = "No test invocation recorded in this session. Consider running tests before pushing."
+severity = "inform"
+```
+
+**YAML:**
+
+```yaml
+meta:
+  schema_version: 1
+
+rules:
+  - id: alembic-no-handwrite
+    description: Never hand-write Alembic migrations — let `alembic revision --autogenerate` produce them
+    when:
+      tool: [Write]
+      path:
+        - "**/migrations/versions/*.py"
+        - "**/alembic/versions/*.py"
+    then:
+      action: block
+      message: >
+        Hand-writing migrations bypasses schema-drift detection.
+        Use `alembic revision --autogenerate -m <slug>` instead.
+    severity: block
+
+  - id: git-force-push-main
+    description: Refuse force-pushes targeting main or master
+    when:
+      tool: [Bash]
+      command_pattern: "^git push.*--force.*\\b(main|master)\\b"
+    then:
+      action: block
+      message: >
+        Force-pushing to a protected branch overwrites peer history.
+        If you really mean it, run the command yourself outside the agent.
+    severity: block
+
+  - id: no-committed-secrets
+    description: Block any Write that looks like it contains an AWS access key
+    when:
+      tool: [Write, Edit]
+      content_pattern: "AKIA[0-9A-Z]{16}"
+    then:
+      action: block
+      message: That looks like an AWS access key. Move it to environment variables or a secret manager.
+    severity: block
+
+  - id: test-before-push
+    description: Encourage running tests before pushing
+    when:
+      tool: [Bash]
+      command_pattern: "^git push"
+      session_lacks: [cargo test, pytest, npm test]
+    then:
+      action: warn
+      message: No test invocation recorded in this session. Consider running tests before pushing.
+    severity: inform
+```
+
+### What the spike found
+
+**TOML wins.** Three reasons that matter in practice:
+
+1. **Indentation isn't load-bearing.** The YAML samples above need careful attention to where `when:` and `then:` indent — paste into a different editor and reflow can silently change meaning. Non-technical contributors hit this. TOML doesn't have that surface.
+2. **No quoting ambiguity on patterns.** `command_pattern: "^git push.*--force.*\\b(main|master)\\b"` in YAML needs both outer quotes *and* the right escaping discipline; YAML's "is this a string or a multi-doc anchor or a tag" parsing is fiddly when the value contains `&`, `*`, `:`, `<`, `>`, `|`, `!`, or unquoted leading `-`. TOML strings are just strings.
+3. **Comments are first-class in both, but TOML's `#` matches the existing CLAUDE.md / `.cursorrules` convention** users are already used to. The cognitive switching cost is lower.
+
+YAML's only meaningful win is multi-line strings (`>` folded scalar). TOML handles this with `"""..."""` blocks; that's enough. There is no scenario where YAML is materially easier for a hand-authoring contributor.
+
+**Anchors and includes:** YAML's `&anchor` / `<<: *anchor` looks useful for rule packs (factor a shared `when.path` set and reference it), but the moment a contributor needs to read someone else's anchored YAML they have to learn the syntax. The TOML equivalent is just naming a `[fragments.alembic_paths]` table and referencing it from a code-side composition step (`extends = ["packs/alembic"]`, expanded by `arai sync`). The expansion is explicit, which is the right tradeoff for a policy file.
+
+**Decision:** `arai.toml`. The schema below assumes TOML throughout.
+
+---
+
+## Part 2 — Schema (resolves #76)
+
+The v1 schema fixes the minimum needed to make `arai sync` (#77) and `arai migrate` (#78) implementable. Anything not listed is deliberately out of scope for v1.
+
+### Top-level layout
+
+```toml
+[meta]
+schema_version = 1               # required; bump on incompatible change
+project = "arai"                 # optional; pure documentation
+
+# Optional — pack references (see Part 3). Each entry is a URL or
+# shorthand recognised by Arai's trust list (`arai trust --add`).
+extends = [
+    "taniwhaai/rules-fastapi-alembic@v1.0.0",
+]
+
+# Rules are an array of inline tables.  Order doesn't matter for matching;
+# `arai sync` writes per-tool files in id order.
+[[rule]]
+id = "..."
+...
+```
+
+### Per-rule fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | Stable, kebab-case, project-unique. Survives renames; appears in audit log. |
+| `description` | string | yes | Free-form prose. The human-readable "why this rule exists". Not shown to the agent. |
+| `when.tool` | `[string]` | yes | Arai tool names: `Bash`, `Write`, `Edit`, `NotebookEdit`, `Read`, `Glob`, `Grep`, ... or `"*"`. |
+| `when.path` | `[string]` | no | Glob patterns matched against the tool's target path (Write/Edit/Read). Multiple = OR. |
+| `when.command_pattern` | string (regex) | no | Regex over `Bash` command strings. Mutually exclusive with `when.path`. |
+| `when.content_pattern` | string (regex) | no | Regex over file content being written (Write) or the patch being applied (Edit). |
+| `when.session_lacks` | `[string]` | no | Strings that must NOT have appeared in any Bash invocation in this session. Used for prerequisite rules (e.g. "tests before push"). |
+| `then.action` | `"block" \| "warn" \| "allow"` | yes | What Arai does on match. `block` denies the tool call; `warn` injects context; `allow` is an explicit positive (overrides a more general rule, see "exceptions" below). |
+| `then.message` | string | yes | Shown to the agent as `additionalContext` (warn) or `deny.reason` (block). Plain text; multi-line OK. |
+| `severity` | `"block" \| "warn" \| "inform"` | yes | Routing for the existing severity-aware enforcement in `intent.rs`. Usually matches `then.action`; `severity = "inform"` with `then.action = "warn"` is a soft nudge. |
+| `expires` | string (`YYYY-MM-DD`) | no | Mirrors the existing `(expires YYYY-MM-DD)` annotation; rule is silently dropped after the date. |
+
+### Exceptions and overrides
+
+A single `[[rule]]` block expresses one positive or negative rule. To say "Edit allowed but Write blocked for a path", write two rules and let action selection resolve them:
+
+```toml
+[[rule]]
+id = "alembic-no-handwrite"
+when.tool = ["Write"]
+when.path = ["**/migrations/versions/*.py"]
+then.action = "block"
+severity = "block"
+then.message = "..."
+
+[[rule]]
+id = "alembic-edits-fine"
+when.tool = ["Edit"]
+when.path = ["**/migrations/versions/*.py"]
+then.action = "allow"
+severity = "inform"
+then.message = "(no-op — editing existing migrations is fine)"
+```
+
+Conflict resolution: most-specific wins; ties resolved by `action` priority `block > warn > allow`. This matches Arai's existing severity ordering and avoids inventing a new precedence model.
+
+### Worked example: alembic end-to-end
+
+A complete `arai.toml` that produces the same enforcement as today's prose CLAUDE.md `Never hand-write Alembic migrations` rule, including the "editing existing migrations is fine" exception, looks like:
+
+```toml
+[meta]
+schema_version = 1
+
+[[rule]]
+id = "alembic-no-handwrite"
+description = "Force migrations through `alembic revision --autogenerate`"
+when.tool = ["Write"]
+when.path = ["**/migrations/versions/*.py", "**/alembic/versions/*.py"]
+then.action = "block"
+then.message = """\
+Hand-writing migrations bypasses schema-drift detection.
+Use `alembic revision --autogenerate -m <slug>` instead — \
+it inspects the SQLAlchemy models and emits the diff for you."""
+severity = "block"
+
+[[rule]]
+id = "alembic-edits-fine"
+description = "Editing an already-generated migration is fine — only creation is restricted"
+when.tool = ["Edit"]
+when.path = ["**/migrations/versions/*.py", "**/alembic/versions/*.py"]
+then.action = "allow"
+then.message = "(no-op — explicit override of alembic-no-handwrite for Edit)"
+severity = "inform"
+```
+
+`arai sync` will fan this out to `CLAUDE.md`, `.cursorrules`, etc., using each tool's preferred conventions. The `id` is preserved in audit-log entries so post-hoc analysis (`arai audit --rule alembic-no-handwrite`) joins cleanly across tools.
+
+---
+
+## Part 3 — Rule-pack accommodation (resolves #79)
+
+Rule packs (FastAPI + alembic + pytest; Next.js + Prisma; etc.) are explicitly out of scope for v1. But the schema must not need a breaking change when packs ship. Three points to verify:
+
+1. **`extends` field is reserved at the top level.** Already shown above. The array contains entries that are either URLs (HTTPS only, matching `arai:extends` precedent in `src/extends.rs`) or shorthand identifiers resolved against a future registry. v1 parser MUST recognise this field and either inline-expand it (when packs ship) or warn-and-ignore (now). The latter means a user can write `extends = []` today without breakage.
+
+2. **Pinned-in-canonical vs inherited-from-pack** is distinguished by the `id` namespace. Pack-imported rules use prefixed ids (`fastapi-alembic.no-handwrite`); locally-pinned overrides drop the prefix (`my-no-handwrite`) and `then.action`/`severity` from the local entry wins over the pack version with the same suffix. No new field needed — convention only.
+
+3. **Trust model for packs** reuses the existing `arai trust --add` list from #29 / `src/extends.rs`. URL packs are subject to the same HTTPS + 24h-cache + 512 KB cap. Shorthand packs (`taniwhaai/rules-fastapi-alembic`) resolve via a future registry; v1 schema doesn't commit to one, and the parser MUST surface a "shorthand not yet supported" error if it sees one. No silent failure.
+
+**Conclusion for #79:** the v1 schema accommodates packs without a breaking change. The only thing v1 has to *do* is reserve the `extends` top-level field name and define id-prefix conventions. Both are in this spec.
+
+---
+
+## What ships in v1
+
+1. The `arai.toml` file format (TOML, per Part 1).
+2. The schema defined in Part 2: per-rule `when` / `then` / `severity` / `expires`.
+3. A reserved `extends` field at the top level and a documented id-prefix convention (Part 3).
+4. Parser warn-and-ignore for any field not in the schema (forwards compatibility for v2 additions).
+
+What does *not* ship in v1: rule-pack publication, registry resolution, semver version pinning, signature verification on packs. These are tracked in #29 and the pack-publication discussion that grows out of #79.
+
+## Open questions for review
+
+- **`then.action = "allow"` semantics.** This spec treats it as an explicit positive override (Part 2). Alternative: drop it entirely and rely on absence-of-rule. Keeping it lets the alembic-edits-fine pattern stay explicit, which reads better in code review. Recommended: keep.
+- **Glob vs regex on `when.path`.** Spec says glob. Regex is more powerful but easier to write wrong. Rust crates exist for both (`globset`, `regex`). Recommended: glob; users who need regex use `when.command_pattern` for `Bash` or escalate to v2.
+- **`severity = "inform"` with `then.action = "block"`.** Currently the spec says these usually agree but doesn't forbid the mismatch. Should the schema validate it? Recommended: no — the mismatch is sometimes meaningful (e.g. a block whose audit-log routing should be quiet).

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod hooks;
 mod init;
 mod intent;
 mod mcp;
+mod migrate;
 mod parser;
 mod scenarios;
 mod session;
@@ -265,6 +266,20 @@ enum Commands {
         /// triple-id of the rule to re-enable.
         triple_id: i64,
     },
+    /// Move data from the legacy `~/.arai` layout to the current
+    /// `~/.taniwha/arai` layout.  Prompts before moving anything; default
+    /// answer is "no".  If you decline, a `.migrate_declined` marker is
+    /// written so re-running this command (or any future auto-trigger)
+    /// won't re-prompt until you delete it.
+    ///
+    /// Examples:
+    ///   arai migrate           # interactive, default no
+    ///   arai migrate --yes     # non-interactive, proceed
+    Migrate {
+        /// Skip the interactive prompt and proceed.  Use in scripts.
+        #[arg(long)]
+        yes: bool,
+    },
     /// Explain which guardrails would fire on a hypothetical tool call —
     /// useful for debugging "why did this rule fire?" without running the
     /// hook live.  Pass either a Bash command or `--tool Edit <path>`.
@@ -347,6 +362,7 @@ fn main() {
         Commands::Diff { file, json } => cmd_diff(&file, json),
         Commands::Disable { triple_id } => cmd_disable(triple_id),
         Commands::Enable { triple_id } => cmd_enable(triple_id),
+        Commands::Migrate { yes } => cmd_migrate(yes),
         Commands::Why {
             input,
             tool,
@@ -570,6 +586,20 @@ fn chrono_now() -> String {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default();
     format!("{}", now.as_secs())
+}
+
+fn cmd_migrate(yes: bool) -> Result<(), String> {
+    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+    // Resolve the project root the same way config::load does, so a
+    // repo-local `.arai` next to the cwd is detected.  Failing to find one
+    // (e.g. running `arai migrate` from outside any git repo) is fine — the
+    // migrate flow only needs the home dir.
+    let repo_root = std::env::current_dir().ok();
+    if yes {
+        migrate::run_with_confirm(&home, repo_root.as_deref(), |_| true)
+    } else {
+        migrate::run(&home, repo_root.as_deref())
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -816,6 +846,7 @@ fn cmd_lint(path: &str, json: bool) -> Result<(), String> {
                     "action": intent.action.as_str(),
                     "timing": format!("{:?}", intent.timing),
                     "tools": intent.tools,
+                    "severity": intent.severity.as_str(),
                 })
             })
             .collect();

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,0 +1,495 @@
+//! `arai migrate` — move data from the legacy `~/.arai` layout to the
+//! current `~/.taniwha/arai` layout.
+//!
+//! The path resolver in `config::resolve_base_dir` already keeps an existing
+//! `~/.arai` working (branch 4, with a deprecation notice).  This module
+//! handles the actual *move* — opt-in, prompted, idempotent.
+//!
+//! Flow:
+//!   1. Detect: is there a legacy `~/.arai`?  Is the new `~/.taniwha/arai`
+//!      already populated?  Is there a marker saying the user declined a
+//!      previous prompt?
+//!   2. Summarise: count files + total size so the prompt has substance.
+//!   3. Prompt (default "no"): explicit y/N, no surprises.
+//!   4. Move: `fs::rename` if possible (same filesystem), otherwise
+//!      copy-then-delete; on success, leave a marker file at the old
+//!      location pointing at the new one for the deprecation window.
+//!   5. Decline: drop a `.migrate_declined` marker under `~/.taniwha/arai`
+//!      so re-running `arai migrate` (or any auto-trigger from init) won't
+//!      re-prompt.
+//!
+//! Repo-local `<repo>/.arai` is detected as a second candidate but its
+//! migration target is also `~/.taniwha/arai` — Arai never wrote project-
+//! scoped state into a repo-local directory in practice, so encountering
+//! one means a manual artefact; we warn and skip rather than silently
+//! merging.
+
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+/// Marker file written under the *new* base after a confirmed decline.
+/// Path: `{new_base}/.migrate_declined`.
+const DECLINE_MARKER: &str = ".migrate_declined";
+
+/// Marker file left at the *old* base after a successful migration, so a
+/// user revisiting `~/.arai` understands where their data went and that the
+/// move was intentional.  Path: `{old_base}/MOVED-TO-TANIWHA.txt`.
+const MOVED_MARKER: &str = "MOVED-TO-TANIWHA.txt";
+
+/// What `detect` found.  Drives the rest of the flow.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Detected {
+    /// Nothing to do — no legacy `~/.arai`, or the user already declined.
+    NothingToMigrate { reason: String },
+    /// New base is already populated and would be overwritten.  Abort with
+    /// a message instead of merging.
+    NewBaseInUse { new_base: PathBuf },
+    /// Legacy path exists and looks safe to move.
+    Found {
+        old_base: PathBuf,
+        new_base: PathBuf,
+        file_count: u64,
+        total_bytes: u64,
+        repo_local_path: Option<PathBuf>,
+    },
+}
+
+/// Run the migration end-to-end.  Pure for the prompt/IO seam — the
+/// `confirm` closure decides whether to proceed.  Returning closures lets
+/// tests skip the interactive prompt without monkey-patching stdin.
+///
+/// Exits with `Ok(())` on every documented outcome (nothing-to-migrate,
+/// decline, successful move).  Returns `Err` only for genuine IO failures
+/// that prevent any safe progression.
+pub fn run(home_dir: &Path, repo_root: Option<&Path>) -> Result<(), String> {
+    run_with_confirm(home_dir, repo_root, prompt_default_no)
+}
+
+/// Variant of [`run`] that accepts a confirmation closure — used by tests
+/// to drive accept/decline deterministically.
+pub fn run_with_confirm<F>(
+    home_dir: &Path,
+    repo_root: Option<&Path>,
+    confirm: F,
+) -> Result<(), String>
+where
+    F: FnOnce(&Detected) -> bool,
+{
+    let detected = detect(home_dir, repo_root);
+
+    match &detected {
+        Detected::NothingToMigrate { reason } => {
+            println!("arai migrate: {reason}");
+            Ok(())
+        }
+        Detected::NewBaseInUse { new_base } => {
+            println!(
+                "arai migrate: {} already exists and is non-empty.\n\
+                 Refusing to overwrite.  Remove or back up the new directory \
+                 first if you want to re-migrate from the legacy layout.",
+                new_base.display(),
+            );
+            Ok(())
+        }
+        Detected::Found {
+            old_base,
+            new_base,
+            file_count,
+            total_bytes,
+            repo_local_path,
+        } => {
+            print_summary(
+                old_base,
+                new_base,
+                *file_count,
+                *total_bytes,
+                repo_local_path.as_deref(),
+            );
+            if !confirm(&detected) {
+                write_decline_marker(new_base)?;
+                println!(
+                    "arai migrate: declined.  Marker written to {} — \
+                     re-run `arai migrate` to revisit.",
+                    new_base.join(DECLINE_MARKER).display(),
+                );
+                return Ok(());
+            }
+            perform_move(old_base, new_base)?;
+            println!(
+                "arai migrate: moved {} → {} ({} file(s), {} bytes).",
+                old_base.display(),
+                new_base.display(),
+                file_count,
+                total_bytes,
+            );
+            if let Some(repo) = repo_local_path {
+                println!(
+                    "arai migrate: also detected repo-local {} — not moved \
+                     automatically (manual artefact; inspect and delete by hand).",
+                    repo.display(),
+                );
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Pure detection — no IO beyond `stat`/`read_dir`.
+pub fn detect(home_dir: &Path, repo_root: Option<&Path>) -> Detected {
+    let old_base = home_dir.join(".arai");
+    let new_base = home_dir.join(".taniwha").join("arai");
+
+    let repo_local_path = repo_root
+        .map(|r| r.join(".arai"))
+        .filter(|p| p.exists() && p != &old_base);
+
+    if !old_base.exists() {
+        return Detected::NothingToMigrate {
+            reason: format!("no legacy directory at {}", old_base.display()),
+        };
+    }
+
+    // Honour a previous decline.
+    if new_base.join(DECLINE_MARKER).exists() {
+        return Detected::NothingToMigrate {
+            reason: format!(
+                "previous decline recorded at {} — delete it to re-prompt",
+                new_base.join(DECLINE_MARKER).display(),
+            ),
+        };
+    }
+
+    // If the new base already has content beyond the decline marker, we
+    // refuse to merge — moving on top would lose either side's state.
+    if new_base.exists() && has_real_content(&new_base) {
+        return Detected::NewBaseInUse { new_base };
+    }
+
+    let (file_count, total_bytes) = walk_size(&old_base);
+    Detected::Found {
+        old_base,
+        new_base,
+        file_count,
+        total_bytes,
+        repo_local_path,
+    }
+}
+
+fn has_real_content(dir: &Path) -> bool {
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return false,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str == DECLINE_MARKER {
+            continue;
+        }
+        return true;
+    }
+    false
+}
+
+fn walk_size(dir: &Path) -> (u64, u64) {
+    let mut files = 0u64;
+    let mut bytes = 0u64;
+    let mut stack: Vec<PathBuf> = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let entries = match fs::read_dir(&d) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let ft = match entry.file_type() {
+                Ok(ft) => ft,
+                Err(_) => continue,
+            };
+            if ft.is_dir() {
+                stack.push(path);
+            } else if ft.is_file() {
+                files += 1;
+                if let Ok(meta) = entry.metadata() {
+                    bytes += meta.len();
+                }
+            }
+        }
+    }
+    (files, bytes)
+}
+
+fn print_summary(
+    old_base: &Path,
+    new_base: &Path,
+    file_count: u64,
+    total_bytes: u64,
+    repo_local_path: Option<&Path>,
+) {
+    println!("arai migrate — legacy layout detected.");
+    println!("  from: {}", old_base.display());
+    println!("    to: {}", new_base.display());
+    println!(
+        "    {} file(s), {} ({} bytes)",
+        file_count,
+        human_size(total_bytes),
+        total_bytes,
+    );
+    if let Some(repo) = repo_local_path {
+        println!(
+            "  also: {} (repo-local; will NOT be moved automatically)",
+            repo.display(),
+        );
+    }
+}
+
+fn human_size(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = 1024 * KB;
+    const GB: u64 = 1024 * MB;
+    if bytes >= GB {
+        format!("{:.2} GiB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MiB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} KiB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+fn prompt_default_no(_d: &Detected) -> bool {
+    print!("\nProceed with migration? [y/N]: ");
+    let _ = io::stdout().flush();
+    let mut input = String::new();
+    if io::stdin().read_line(&mut input).is_err() {
+        return false;
+    }
+    matches!(input.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+}
+
+fn write_decline_marker(new_base: &Path) -> Result<(), String> {
+    fs::create_dir_all(new_base).map_err(|e| format!("create {}: {}", new_base.display(), e))?;
+    let marker = new_base.join(DECLINE_MARKER);
+    fs::write(
+        &marker,
+        b"User declined `arai migrate`. Delete this file to re-prompt.\n",
+    )
+    .map_err(|e| format!("write {}: {}", marker.display(), e))
+}
+
+fn perform_move(old_base: &Path, new_base: &Path) -> Result<(), String> {
+    if let Some(parent) = new_base.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("create {}: {}", parent.display(), e))?;
+    }
+
+    // If the new base exists but is empty (or only holds the decline
+    // marker), remove it so `rename` has a clear target on platforms that
+    // require it.
+    if new_base.exists() {
+        let marker = new_base.join(DECLINE_MARKER);
+        if marker.exists() {
+            let _ = fs::remove_file(&marker);
+        }
+        // Best-effort empty-dir removal; if anything else is present
+        // detect() should already have flagged NewBaseInUse.
+        let _ = fs::remove_dir(new_base);
+    }
+
+    // Try the cheap rename first; fall back to recursive copy + delete
+    // when it fails (cross-device on Linux, ACL quirks on Windows).
+    if fs::rename(old_base, new_base).is_err() {
+        copy_dir_recursive(old_base, new_base)?;
+        fs::remove_dir_all(old_base)
+            .map_err(|e| format!("remove {}: {}", old_base.display(), e))?;
+    }
+
+    // Leave a forwarding marker at the old location.  Best-effort —
+    // creating it inside a directory we just removed means we have to
+    // recreate the dir, which would be misleading; only write if the
+    // parent still exists (i.e. the user has other ~/.arai siblings).
+    if let Some(parent) = old_base.parent() {
+        if parent.exists() {
+            let marker = parent.join(MOVED_MARKER);
+            let _ = fs::write(
+                &marker,
+                format!(
+                    "Arai data was moved to {} on `arai migrate`.\n\
+                     The legacy ~/.arai directory is no longer used.\n",
+                    new_base.display(),
+                ),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {
+    fs::create_dir_all(dst).map_err(|e| format!("create {}: {}", dst.display(), e))?;
+    let entries = fs::read_dir(src).map_err(|e| format!("read {}: {}", src.display(), e))?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let dest = dst.join(entry.file_name());
+        let ft = entry
+            .file_type()
+            .map_err(|e| format!("stat {}: {}", path.display(), e))?;
+        if ft.is_dir() {
+            copy_dir_recursive(&path, &dest)?;
+        } else if ft.is_file() {
+            fs::copy(&path, &dest)
+                .map_err(|e| format!("copy {} → {}: {}", path.display(), dest.display(), e))?;
+        }
+        // Symlinks and other special files are skipped — Arai doesn't
+        // write them, and silently copying them risks loops / surprises.
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh_home(label: &str) -> PathBuf {
+        let base = std::env::temp_dir().join(format!(
+            "arai_migrate_{label}_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        fs::create_dir_all(&base).unwrap();
+        base
+    }
+
+    fn seed_legacy(home: &Path) {
+        let old = home.join(".arai");
+        fs::create_dir_all(old.join("audit").join("my-project")).unwrap();
+        fs::write(
+            old.join("audit").join("my-project").join("20260101.jsonl"),
+            b"{\"x\":1}\n",
+        )
+        .unwrap();
+        fs::write(old.join("config.toml"), b"# legacy\n").unwrap();
+    }
+
+    /// State A — no legacy directory.  `detect` reports nothing to do; `run`
+    /// completes silently.
+    #[test]
+    fn state_a_no_legacy_directory() {
+        let home = fresh_home("noop");
+        let detected = detect(&home, None);
+        assert!(matches!(detected, Detected::NothingToMigrate { .. }));
+        // Run must succeed without prompting (closure never invoked).
+        run_with_confirm(&home, None, |_| panic!("confirm should not be called")).unwrap();
+        fs::remove_dir_all(&home).ok();
+    }
+
+    /// State B — legacy present, user accepts.  Files move; old dir gone;
+    /// new dir contains the originals.
+    #[test]
+    fn state_b_accept_moves_files() {
+        let home = fresh_home("accept");
+        seed_legacy(&home);
+        let old = home.join(".arai");
+        let new = home.join(".taniwha").join("arai");
+        assert!(old.exists());
+        assert!(!new.exists());
+
+        run_with_confirm(&home, None, |_| true).unwrap();
+
+        assert!(!old.exists(), "legacy ~/.arai should be gone after accept");
+        assert!(new.exists(), "new ~/.taniwha/arai should exist");
+        assert!(
+            new.join("audit")
+                .join("my-project")
+                .join("20260101.jsonl")
+                .exists(),
+            "audit file should have moved to new location",
+        );
+        assert!(new.join("config.toml").exists());
+        fs::remove_dir_all(&home).ok();
+    }
+
+    /// State C — legacy present, user declines.  Old dir untouched;
+    /// decline marker written under new base; second run sees nothing to do.
+    #[test]
+    fn state_c_decline_writes_marker_and_does_not_reprompt() {
+        let home = fresh_home("decline");
+        seed_legacy(&home);
+        let old = home.join(".arai");
+        let new = home.join(".taniwha").join("arai");
+
+        run_with_confirm(&home, None, |_| false).unwrap();
+
+        assert!(
+            old.exists(),
+            "legacy ~/.arai must NOT be touched on decline"
+        );
+        assert!(
+            new.join(DECLINE_MARKER).exists(),
+            "decline marker should be written under {}",
+            new.display(),
+        );
+
+        // Second run — confirm closure must NOT be invoked because detect()
+        // sees the marker and reports NothingToMigrate.
+        run_with_confirm(&home, None, |_| {
+            panic!("should not re-prompt after decline")
+        })
+        .unwrap();
+        fs::remove_dir_all(&home).ok();
+    }
+
+    /// New base already populated → refuse, don't merge.
+    #[test]
+    fn refuses_to_overwrite_populated_new_base() {
+        let home = fresh_home("populated");
+        seed_legacy(&home);
+        let new = home.join(".taniwha").join("arai");
+        fs::create_dir_all(&new).unwrap();
+        fs::write(new.join("important.db"), b"keepme").unwrap();
+
+        let detected = detect(&home, None);
+        assert!(matches!(detected, Detected::NewBaseInUse { .. }));
+
+        // Run completes (returns Ok) but does not touch either dir.
+        run_with_confirm(&home, None, |_| {
+            panic!("should not prompt when new base is in use")
+        })
+        .unwrap();
+        assert!(home.join(".arai").exists());
+        assert!(new.join("important.db").exists());
+        fs::remove_dir_all(&home).ok();
+    }
+
+    /// Repo-local `<repo>/.arai` is detected but reported separately.
+    #[test]
+    fn repo_local_arai_surfaces_in_detected() {
+        let home = fresh_home("repolocal");
+        let repo = home.join("some-repo");
+        fs::create_dir_all(repo.join(".arai")).unwrap();
+        fs::write(repo.join(".arai").join("misc.txt"), b"x").unwrap();
+        seed_legacy(&home);
+
+        let detected = detect(&home, Some(&repo));
+        match detected {
+            Detected::Found {
+                repo_local_path: Some(p),
+                ..
+            } => assert_eq!(p, repo.join(".arai")),
+            other => panic!("expected Found with repo_local_path, got {other:?}"),
+        }
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn human_size_formats_units() {
+        assert_eq!(human_size(0), "0 B");
+        assert_eq!(human_size(512), "512 B");
+        assert_eq!(human_size(2048), "2.00 KiB");
+        assert_eq!(human_size(5 * 1024 * 1024), "5.00 MiB");
+    }
+}

--- a/tests/compliance_correlation.rs
+++ b/tests/compliance_correlation.rs
@@ -1,0 +1,288 @@
+//! Integration coverage for `compliance.rs` Pre/Post correlation.
+//!
+//! Drives the live `arai` binary end-to-end:
+//!
+//!   1. Seed a tmp project + tmp `ARAI_BASE_DIR`.
+//!   2. `arai add` a rule with a prohibitive predicate.
+//!   3. Pipe a PreToolUse hook payload that triggers the rule.
+//!   4. Pipe a matching PostToolUse hook payload — either still showing
+//!      the forbidden phrase (→ `Ignored` verdict) or showing a compliant
+//!      command (→ `Obeyed` verdict).
+//!   5. Run `arai audit --event=Compliance --json` and assert the verdict
+//!      that landed in the local audit log.
+//!
+//! Why integration: the unit tests in `src/compliance.rs::evaluate` cover
+//! the pure correlation function in isolation.  This test pins the
+//! *pipeline* — hook ingest → session lookup → audit query → verdict
+//! emit — so a future refactor that re-routes any of those stages can't
+//! silently break the user-visible audit field that compliance reporting
+//! depends on (e.g. `arai stats --by-rule`).
+
+use serde_json::Value;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// Build a fresh tmp project root (with `.git` so `find_project_root`
+/// stops there) and a fresh tmp arai base.  Returned paths are unique per
+/// test invocation so concurrent `cargo test` runs don't collide.
+fn fresh_env(label: &str) -> (PathBuf, PathBuf) {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let root = std::env::temp_dir().join(format!(
+        "arai_compliance_{label}_{}_{}",
+        std::process::id(),
+        nanos,
+    ));
+    let project = root.join("project");
+    let arai_base = root.join("arai_base");
+    std::fs::create_dir_all(project.join(".git")).expect("create project");
+    std::fs::create_dir_all(&arai_base).expect("create arai base");
+    (project, arai_base)
+}
+
+fn arai_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_arai")
+}
+
+/// Run `arai <args...>` with the project root as cwd and ARAI_BASE_DIR set.
+/// Returns (stdout, stderr, exit_code).
+fn run(args: &[&str], project: &Path, arai_base: &Path) -> (String, String, i32) {
+    let output = Command::new(arai_bin())
+        .args(args)
+        .current_dir(project)
+        .env("ARAI_BASE_DIR", arai_base)
+        // Disable telemetry so the test doesn't write outside its tmp dir.
+        .env("ARAI_TELEMETRY", "off")
+        .env("DO_NOT_TRACK", "1")
+        .output()
+        .expect("spawn arai");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+/// Pipe `payload` into `arai guardrails --match-stdin` and return stdout.
+fn pipe_hook(payload: &str, project: &Path, arai_base: &Path) -> String {
+    let mut child = Command::new(arai_bin())
+        .arg("guardrails")
+        .arg("--match-stdin")
+        .current_dir(project)
+        .env("ARAI_BASE_DIR", arai_base)
+        .env("ARAI_TELEMETRY", "off")
+        .env("DO_NOT_TRACK", "1")
+        // Force deny-mode on so the Pre firing is recorded with
+        // decision="deny" — the audit log still records it either way,
+        // but pinning this makes the test's expectations explicit.
+        .env("ARAI_DENY_MODE", "on")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn arai guardrails");
+    if let Some(stdin) = child.stdin.as_mut() {
+        stdin.write_all(payload.as_bytes()).expect("write payload");
+    }
+    let output = child.wait_with_output().expect("wait arai guardrails");
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// Read every Compliance audit entry written for the test project.
+/// Parsed from `arai audit --event=Compliance --json` so we go through
+/// the same query path users do.
+fn read_compliance_entries(project: &Path, arai_base: &Path) -> Vec<Value> {
+    let (stdout, stderr, code) = run(
+        &["audit", "--event=Compliance", "--json", "--limit=100"],
+        project,
+        arai_base,
+    );
+    assert_eq!(
+        code, 0,
+        "arai audit exited non-zero: stderr={stderr} stdout={stdout}",
+    );
+    stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| {
+            serde_json::from_str::<Value>(l).unwrap_or_else(|e| panic!("non-JSON line: {e}\n{l}"))
+        })
+        .collect()
+}
+
+/// Collect every (outcome, predicate) tuple across every rule of every
+/// Compliance entry — flattens the `payload.rules[]` array so tests can
+/// assert on the shape directly.
+fn flatten_outcomes(entries: &[Value]) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for entry in entries {
+        let rules = entry
+            .get("payload")
+            .and_then(|p| p.get("rules"))
+            .and_then(|r| r.as_array())
+            .cloned()
+            .unwrap_or_default();
+        for r in rules {
+            let outcome = r
+                .get("outcome")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let predicate = r
+                .get("predicate")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            out.push((outcome, predicate));
+        }
+    }
+    out
+}
+
+fn pre_payload(command: &str, session_id: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": { "command": command },
+        "session_id": session_id,
+    })
+    .to_string()
+}
+
+fn post_payload(command: &str, session_id: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": { "command": command },
+        "tool_result": "",
+        "session_id": session_id,
+    })
+    .to_string()
+}
+
+/// Prohibitive rule + Post still containing the forbidden phrase →
+/// Compliance verdict must be `ignored`.
+#[test]
+fn prohibitive_rule_post_contains_forbidden_phrase_records_ignored() {
+    let (project, arai_base) = fresh_env("ignored");
+
+    let (add_out, add_err, add_code) = run(
+        &["add", "Never run alembic upgrade by hand"],
+        &project,
+        &arai_base,
+    );
+    assert_eq!(
+        add_code, 0,
+        "arai add failed: stdout={add_out} stderr={add_err}",
+    );
+
+    let session = "test-session-ignored-aaaaaaaa";
+
+    // Pre: trigger the rule.
+    let pre_out = pipe_hook(
+        &pre_payload("alembic upgrade head", session),
+        &project,
+        &arai_base,
+    );
+    // We don't strictly need to assert on the Pre stdout — the audit log
+    // is the source of truth — but a sanity check that *something*
+    // happened keeps a parser regression from silently passing.
+    assert!(
+        pre_out.contains("permissionDecision"),
+        "pre-stdout should carry a permissionDecision (parser/match regression?): {pre_out}",
+    );
+
+    // Post: still doing the forbidden thing.
+    let _ = pipe_hook(
+        &post_payload("alembic upgrade head", session),
+        &project,
+        &arai_base,
+    );
+
+    let entries = read_compliance_entries(&project, &arai_base);
+    let outcomes = flatten_outcomes(&entries);
+    assert!(
+        outcomes.iter().any(|(o, p)| o == "ignored" && p == "never"),
+        "expected an (ignored, never) outcome in compliance entries; got {outcomes:?}\nentries: {entries:#?}",
+    );
+
+    let _ = std::fs::remove_dir_all(&project);
+    let _ = std::fs::remove_dir_all(&arai_base);
+}
+
+/// Prohibitive rule + Post NOT containing the forbidden phrase →
+/// Compliance verdict must be `obeyed`.
+#[test]
+fn prohibitive_rule_post_compliant_records_obeyed() {
+    let (project, arai_base) = fresh_env("obeyed");
+
+    let (_o, _e, code) = run(
+        &["add", "Never run alembic upgrade by hand"],
+        &project,
+        &arai_base,
+    );
+    assert_eq!(code, 0);
+
+    let session = "test-session-obeyed-bbbbbbbb";
+
+    // Pre: trigger the rule.
+    let _ = pipe_hook(
+        &pre_payload("alembic upgrade head", session),
+        &project,
+        &arai_base,
+    );
+    // Post: the model complied — no `alembic upgrade` in this call.
+    let _ = pipe_hook(&post_payload("ls", session), &project, &arai_base);
+
+    let entries = read_compliance_entries(&project, &arai_base);
+    let outcomes = flatten_outcomes(&entries);
+    assert!(
+        outcomes.iter().any(|(o, p)| o == "obeyed" && p == "never"),
+        "expected an (obeyed, never) outcome in compliance entries; got {outcomes:?}\nentries: {entries:#?}",
+    );
+    // And NOT an `ignored` for the same rule — that would mean the
+    // matcher is over-counting.
+    assert!(
+        !outcomes.iter().any(|(o, p)| o == "ignored" && p == "never"),
+        "should not record ignored when the Post is compliant; got {outcomes:?}",
+    );
+
+    let _ = std::fs::remove_dir_all(&project);
+    let _ = std::fs::remove_dir_all(&arai_base);
+}
+
+/// PostToolUse with no preceding PreToolUse firing in the session must
+/// NOT write a spurious Compliance entry.  Otherwise the per-rule
+/// `obeyed/ignored/unclear` ratios would inflate from tool calls that
+/// never matched a rule in the first place.
+#[test]
+fn post_without_pre_emits_no_compliance_entry() {
+    let (project, arai_base) = fresh_env("nopre");
+
+    let (_o, _e, code) = run(
+        &["add", "Never run alembic upgrade by hand"],
+        &project,
+        &arai_base,
+    );
+    assert_eq!(code, 0);
+
+    let session = "test-session-nopre-cccccccc";
+    // Post only — no preceding Pre on this session.
+    let _ = pipe_hook(
+        &post_payload("alembic upgrade head", session),
+        &project,
+        &arai_base,
+    );
+
+    let entries = read_compliance_entries(&project, &arai_base);
+    assert!(
+        entries.is_empty(),
+        "Post-without-Pre should produce no Compliance entry; got {entries:#?}",
+    );
+
+    let _ = std::fs::remove_dir_all(&project);
+    let _ = std::fs::remove_dir_all(&arai_base);
+}

--- a/tests/intent_severity.rs
+++ b/tests/intent_severity.rs
@@ -1,0 +1,238 @@
+//! Integration coverage for `intent.rs` severity inference.
+//!
+//! Drives the live `arai lint --json` binary over a synthetic instruction
+//! file shaped to exercise every predicate → severity mapping in
+//! `Severity::from_predicate`.  Why integration and not unit-only:
+//!
+//!   - The in-module unit tests in `src/intent.rs` already cover the
+//!     mapping in isolation.
+//!   - This test pins the *pipeline* — parser → classifier → JSON output —
+//!     so future refactors that move severity inference can't silently
+//!     break the user-visible field.
+//!   - `arai lint --json` is the documented surface a CI pipeline or
+//!     pre-commit hook would use to validate an instruction-file change
+//!     against the live classifier; integration coverage here protects
+//!     that contract.
+//!
+//! Coverage matrix per `Severity::from_predicate`:
+//!
+//!   | Predicate     | Expected severity |
+//!   |---------------|-------------------|
+//!   | never         | block             |
+//!   | forbids       | block             |
+//!   | must_not      | block             |
+//!   | always        | warn              |
+//!   | requires      | warn              |
+//!   | enforces      | warn              |
+//!   | prefers       | inform            |
+//!   | learned_from  | inform            |
+//!
+//! The corpus produces at least one rule per predicate via the parser's
+//! v0.2.11 imperative-pattern coverage (Layer 1 leaders, "should" /
+//! "should not", "consider", bold emphasis).
+
+use serde_json::Value;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn write_corpus(contents: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let path = std::env::temp_dir().join(format!(
+        "arai_intent_severity_{}_{}.md",
+        std::process::id(),
+        nanos
+    ));
+    std::fs::write(&path, contents).expect("write corpus");
+    path
+}
+
+fn lint_json(corpus: &PathBuf) -> Vec<Value> {
+    let bin = env!("CARGO_BIN_EXE_arai");
+    let output = Command::new(bin)
+        .arg("lint")
+        .arg(corpus)
+        .arg("--json")
+        .output()
+        .expect("spawn arai lint");
+    assert!(
+        output.status.success(),
+        "arai lint exited non-zero: stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("non-JSON output: {e}\n{stdout}"));
+    parsed.as_array().expect("top-level array").clone()
+}
+
+fn assert_severity_for_predicate(rules: &[Value], predicate: &str, expected: &str) {
+    let matching: Vec<&Value> = rules
+        .iter()
+        .filter(|r| r.get("predicate").and_then(|v| v.as_str()) == Some(predicate))
+        .collect();
+    assert!(
+        !matching.is_empty(),
+        "corpus should produce at least one rule with predicate={predicate}; got:\n{rules:#?}",
+    );
+    for rule in matching {
+        let actual = rule.get("severity").and_then(|v| v.as_str());
+        assert_eq!(
+            actual,
+            Some(expected),
+            "predicate={predicate} should infer severity={expected}, got {actual:?} on rule: {rule:?}",
+        );
+    }
+}
+
+/// Every predicate maps to the documented severity end-to-end through
+/// `arai lint --json`.
+#[test]
+fn every_predicate_maps_to_correct_severity() {
+    // Each block is chosen so the parser produces a rule with the
+    // intended predicate.  See src/parser.rs::match_imperative for the
+    // patterns — Layer 1 ("Never X") → never; "must not X" → must_not;
+    // affirmative leaders ("Always X", "Must X") → always / requires;
+    // "should" / "should not" / "consider" → prefers / must_not / prefers
+    // depending on grammatical weight.
+    let corpus = write_corpus(
+        r#"# Synthetic corpus for severity inference
+
+## Rules
+
+- Never hand-write Alembic migration files.
+- Do not commit credentials.
+- Must not force-push to main.
+- Always run cargo test before pushing.
+- Require a passing build before merge.
+- Enforce ruff formatting on every commit.
+- Prefer smaller diffs over large ones.
+- Consider running clippy before review.
+"#,
+    );
+
+    let rules = lint_json(&corpus);
+    assert!(
+        rules.len() >= 6,
+        "expected the parser to extract at least 6 rules from the corpus, got {}: {rules:#?}",
+        rules.len(),
+    );
+
+    // Map each predicate the parser is expected to produce to the
+    // severity Severity::from_predicate should infer.
+    let cases: &[(&str, &str)] = &[
+        ("never", "block"),
+        ("must_not", "block"),
+        ("always", "warn"),
+        ("requires", "warn"),
+        ("enforces", "warn"),
+        ("prefers", "inform"),
+    ];
+
+    for (predicate, expected) in cases {
+        assert_severity_for_predicate(&rules, predicate, expected);
+    }
+
+    let _ = std::fs::remove_file(&corpus);
+}
+
+/// `forbids` is produced by the parser's negative-imperative shapes
+/// ("Don't X", "Do not X", "No X").  Pinned separately because the
+/// corpus needs distinct phrasing the other test does not require.
+#[test]
+fn forbids_predicate_infers_block_severity() {
+    let corpus = write_corpus(
+        r#"# Forbids severity
+
+## Rules
+
+- Don't commit secrets to git.
+- Do not edit generated files.
+"#,
+    );
+
+    let rules = lint_json(&corpus);
+    assert_severity_for_predicate(&rules, "forbids", "block");
+    let _ = std::fs::remove_file(&corpus);
+}
+
+/// `learned_from` arises from past-incident feedback shapes.  Folded into
+/// `Severity::Inform` because the rule represents a soft historical note
+/// rather than a present-tense prohibition.
+#[test]
+fn learned_from_predicate_infers_inform_when_emitted() {
+    // Not every corpus produces a `learned_from` predicate; the parser
+    // shapes that emit it ("we learned that X", "incident showed Y") are
+    // narrower than the other layers.  If the corpus doesn't yield one,
+    // the test asserts the matrix is at least documented via the
+    // unit-level test in src/intent.rs — no false negative here.
+    let corpus = write_corpus(
+        r#"# Historical lessons
+
+## Rules
+
+- We learned from the 2025 outage that all writes need timeouts.
+- Past incidents taught us to never deploy on Fridays.
+"#,
+    );
+
+    let rules = lint_json(&corpus);
+    let any_learned = rules
+        .iter()
+        .any(|r| r.get("predicate").and_then(|v| v.as_str()) == Some("learned_from"));
+    if any_learned {
+        assert_severity_for_predicate(&rules, "learned_from", "inform");
+    } else {
+        // Parser didn't emit `learned_from` for the chosen phrasings —
+        // acceptable; the mapping itself is unit-tested in src/intent.rs.
+        // What we must NOT see is a `learned_from` rule with a different
+        // severity (would mean a regression in the mapping table).
+        eprintln!(
+            "note: corpus did not produce a learned_from rule — \
+             integration coverage falls back to unit test in src/intent.rs"
+        );
+    }
+    let _ = std::fs::remove_file(&corpus);
+}
+
+/// Unknown predicates fall back to `warn` so a rule-set written for an
+/// older Arai keeps the safer advise-only behaviour rather than
+/// accidentally escalating to block.  This is the *invariant* that
+/// matters most for users upgrading: a new schema field can't quietly
+/// turn warns into blocks.
+#[test]
+fn unknown_predicate_defaults_to_warn() {
+    // We can't easily force the parser to emit an "unknown" predicate
+    // via natural prose — every shape it knows maps to one of the
+    // documented predicates.  Instead, assert that *every* rule the
+    // parser does emit has a severity in the documented set; any future
+    // predicate added to the parser without a corresponding severity
+    // mapping would default to warn (the safe fallback) rather than
+    // break the schema.
+    let corpus = write_corpus(
+        r#"# Mixed bag
+
+## Rules
+
+- Always validate inputs at the boundary.
+- Never log secrets, even in debug mode.
+- Prefer integration tests over mocks for migrations.
+"#,
+    );
+    let rules = lint_json(&corpus);
+    let allowed = ["block", "warn", "inform"];
+    for rule in &rules {
+        let sev = rule
+            .get("severity")
+            .and_then(|v| v.as_str())
+            .unwrap_or("<missing>");
+        assert!(
+            allowed.contains(&sev),
+            "severity must be one of {:?}, got {sev} on rule: {rule:?}",
+            allowed,
+        );
+    }
+    let _ = std::fs::remove_file(&corpus);
+}


### PR DESCRIPTION
## Summary

Bundles the four cleanly-resolvable items from the open-issue list. Each is referenced below; this PR closes them when it merges.

- **#72** — `arai migrate` subcommand to move legacy `~/.arai` → `~/.taniwha/arai`. Detect, summarise, prompt (default no), move on accept with a forwarding marker, write `.migrate_declined` on decline so it doesn't re-prompt. New `src/migrate.rs` with 6 unit tests covering the three acceptance states plus the new-base-populated and repo-local edge cases. `--yes` for scripts.
- **#95 part 1** (hash-chain + `arai audit verify`) — verified already shipped in the prior security-audit commit ([f86ea86](https://github.com/taniwhaai/arai/commit/f86ea86)); no new code. CLAUDE.md updated to document the command.
- **#95 part 3** — Integration coverage for intent severity inference (`tests/intent_severity.rs`, 4 tests) and compliance Pre/Post correlation (`tests/compliance_correlation.rs`, 3 tests). Both drive the live binary end-to-end so a refactor that re-routes any pipeline stage can't silently break the user-visible severity field or the compliance verdict `arai stats --by-rule` reports on. Required exposing `severity` in `arai lint --json` output (one-line additive change).
- **#75 + #76 + #79** — New `docs/rules-file-spec.md`. Part 1: TOML-vs-YAML spike with four worked rules in both formats, recommends TOML. Part 2: v1 schema (`id` / `when` / `then` / `severity` / `expires`) with a worked alembic example including the "Edit allowed, Write blocked" exception pattern. Part 3: confirms `extends` field reservation + id-prefix conventions accommodate rule packs without a breaking change.

## What this is NOT

- Not the rule-pack implementation itself (`#77`, `#78`) — those depend on the schema doc landing first.
- Not `#95 part 5` (audit retention controls) — that overlaps with retention concerns and warrants a separate conversation. PR #108 already shipped `arai audit --purge` which is part of the picture.
- Not changes to `arai init` to auto-trigger migration — the existing deprecation notice in `config::resolve_base_dir` already nudges users; auto-prompting from inside `Config::load` would be too noisy.

## Test plan

- [x] `cargo build` — clean.
- [x] `cargo test` — 343 pass (310 unit + 33 integration), 0 fail.
- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy -- -D warnings` — clean.
- [x] Manually exercised `arai migrate` against a seeded legacy `~/.arai` (accept and decline paths) via the WSL test harness.
- [x] Manually exercised `arai add` + Pre/Post hook + `arai audit --event=Compliance --json` end-to-end to confirm the compliance pipeline writes `Obeyed`/`Ignored` verdicts as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)