### PR TITLE
Release v1.0.0 + GitHub Packages & ghcr container publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,3 +330,45 @@ jobs:
         run: cd npm && npm publish --registry=https://npm.pkg.github.com
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Build the repo's existing Dockerfile (MCP-server image, built from source)
+  # and push it to ghcr.io. The image's org.opencontainers.image.source label
+  # links the package to this repo, so it surfaces in the Packages sidebar
+  # alongside the npm artifact. Built from source rather than the prebuilt
+  # binary, so it has no dependency on the binary-attach job; gated on tests
+  # like the binary build. linux/amd64 only — an emulated arm64 Rust compile
+  # would dominate the release wall-clock; add a native arm64 runner later.
+  container-publish:
+    name: Publish container to ghcr.io
+    needs: [test, test-enrich]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    # Job-level permissions REPLACE the workflow-level block.
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: ver
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/taniwhaai/arai:${{ steps.ver.outputs.version }}
+            ghcr.io/taniwhaai/arai:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,3 +292,41 @@ jobs:
         run: cd npm && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # Mirror the same npm wrapper to GitHub Packages so the repo's
+  # "Packages" sidebar resolves to a first-party artifact.  The @taniwhaai
+  # scope matches the org, so GitHub Packages accepts it and auto-links the
+  # package to this repo (via package.json's repository field).  Uses the
+  # built-in GITHUB_TOKEN — no extra secret — and runs only after binaries
+  # are attached, since the wrapper's postinstall fetches them from the
+  # release.  Separate runner from npm-publish, so the npmjs publish is
+  # unaffected by the GitHub Packages registry config.
+  github-packages-publish:
+    name: Publish to GitHub Packages
+    needs: attach-binaries
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    # Job-level permissions REPLACE the workflow-level block, so contents:read
+    # (for checkout) must be restated alongside packages:write.
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@taniwhaai'
+
+      - name: Sync version from tag
+        run: |
+          TAG=${GITHUB_REF#refs/tags/v}
+          cd npm
+          node -e "const p=require('./package.json'); p.version='$TAG'; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n')"
+
+      - name: Publish
+        run: cd npm && npm publish --registry=https://npm.pkg.github.com
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-06-02
+
+First stable release. The CLI surface, hook protocol, and on-disk
+formats (audit log, `arai.toml`, severity overrides) are now stable and
+follow semantic versioning.
+
+### Added
+
+- *(dist)* Publish the npm wrapper to GitHub Packages alongside npmjs
+
 ## [0.2.28] - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ follow semantic versioning.
 ### Added
 
 - *(dist)* Publish the npm wrapper to GitHub Packages alongside npmjs
+- *(dist)* Publish a container image to ghcr.io on release
 
 ## [0.2.28] - 2026-06-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "0.2.28"
+version = "1.0.0"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "0.2.28"
+version = "1.0.0"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,12 @@ RUN cargo build --release --locked
 # ---------- Runtime stage ----------
 FROM debian:bookworm-slim AS runtime
 
+# OCI labels. `image.source` is what GitHub uses to auto-link the ghcr
+# package back to this repo, so it surfaces in the repo's Packages sidebar.
+LABEL org.opencontainers.image.source="https://github.com/taniwhaai/arai"
+LABEL org.opencontainers.image.description="Arai — enforce AI coding instruction files (CLAUDE.md, AGENTS.md, .cursorrules) via hooks."
+LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
+
 # ca-certificates: needed for `arai:extends` HTTPS fetches of trusted upstream
 # policy files. Nothing else reaches the network on the hook hot path.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/src/store.rs
+++ b/src/store.rs
@@ -1186,7 +1186,12 @@ mod tests {
             source_label: None,
         };
         store
-            .upsert_file("CLAUDE.md", "- a", &[t.clone()], "claude_md_project")
+            .upsert_file(
+                "CLAUDE.md",
+                "- a",
+                std::slice::from_ref(&t),
+                "claude_md_project",
+            )
             .unwrap();
         store
             .upsert_file(
@@ -1720,7 +1725,7 @@ mod tests {
             source_label: None,
         };
         store
-            .upsert_file("CLAUDE.md", "x", &[t.clone()], "test")
+            .upsert_file("CLAUDE.md", "x", std::slice::from_ref(&t), "test")
             .unwrap();
         store
             .disable_rule("git", "never", "force-push to main")


### PR DESCRIPTION
First stable release, plus two new distribution channels that populate the repo's **Packages** sidebar.

## What this does

**v1.0.0** — All issues are closed; this declares the CLI surface, hook protocol, and on-disk formats (audit log, \`arai.toml\`, severity overrides) stable, now under semantic versioning. Version bumped manually in \`Cargo.toml\`/\`Cargo.lock\` so release-plz's \`release\` step publishes the manifest version to crates.io and tags \`v1.0.0\` on merge.

**GitHub Packages (npm)** — New \`github-packages-publish\` job mirrors the existing \`@taniwhaai/arai\` wrapper to \`npm.pkg.github.com\`. The org-matching scope lets GitHub auto-link the package to this repo.

**ghcr container** — New \`container-publish\` job builds the repo's existing Dockerfile (MCP-server image, built from source) and pushes \`ghcr.io/taniwhaai/arai:<version>\` + \`:latest\`. Added \`org.opencontainers.image.source\` label so the package links to this repo. linux/amd64 only — an emulated arm64 Rust compile would dominate the release wall-clock; a native arm64 runner can be added later.

Both publish jobs use the built-in \`GITHUB_TOKEN\` — no new secrets. Everything ships together so the new CI jobs exist on the commit the \`v1.0.0\` tag points to.

**Clippy cleanup** — Fixed the \`cloned_ref_to_slice_refs\` lint (clippy 1.94, \`--all-targets\`) at the two \`store.rs\` test call sites by using \`std::slice::from_ref\`.

## Release flow on merge

1. \`release-plz\` sees manifest \`1.0.0\` (unpublished) → publishes to crates.io, tags \`v1.0.0\`, cuts the GitHub release.
2. The \`v1.0.0\` tag triggers: multi-platform binaries → cosign + SLSA attestation → npmjs publish → **GitHub Packages publish** + **ghcr container publish** (new).

## Verification

- \`cargo build\` → \`arai v1.0.0\`; \`Cargo.lock\` consistent.
- \`cargo fmt --all -- --check\` ✓; \`cargo clippy -- -D warnings\` (CI's invocation) ✓ exit 0; \`cargo test\` ✓ all suites pass.
- Workflow YAML validates; \`github-packages-publish\` and \`container-publish\` jobs present with \`packages: write\`.

## Known follow-up (out of scope)

\`cargo clippy --all-targets\` surfaces a handful of additional pre-existing, test-only lints (\`filter_next\`, \`double_ended_iterator_last\`, \`useless format!\`, etc.) in \`tests/\`. CI's gate (\`cargo clippy -- -D warnings\`, no \`--all-targets\`) doesn't hit them, so they don't block this release — left for a focused cleanup PR rather than churning test files here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)