### PR TITLE
chore: release v0.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.21] - 2026-05-21
+
+### Miscellaneous
+
+- Clean out four open issues — migrate cmd, compliance/severity integration tests, rules-file spec ([#114](https://github.com/taniwhaai/arai/pull/114))
+
+
 ## [0.2.20] - 2026-05-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "0.2.20"
+version = "0.2.21"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 0.2.20 -> 0.2.21

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.21] - 2026-05-21

### Miscellaneous

- Clean out four open issues — migrate cmd, compliance/severity integration tests, rules-file spec ([#114](https://github.com/taniwhaai/arai/pull/114))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).