### PR TITLE
chore: release v0.2.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.25] - 2026-05-27
+
+### Added
+
+- Add Arai guardrails hooks to Grok and Claude settings
+- Arai canonicalize — extract rules from instruction files to arai.toml ([#78](https://github.com/taniwhaai/arai/pull/78))
+- Arai sync — write per-tool instruction files from arai.toml ([#77](https://github.com/taniwhaai/arai/pull/77))
+
+### Documentation
+
+- Make marketing copy and README assistant-agnostic ([#125](https://github.com/taniwhaai/arai/pull/125))
+
+
 ## [0.2.24] - 2026-05-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "0.2.24"
+version = "0.2.25"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 0.2.24 -> 0.2.25

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.25] - 2026-05-27

### Added

- Add Arai guardrails hooks to Grok and Claude settings
- Arai canonicalize — extract rules from instruction files to arai.toml ([#78](https://github.com/taniwhaai/arai/pull/78))
- Arai sync — write per-tool instruction files from arai.toml ([#77](https://github.com/taniwhaai/arai/pull/77))

### Documentation

- Make marketing copy and README assistant-agnostic ([#125](https://github.com/taniwhaai/arai/pull/125))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).