### PR TITLE
chore: release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-06-09
+
+### Fixed
+
+- *(hooks)* Validate CwdChanged new_cwd before rooting a background scan ([#146](https://github.com/taniwhaai/arai/pull/146))
+
+
 ## [1.0.1] - 2026-06-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 1.0.1 -> 1.0.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.2] - 2026-06-09

### Fixed

- *(hooks)* Validate CwdChanged new_cwd before rooting a background scan ([#146](https://github.com/taniwhaai/arai/pull/146))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).