### PR TITLE
Fix release pipeline + roll forward to v1.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,9 +191,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download all artifacts
+      - name: Download binary artifacts
         uses: actions/download-artifact@v8
         with:
+          # Scope to the per-platform binary artifacts only. Other jobs in
+          # the run upload unrelated artifacts (e.g. the container job's
+          # `.dockerbuild` build record); pulling those in broke the merge.
+          pattern: binaries-*
           path: binaries
           merge-multiple: true
 
@@ -365,6 +369,11 @@ jobs:
 
       - name: Build and push
         uses: docker/build-push-action@v6
+        # Suppress the `.dockerbuild` build-record artifact this action
+        # uploads by default — nothing consumes it, and an unfiltered
+        # download-artifact elsewhere in the run trips over it.
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           push: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-06-02
+
+### Fixed
+
+- *(ci)* Scope the release artifact download to the binary artifacts, so
+  the container job's build-record artifact no longer breaks GitHub-release
+  asset attachment and the npm publishes downstream of it
+
 ## [1.0.0] - 2026-06-02
 
 First stable release. The CLI surface, hook protocol, and on-disk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Why

The \`v1.0.0\` tag run failed at **attach-binaries**, which cascaded: **npm publish, GitHub Packages, and SLSA provenance were skipped**. Net state after v1.0.0:

- ✅ crates.io \`1.0.0\` — published
- ✅ ghcr container \`1.0.0\`/\`latest\` — published (that job only needs tests)
- ❌ GitHub release \`v1.0.0\` — **no binary assets attached**
- ❌ npmjs / GitHub Packages npm — **not published** (still \`0.2.28\`)
- ❌ SLSA provenance — skipped

## Root cause

\`docker/build-push-action@v6\` (added in the container job) uploads a \`.dockerbuild\` build-record artifact by default. \`attach-binaries\` used an **unfiltered** \`download-artifact\` (\`merge-multiple: true\`, no pattern), swept up that non-binary artifact, and failed: \`digest-mismatch … Artifact download failed after 5 retries\`. Everything downstream of attach-binaries was then skipped.

## Fix

1. **\`attach-binaries\`** → \`download-artifact\` now uses \`pattern: binaries-*\` so it only pulls the per-platform binaries, immune to any other artifacts in the run. *(This alone fixes the failure.)*
2. **\`container-publish\`** → set \`DOCKER_BUILD_RECORD_UPLOAD: false\` so the stray \`.dockerbuild\` artifact is never produced.

## Roll-forward, not tag-move

Rather than force-moving the published \`v1.0.0\` tag (which crates.io + ghcr already reference), this bumps to **v1.0.1**. On merge, release-plz publishes \`1.0.1\` to crates.io and tags it; the fixed pipeline then runs to completion — binaries attached, npmjs + GitHub Packages published, ghcr \`1.0.1\`/\`latest\`, SLSA provenance. \`1.0.1\` becomes "latest" everywhere; \`1.0.0\` stays valid on crates.io/ghcr.

## Verification

- \`cargo build\` → \`arai v1.0.1\`; lock consistent.
- \`cargo fmt --check\` ✓ · \`cargo clippy -- -D warnings\` ✓ exit 0 · \`cargo test\` ✓.
- Workflow YAML validates (11 jobs).

## Note

The \`v1.0.0\` GitHub release will remain asset-less (superseded by \`1.0.1\`). Optional cleanup: delete the \`v1.0.0\` GitHub release to avoid confusion — say the word and I'll do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)