### PR TITLE
chore: release v0.2.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.22] - 2026-05-22
+
+### Miscellaneous
+
+- Update Cargo.lock dependencies
+
+
 ## [0.2.21] - 2026-05-21
 
 ### Miscellaneous

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "0.2.21"
+version = "0.2.22"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 0.2.21 -> 0.2.22

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.22] - 2026-05-22

### Miscellaneous

- Update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).