### PR TITLE
chore: release v0.2.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.26] - 2026-05-27
+
+### Documentation
+
+- Scope repo-layer (pre-commit) enforcement ([#82](https://github.com/taniwhaai/arai/pull/82))
+
+
 ## [0.2.25] - 2026-05-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "0.2.25"
+version = "0.2.26"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 0.2.25 -> 0.2.26

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.26] - 2026-05-27

### Documentation

- Scope repo-layer (pre-commit) enforcement ([#82](https://github.com/taniwhaai/arai/pull/82))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).