### PR TITLE
ci: add SLSA L3 provenance via slsa-github-generator (#129)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,11 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    outputs:
+      # Base64-encoded `sha256sum`-style lines, one per `arai-*` binary,
+      # consumed by the slsa-provenance job below.  The SLSA generator
+      # expects the format `<sha256>  <filename>\n...` then base64'd.
+      hashes: ${{ steps.compute-hashes.outputs.hashes }}
     steps:
       - uses: actions/checkout@v6
 
@@ -221,6 +226,17 @@ jobs:
               "$file"
           done
 
+      - name: Compute hashes for SLSA provenance
+        id: compute-hashes
+        run: |
+          # The SLSA reusable workflow expects `base64-subjects`: a
+          # base64-encoded blob of `<sha256>  <filename>\n` lines.  We
+          # already have that exact shape in checksums.txt — just b64 it.
+          cd binaries
+          {
+            echo "hashes=$(base64 -w0 < checksums.txt)"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Attach to release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
@@ -230,6 +246,28 @@ jobs:
             echo "Uploading $(basename $file)..."
             gh release upload "$TAG" "$file" --clobber
           done
+
+  # SLSA Level 3 provenance attestation via the slsa-github-generator
+  # reusable workflow.  Builds a verifiable record of *how* each binary
+  # was built (commit, workflow, inputs, toolchain) so verifiers can
+  # answer "was this binary produced by this exact CI pipeline" — the
+  # provenance question cosign doesn't answer on its own.
+  #
+  # The generator emits a single `<tag>.intoto.jsonl` attestation
+  # covering every subject in `base64-subjects` and (with
+  # upload-assets: true) attaches it to the release.  Verify
+  # consumer-side with `slsa-verifier verify-artifact`.
+  slsa-provenance:
+    needs: attach-binaries
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      actions: read      # generator reads the workflow run for provenance
+      id-token: write    # OIDC keyless signing (same trust model as cosign)
+      contents: write    # attach the attestation to the release
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    with:
+      base64-subjects: ${{ needs.attach-binaries.outputs.hashes }}
+      upload-assets: true
 
   npm-publish:
     name: Publish to npm

--- a/README.md
+++ b/README.md
@@ -744,6 +744,56 @@ flags are the load-bearing ones: they assert that the signing
 certificate was issued to *this* repo's CI workflow on a tag push, not
 to some attacker's fork. Loosening either flag defeats the point.
 
+### Verifying SLSA L3 provenance
+
+cosign answers *"was this binary signed by this repo's CI?"*. SLSA
+provenance answers the harder question: *"how was this binary built —
+which commit, which workflow, which inputs?"*. Together they cover
+both the signing identity (cosign) and the build process (SLSA), so
+verifiers can detect a tampered build pipeline even if the signing
+identity itself is intact.
+
+Releases include a single `<tag>.intoto.jsonl` attestation generated
+by the [SLSA GitHub generator](https://github.com/slsa-framework/slsa-github-generator).
+Verify consumer-side with [`slsa-verifier`](https://github.com/slsa-framework/slsa-verifier):
+
+```bash
+# 1. Download the binary and the release-level provenance attestation
+VERSION=v0.2.25
+FILE=arai-linux-x86_64
+curl -fL -o "$FILE" \
+  "https://github.com/taniwhaai/arai/releases/download/${VERSION}/${FILE}"
+curl -fL -o "${VERSION}.intoto.jsonl" \
+  "https://github.com/taniwhaai/arai/releases/download/${VERSION}/${VERSION}.intoto.jsonl"
+
+# 2. Verify the binary against the provenance, pinned to this repo + tag
+slsa-verifier verify-artifact \
+  --provenance-path "${VERSION}.intoto.jsonl" \
+  --source-uri github.com/taniwhaai/arai \
+  --source-tag "${VERSION}" \
+  "$FILE"
+```
+
+A successful verification prints `PASSED: SLSA verification passed` and
+exits 0. Failure exits non-zero — do not run the binary.
+
+`--source-uri` is the load-bearing flag: it asserts that the provenance
+was produced from a build of this repo's source. `--source-tag` (or
+`--source-branch`) further pins to a specific release.
+
+### What each layer protects against
+
+| Attack | SHA-256 checksums | cosign keyless | SLSA L3 provenance |
+|---|---|---|---|
+| Corrupted download | ✅ caught | ✅ caught | ✅ caught |
+| Substituted binary at release | ❌ checksums.txt would also be swapped | ✅ certificate identity ≠ this repo's workflow | ✅ provenance source-uri ≠ this repo |
+| Stolen release-pipeline secret | ❌ | ✅ no long-lived secret to steal | ✅ provenance binds to specific workflow run |
+| Tampered build process (compromised toolchain or workflow inputs) | ❌ | ❌ — cosign signs the artifact, not the build | ✅ provenance records the exact workflow, commit, and inputs |
+
+SHA-256 stays the default in `install.sh` / `npm` because it doesn't
+require any extra tooling client-side. cosign and SLSA are opt-in for
+environments that need the higher tier.
+
 ## Performance
 
 | Operation | Median | p95 |


### PR DESCRIPTION
Closes #129. Builds on the cosign keyless signing (PR #128 / v0.2.25) — same trust model, different supply-chain layer.

## Summary

- `attach-binaries` exposes a `hashes` output containing base64-encoded `sha256  filename` pairs (just the existing `checksums.txt` content b64'd) — that's the input shape the SLSA generator's `base64-subjects` expects.
- New `slsa-provenance` job calls `slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0` with `upload-assets: true`. The reusable workflow attaches a single `<tag>.intoto.jsonl` covering every binary to the release.
- README extended with `slsa-verifier verify-artifact` invocation pinned to repo + tag and an updated threat-model table.

## What each supply-chain layer covers now

| Attack | SHA-256 | cosign | SLSA L3 |
|---|---|---|---|
| Corrupted download | ✅ | ✅ | ✅ |
| Substituted binary at release | ❌ | ✅ | ✅ |
| Stolen release-pipeline secret | ❌ | ✅ | ✅ |
| **Tampered build process** (compromised toolchain / workflow inputs) | ❌ | ❌ | ✅ |

cosign signs the artifact; SLSA additionally signs the build process. That last row is the reason both layers matter.

## Posture (unchanged from #128)

SHA-256 stays the default in `install.sh` / `npm` because it requires no client-side tooling. cosign and SLSA are documented as opt-in higher tiers for environments that need them.

## What's out of scope

- **Mandatory SLSA verification in install paths** — would regress UX for users without `slsa-verifier` on PATH. Same reasoning as cosign in #128.
- **`install.sh` / `npm` switching to verify SLSA by default** — explicit follow-up if there's user demand.

## Test plan

- [x] Workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI green on this PR (no tag push, so `slsa-provenance` stays skipped — only fmt / test / install-script-sync run here)
- [ ] Next release tag exercises the SLSA step end-to-end; verify a `<tag>.intoto.jsonl` lands on the release
- [ ] After that release, run the README's `slsa-verifier verify-artifact` command and confirm `PASSED: SLSA verification passed`

Same workflow-file-modification gotcha as #128 may apply on CI dispatch — push an empty commit if `pull_request` event silently drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)