### PR TITLE
ci: sign release binaries with cosign keyless (#121)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,13 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    # id-token: write is required for cosign keyless signing via the
+    # GitHub OIDC token.  contents: write must be repeated because a
+    # job-level permissions block replaces (not merges with) the
+    # workflow-level one, and gh release upload needs it.
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
 
@@ -193,6 +200,26 @@ jobs:
           # hash.  Restricting to `arai-*` keeps the manifest deterministic.
           sha256sum arai-* > checksums.txt
           cat checksums.txt
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign binaries with cosign (keyless)
+        run: |
+          cd binaries
+          # cosign keyless signing via the GitHub OIDC token.  No long-
+          # lived keys: the signing certificate is issued by Fulcio and
+          # bound to the workflow identity, so verifiers can pin to this
+          # workflow + tag without trusting a private key.  The bundle
+          # file (.cosign.bundle) carries both the signature and the
+          # certificate so verifiers only need one extra download.
+          for file in arai-*; do
+            echo "Signing $file..."
+            cosign sign-blob \
+              --yes \
+              --bundle "${file}.cosign.bundle" \
+              "$file"
+          done
 
       - name: Attach to release
         env:

--- a/README.md
+++ b/README.md
@@ -708,6 +708,42 @@ docker run --rm -i -v "$(pwd)/.taniwha/arai:/home/arai/.taniwha/arai" arai
 docker compose run --rm arai
 ```
 
+### Verifying release binaries with cosign
+
+Every release binary is signed in CI using [cosign](https://docs.sigstore.dev/cosign/overview/)
+keyless signing via the GitHub OIDC token. The signing certificate is
+issued by Fulcio and bound to this repo's release workflow, so verifiers
+pin to the workflow identity instead of a long-lived public key. No
+private keys, no key rotation.
+
+The `install.sh` and `npm` paths verify SHA-256 checksums by default,
+which is enough to catch a corrupted download but not a substituted one.
+For higher-assurance environments, verify the cosign signature before
+running the binary:
+
+```bash
+# 1. Download the binary, its .cosign.bundle, and (optionally) checksums.txt
+VERSION=v0.2.24
+FILE=arai-linux-x86_64
+curl -fL -o "$FILE"               "https://github.com/taniwhaai/arai/releases/download/${VERSION}/${FILE}"
+curl -fL -o "${FILE}.cosign.bundle" "https://github.com/taniwhaai/arai/releases/download/${VERSION}/${FILE}.cosign.bundle"
+
+# 2. Verify the signature is bound to this repo's release workflow
+cosign verify-blob \
+  --bundle "${FILE}.cosign.bundle" \
+  --certificate-identity-regexp '^https://github\.com/taniwhaai/arai/\.github/workflows/ci\.yml@refs/tags/v.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  "$FILE"
+```
+
+A successful verification prints `Verified OK` and exits 0. Failure
+exits non-zero — do not run the binary.
+
+The `--certificate-identity-regexp` and `--certificate-oidc-issuer`
+flags are the load-bearing ones: they assert that the signing
+certificate was issued to *this* repo's CI workflow on a tag push, not
+to some attacker's fork. Loosening either flag defeats the point.
+
 ## Performance
 
 | Operation | Median | p95 |


### PR DESCRIPTION
Closes #121 (cosign portion).

## Summary

- Adds a cosign keyless signing step to the `attach-binaries` job in `.github/workflows/ci.yml`. Each `arai-*` binary gets a `.cosign.bundle` sidecar signed via Fulcio using the GitHub OIDC token.
- Documents the verification flow in `README.md` under Installation, with the load-bearing `--certificate-identity-regexp` and `--certificate-oidc-issuer` flags pinned to this repo's CI workflow on tag pushes.
- No changes to `install.sh` or `npm/install.js` — SHA-256 checksum verification stays the default; cosign is opt-in for higher-assurance environments.

## Why this approach

- **Keyless** (no `--key`) — the signing certificate is short-lived (10 min) and bound to the workflow identity. Nothing to rotate, nothing to leak.
- **Bundle file** — `.cosign.bundle` carries both the signature and the certificate, so verifiers need one extra download instead of two (`.sig` + `.pem`).
- **Job-level permissions** — `id-token: write` is scoped to `attach-binaries` only; the rest of the workflow can't request OIDC tokens. Note that a job-level `permissions:` block *replaces* (not merges with) the workflow-level one, so `contents: write` is repeated for `gh release upload`.

## What this does NOT cover (intentionally)

- **SLSA provenance attestation** (the other half of #121) — left for a follow-up so this PR stays small. The cosign signature covers binary provenance; SLSA would add a verifiable build-process attestation.
- **In-toto attestation** — same, follow-up scope.
- **Mandatory cosign verification in install paths** — would regress UX for users without cosign on PATH. Optional, README-documented for now; can be revisited if there's demand.

## Threat model recap (from #121)

| Attack | Checksums | cosign keyless |
|---|---|---|
| Corrupted download | ✅ caught | ✅ caught |
| Substituted binary in release | ❌ checksums.txt would also be swapped | ✅ certificate identity ≠ this repo's workflow |
| Stolen release-pipeline secret | ❌ | ✅ no long-lived secret to steal |

## Test plan

- [ ] Workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`) — ✅ done locally
- [ ] CI green on this PR (no tag push, so the `attach-binaries` job stays skipped)
- [ ] Next release tag exercises the signing step end-to-end; verify a `.cosign.bundle` lands on the release alongside each `arai-*` binary
- [ ] After that release, run the README's `cosign verify-blob` command against the published binary and confirm `Verified OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)