### PR TITLE
docs: make marketing copy and README assistant-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arai
 
-**CLAUDE.md that actually works.** One command. Runs locally. Zero cost.
+**Instruction files that actually work.** One command. Runs locally. Zero cost.
 
 Arai makes your AI coding assistant instruction files structurally enforceable — not just suggestions that get forgotten as context grows.
 
@@ -15,7 +15,7 @@ cd your-project
 arai init
 ```
 
-That's it. Arai discovers your instruction files, extracts the rules, classifies their intent, scans your codebase for context, and sets up hooks (Claude Code + native Grok TUI) so guardrails fire at the right moment.
+That's it. Arai discovers your instruction files, extracts the rules, classifies their intent, scans your codebase for context, and sets up native hooks so guardrails fire at the right moment.
 
 ## What It Does
 
@@ -27,12 +27,12 @@ You: "Create a new database migration"
   PreToolUse: Write migrations/versions/001_add_users.py
   → Arai: deny
     reason: "Alembic never: hand-write migration files"
-            [from CLAUDE.md:12, layer-1 imperative]
+            [from your rules:12, layer-1 imperative]
 
-Claude: "I should use alembic revision --autogenerate instead..."
+Assistant: "I should use alembic revision --autogenerate instead..."
 ```
 
-Rules only fire when relevant. No noise on `ls`. No repeating principles already in CLAUDE.md.
+Rules only fire when relevant. No noise on `ls`. No repeating principles already in your instruction files.
 
 Every firing is written to a local audit log, and every PostToolUse is correlated with the matching PreToolUse to produce a **compliance verdict** — so you can measure whether the model actually honours the rules you wrote.
 
@@ -43,7 +43,7 @@ Every firing is written to a local audit log, and every PostToolUse is correlate
 3. **Classifies** each rule's intent — what action it governs, which tools it applies to, when it should fire
 4. **Scans** your codebase with tree-sitter to understand which tools own which directories
 5. **Tracks** session state — knows if you've already run tests before pushing
-6. **Fires** only relevant rules at the right moment via Claude Code hooks
+6. **Fires** only relevant rules at the right moment via native hooks (where supported)
 
 ## Supported Instruction Files
 
@@ -67,8 +67,8 @@ enforcement strength depends on what surface the assistant exposes.
 - GitHub Copilot currently has no live enforcement surface; the file is
   still ingested for `arai stats`, `arai diff`, and the audit log.
 
-Arai hooks several more events (on both Claude Code and Grok TUI) alongside
-the standard tool-call events so the rule set stays accurate to the live
+Arai hooks several more events alongside the standard tool-call events
+(when the assistant supports them) so the rule set stays accurate to the live
 working tree:
 
 - **`FileChanged` + `InstructionsLoaded`** — when an instruction file
@@ -219,7 +219,7 @@ arai upgrade --full        # Switch to full binary (with ONNX enrichment)
 
 Starting in v0.2.3, Arai no longer just *advises*: rules derived from
 prohibitive predicates (`never`, `forbids`, `must_not`) emit
-`permissionDecision: "deny"` so Claude Code refuses the tool call. Advisory
+`permissionDecision: "deny"` (or equivalent) so the assistant refuses the tool call. Advisory
 rules (`always`, `requires`, `prefers`) keep the previous behaviour.
 
 Severity is inferred from the predicate at extract time:
@@ -250,7 +250,7 @@ the audit log per rule:
   prohibitive rules), or the required evidence present (for affirmative
   rules).
 - **ignored** — forbidden phrase still in the executed command.
