### PR TITLE
chore: release v0.2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.23] - 2026-05-25
+
+### Added
+
+- *(prompt-collector)* Log-only UserPromptSubmit observation ([#113](https://github.com/taniwhaai/arai/pull/113))
+
+### Style
+
+- Rustfmt prompt-collector files ([#113](https://github.com/taniwhaai/arai/pull/113))
+
+
 ## [0.2.22] - 2026-05-22
 
 ### Miscellaneous

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "0.2.22"
+version = "0.2.23"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 0.2.22 -> 0.2.23

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.23] - 2026-05-25

### Added

- *(prompt-collector)* Log-only UserPromptSubmit observation ([#113](https://github.com/taniwhaai/arai/pull/113))

### Style

- Rustfmt prompt-collector files ([#113](https://github.com/taniwhaai/arai/pull/113))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).