### PR TITLE
chore: release v0.2.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.28] - 2026-06-01
+
+### Added
+
+- *(extends)* Add @sha256 pinning, ed25519 sidecar signing, and tier provenance ([#29](https://github.com/taniwhaai/arai/pull/29))
+- *(style)* Add pounamu/ochre semantic colour palette for CLI output ([#83](https://github.com/taniwhaai/arai/pull/83))
+- *(style)* Add gateway outcome glyphs for blocked/allowed/warned ([#84](https://github.com/taniwhaai/arai/pull/84))
+- *(copy-tone)* Retune user-facing strings to restrained-declarative register ([#85](https://github.com/taniwhaai/arai/pull/85))
+
+
 ## [0.2.27] - 2026-05-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "0.2.27"
+version = "0.2.28"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 0.2.27 -> 0.2.28

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.28] - 2026-06-01

### Added

- *(extends)* Add @sha256 pinning, ed25519 sidecar signing, and tier provenance ([#29](https://github.com/taniwhaai/arai/pull/29))
- *(style)* Add pounamu/ochre semantic colour palette for CLI output ([#83](https://github.com/taniwhaai/arai/pull/83))
- *(style)* Add gateway outcome glyphs for blocked/allowed/warned ([#84](https://github.com/taniwhaai/arai/pull/84))
- *(copy-tone)* Retune user-facing strings to restrained-declarative register ([#85](https://github.com/taniwhaai/arai/pull/85))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).