-  The model ran the thing anyway (either deny was off or Claude Code
+  The model ran the thing anyway (either deny was off or the assistant
   chose to proceed).
 - **unclear** — not enough signal to decide (short object text, or
   affirmative rule without evidence in this call).
@@ -571,7 +571,7 @@ re-ingest.
 ## Record — seed scenarios from real firings
 
 `arai record` turns entries in the audit log into scenario skeletons
-so you don't hand-write regression tests. Flow: run Claude Code, hit a
+so you don't hand-write regression tests. Flow: run your assistant, hit a
 rule firing you want pinned, `arai record --since=1h > tests.json`,
 tune the expectations, check in.
 
@@ -622,12 +622,12 @@ one merged file.
 ## MCP: agent-authored guardrails
 
 `arai mcp` is also the integration path for assistants that don't have a
-PreToolUse hook surface. Cursor and Windsurf are both MCP clients — point
-them at `arai mcp` and the agent can read the same rule set Claude Code
-sees, register new guards mid-session, and self-check recent decisions.
-The blocking path is still Claude-Code-only (no other assistant exposes
-a deny hook today), but everything else — rule lookup, agent-authored
-guards, decision history — is shared.
+native PreToolUse hook surface. Cursor and Windsurf are both MCP clients — point
+them at `arai mcp` and the agent can read the same rule set, register new guards
+mid-session, and self-check recent decisions.
+The strongest blocking enforcement is available in assistants with native hook
+support (currently Claude Code and Grok TUI), but everything else — rule lookup,
+agent-authored guards, decision history — is shared via MCP.
 
 `arai mcp` runs a [Model Context Protocol](https://modelcontextprotocol.io/)
 server on stdio. Three tools, exposed to any MCP-capable agent:
@@ -647,7 +647,7 @@ call `arai_recent_decisions` to see what it was just refused for —
 useful for avoiding "try the same thing twice" loops when a single
 rule keeps getting hit.
 
-Register it with Claude Code by adding to your MCP settings:
+Register it with your assistant (for example in Claude Code or Cline) by adding to your MCP settings:
 
 ```json
 {
@@ -716,7 +716,7 @@ docker compose run --rm arai
 | Hook check (full match pipeline) | ~32 ms | ~55 ms |
 | Full init | <200 ms | — |
 
-End-to-end wall clock per Claude Code tool call, measured by
+End-to-end wall clock per tool call (on supported assistants), measured by
 `bench/hot_path.sh`. Cost is dominated by Rust binary fork+exec
 (~20 ms floor on Linux/WSL); rule matching itself is sub-ms above 200
 rules thanks to the LEFT-JOIN'd intent and Aho-Corasick content sniffing.

--- a/site/index.html
+++ b/site/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Arai — CLAUDE.md that actually works</title>
+    <title>Arai — Instruction files that actually work</title>
     <meta name="description" content="Enforce AI coding assistant instruction files via hooks. One command. Runs locally. Zero cost.">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png">
@@ -254,8 +254,8 @@
 
 <section class="hero">
     <div class="container">
-        <h1><span>CLAUDE.md</span> that actually blocks.</h1>
-        <p>Enforce AI coding assistant instruction files via Claude Code hooks &mdash; or advisory MCP for Cursor and Windsurf. Rules marked <code>never</code> deny the tool call in Claude Code. Every firing is audited and correlated with the action the model actually took. One command. Local. Zero cost.</p>
+        <h1>Instruction files that actually block.</h1>
+        <p>Enforce your AI coding assistant instruction files via native hooks. Rules marked <code>never</code> can deny the tool call. Every firing is audited and correlated with the action the model actually took. One command. Local. Zero cost.</p>
         <div class="install-box" onclick="copyInstall(this)">
             <span class="prompt">$</span>
             <span>curl -sSf https://arai.taniwha.ai/install | sh</span>
@@ -272,8 +272,8 @@
             <span class="accent">PreToolUse:</span> Write migrations/versions/001_add_users.py<br>
             <span class="warm">&rarr; Arai: <strong>deny</strong></span><br>
             <span class="warm">&nbsp;&nbsp;reason: "Alembic never: hand-write migration files"</span><br>
-            <span class="warm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[from CLAUDE.md:12, layer-1 imperative]</span><br><br>
-            <span class="dim">Claude: "I should use alembic revision --autogenerate instead..."</span>
+            <span class="warm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[from your rules:12, layer-1 imperative]</span><br><br>
+            <span class="dim">Assistant: "I should use alembic revision --autogenerate instead..."</span>
         </div>
     </div>
 </section>
@@ -313,7 +313,7 @@
             </div>
             <div class="feature">
                 <h3>Block, don&rsquo;t just advise</h3>
-                <p>Rules with <code>never</code>/<code>forbids</code>/<code>must_not</code> emit <code>permissionDecision: "deny"</code> in Claude Code. <code>always</code> and <code>prefers</code> still advise. Incremental rollout via <code>ARAI_DENY_MODE=off</code>. Cursor and Windsurf get advisory enforcement via MCP &mdash; no other assistant exposes a deny hook today.</p>
+                <p>Rules with <code>never</code>/<code>forbids</code>/<code>must_not</code> can deny the tool call in assistants that expose a hook surface. <code>always</code> and <code>prefers</code> still advise. Incremental rollout via <code>ARAI_DENY_MODE=off</code>. Advisory enforcement is available for other tools via MCP.</p>
             </div>
             <div class="feature">
                 <h3>Per-rule rollout</h3>
@@ -325,7 +325,7 @@
             </div>
             <div class="feature">
                 <h3>Derivation trace</h3>
-                <p>Every firing carries source file, line, and parser layer. Hook output shows <code>[CLAUDE.md:42 layer-1]</code> — no more guessing why a rule fired.</p>
+                <p>Every firing carries source file, line, and parser layer. Hook output shows the origin (e.g. <code>[AGENTS.md:42 layer-1]</code>) — no more guessing why a rule fired.</p>
             </div>
             <div class="feature">
                 <h3>Explain before you commit</h3>
@@ -373,11 +373,11 @@
             </div>
             <div class="feature">
                 <h3>Preview before commit</h3>
-                <p><code>arai lint CLAUDE.md</code> shows exactly which rules a file produces with their classified intent. Iterate on wording without touching the DB.</p>
+                <p><code>arai lint</code> shows exactly which rules a file produces with their classified intent. Iterate on wording without touching the DB.</p>
             </div>
             <div class="feature">
                 <h3>Diff before save</h3>
-                <p><code>arai diff CLAUDE.md</code> shows what an edit would change in the live rule set &mdash; added, removed, moved &mdash; before you commit it. Pre-commit-hook fodder via <code>--json</code>.</p>
+                <p><code>arai diff</code> shows what an edit would change in the live rule set &mdash; added, removed, moved &mdash; before you commit it. Pre-commit-hook fodder via <code>--json</code>.</p>
             </div>
             <div class="feature">
                 <h3>Shared policies</h3>
@@ -389,7 +389,7 @@
             </div>
             <div class="feature">
                 <h3>Zero noise</h3>
-                <p>Only fires domain-specific rules. Principles already in CLAUDE.md stay silent.</p>
+                <p>Only fires domain-specific rules. Principles already in your instruction files stay silent.</p>
             </div>
             <div class="feature">
                 <h3>Any LLM enrichment</h3>

--- a/site/index.html
+++ b/site/index.html
@@ -135,6 +135,39 @@
         }
         .feature p { font-size: 0.9rem; color: var(--text-secondary); }
 
+        /* Supported Environments */
+        .supported {
+            padding: 3rem 0;
+            border-top: 1px solid var(--border);
+            background: var(--bg-light);
+        }
+        .supported h2 {
+            font-size: 1.5rem; font-weight: 700;
+            text-align: center; margin-bottom: 0.75rem;
+        }
+        .supported-intro {
+            text-align: center; color: var(--text-secondary);
+            max-width: 620px; margin: 0 auto 1.5rem; font-size: 0.95rem;
+        }
+        .supported-grid {
+            display: grid; grid-template-columns: repeat(2, 1fr);
+            gap: 0.75rem 1.25rem; max-width: 680px; margin: 0 auto;
+        }
+        .supported-item {
+            background: var(--white);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 0.65rem 0.9rem;
+            font-size: 0.85rem;
+            line-height: 1.35;
+        }
+        .supported-item strong {
+            display: block; color: var(--primary); font-weight: 600; margin-bottom: 0.15rem;
+        }
+        .supported-item span {
+            color: var(--text-secondary);
+        }
+
         /* Install methods */
         .install-methods {
             padding: 4rem 0;
@@ -230,6 +263,7 @@
             .feature-grid { grid-template-columns: 1fr; }
             .methods-grid { grid-template-columns: 1fr; }
             .install-box { font-size: 0.8rem; }
+            .supported-grid { grid-template-columns: 1fr; }
         }
     </style>
     <script>
@@ -255,11 +289,36 @@
 <section class="hero">
     <div class="container">
         <h1>Instruction files that actually block.</h1>
-        <p>Enforce your AI coding assistant instruction files via native hooks. Rules marked <code>never</code> can deny the tool call. Every firing is audited and correlated with the action the model actually took. One command. Local. Zero cost.</p>
+        <p>Enforce your AI coding assistant instruction files via hooks. Claude Code and Grok TUI currently provide the strongest support, including the ability to block tool calls for rules marked <code>never</code>. Other tools receive advisory enforcement via MCP. Every firing is audited and correlated with what the model actually did. One command. Local. Zero cost.</p>
         <div class="install-box" onclick="copyInstall(this)">
             <span class="prompt">$</span>
             <span>curl -sSf https://arai.taniwha.ai/install | sh</span>
             <span class="copy-hint">click to copy</span>
+        </div>
+    </div>
+</section>
+
+<section class="supported">
+    <div class="container">
+        <h2>Supported Environments</h2>
+        <p class="supported-intro">Enforcement strength depends on the assistant's integration surface:</p>
+        <div class="supported-grid">
+            <div class="supported-item">
+                <strong>Claude Code</strong>
+                <span>Native PreToolUse hooks — full blocking support</span>
+            </div>
+            <div class="supported-item">
+                <strong>Grok TUI</strong>
+                <span>Native hooks — full blocking support</span>
+            </div>
+            <div class="supported-item">
+                <strong>Cursor, Windsurf, Cline &amp; others</strong>
+                <span>MCP integration — strong advisory enforcement</span>
+            </div>
+            <div class="supported-item">
+                <strong>GitHub Copilot</strong>
+                <span>Instruction file ingestion only</span>
+            </div>
         </div>
     </div>
 </section>
@@ -313,7 +372,7 @@
             </div>
             <div class="feature">
                 <h3>Block, don&rsquo;t just advise</h3>
-                <p>Rules with <code>never</code>/<code>forbids</code>/<code>must_not</code> can deny the tool call in assistants that expose a hook surface. <code>always</code> and <code>prefers</code> still advise. Incremental rollout via <code>ARAI_DENY_MODE=off</code>. Advisory enforcement is available for other tools via MCP.</p>
+                <p>Rules with <code>never</code>/<code>forbids</code>/<code>must_not</code> can deny the tool call in Claude Code and Grok TUI (the two assistants with native hook support today). <code>always</code> and <code>prefers</code> still advise. Incremental rollout via <code>ARAI_DENY_MODE=off</code>. Cursor, Windsurf and others get advisory enforcement via MCP.</p>
             </div>
             <div class="feature">
                 <h3>Per-rule rollout</h3>
@@ -325,7 +384,7 @@
             </div>
             <div class="feature">
                 <h3>Derivation trace</h3>
-                <p>Every firing carries source file, line, and parser layer. Hook output shows the origin (e.g. <code>[AGENTS.md:42 layer-1]</code>) — no more guessing why a rule fired.</p>
+                <p>Every firing carries source file, line, and parser layer. Hook output shows the origin (e.g. <code>[CLAUDE.md:42 layer-1]</code> or <code>[AGENTS.md:42 layer-1]</code>) — no more guessing why a rule fired.</p>
             </div>
             <div class="feature">
                 <h3>Explain before you commit</h3>
@@ -385,7 +444,7 @@
             </div>
             <div class="feature">
                 <h3>Agent-authored guards</h3>
-                <p>Runs as an MCP server. The agent can register new rules mid-session ("never touch /etc", "always run tests first") and Arai enforces them on the next tool call. <code>arai_recent_decisions</code> lets the agent self-check what it was just denied for &mdash; no more looping on the same refused action. MCP is also how Cursor and Windsurf integrate: same rule set, advisory only.</p>
+                <p>Runs as an MCP server. The agent can register new rules mid-session and Arai enforces them on the next tool call (where supported). <code>arai_recent_decisions</code> lets the agent self-check recent decisions. MCP is the primary integration for Cursor, Windsurf and similar tools (advisory only). Native blocking hooks are currently available in Claude Code and Grok TUI.</p>
             </div>
             <div class="feature">
                 <h3>Zero noise</h3>


### PR DESCRIPTION
## Summary
- Update positioning so the project no longer leads with `CLAUDE.md` as the default identity, now that v0.2.24 ships first-class Grok TUI support ([#123](https://github.com/taniwhaai/arai/pull/123)).
- Generalize taglines, hero copy, and example transcripts in README.md and site/index.html to neutral phrasing ("instruction files", "your assistant").
- Keep assistant-specific references only where technically required (Supported table, `permissionDecision` details, hook surface caveats).

## Test plan
- [ ] Render README.md on GitHub and confirm copy reads coherently end-to-end.
- [ ] Preview site/index.html locally and confirm hero, feature cards, and example block still scan.
- [ ] Spot-check that no remaining copy implies Claude Code is the only supported assistant where Grok TUI is now equally supported.