### PR TITLE
feat: restructure as library + thin CLI binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Ārai now builds as a library crate (`src/lib.rs`) alongside the CLI
+  binary, making the core — parser layers, rule store, guardrail
+  matching, audit chain, hook decision logic — embeddable as a
+  dependency. The CLI surface, hook contract, and DB schema are
+  unchanged; `src/main.rs` is now a thin CLI over the library
+  ([#148](https://github.com/taniwhaai/arai/issues/148))
+
 ## [1.0.2] - 2026-06-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,8 @@ ARAI_DENY_MODE=off cargo run -- guardrails --match-stdin  # Advise-only (no deny
 
 ```
 src/
-├── main.rs               # CLI entry (clap) — init, status, guardrails, scan, add, audit, mcp, upgrade, why
+├── lib.rs                # Library crate root — pub mods for the embeddable core (parser, store, guardrails, hooks, audit, …); CLI-support modules #[doc(hidden)]; telemetry private
+├── main.rs               # Thin CLI over the library (clap) — arg parsing + IO only; init, status, guardrails, scan, add, audit, mcp, upgrade, why
 ├── config.rs             # Config, project paths + slug, env vars, LLM command
 ├── discovery.rs          # Instruction file discovery (CLAUDE.md, .cursorrules, etc.)
 ├── parser.rs             # Rule extraction from markdown (7 layers of pattern matching); tracks layer + expiry

--- a/src/config.rs
+++ b/src/config.rs
@@ -258,7 +258,7 @@ impl Config {
         format!("{dir_name}-{short_hash}")
     }
 
-    /// DB path: ~/.taniwha/arai/projects/<dirname>-<8char-sha256>/arai.db
+    /// DB path: `~/.taniwha/arai/projects/<dirname>-<8char-sha256>/arai.db`
     pub fn db_path(&self) -> PathBuf {
         self.arai_base_dir
             .join("projects")

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -47,6 +47,11 @@ impl Severity {
         }
     }
 
+    // Not `std::str::FromStr`: this parser is infallible — unknown input
+    // falls back to `Warn` instead of erroring, which FromStr can't express
+    // without a lying `Err` type.  Rename is deferred to the library API
+    // surface audit (#148 follow-up).
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s {
             "block" => Severity::Block,
@@ -91,6 +96,8 @@ impl Timing {
         }
     }
 
+    // Infallible fallback parser — see the note on `Severity::from_str`.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s {
             "tool_call" => Timing::ToolCall,
@@ -144,6 +151,8 @@ impl Action {
         }
     }
 
+    // Infallible fallback parser — see the note on `Severity::from_str`.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s {
             "create" => Action::Create,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,85 @@
+//! Ārai as a library.
+//!
+//! Ārai enforces AI coding assistant instruction files (CLAUDE.md,
+//! AGENTS.md, .cursorrules, …) via hooks.  This crate exposes the core
+//! pipeline so wrappers, IDE integrations, and downstream tools can embed
+//! enforcement as a dependency instead of shelling out to the `arai` CLI.
+//!
+//! # Core pipeline
+//!
+//! ```text
+//! instruction file ──parser──▶ rules (triples) ──store──▶ SQLite + FTS5
+//!                                                            │
+//! hook JSON ──hooks::match_hook──▶ guardrails matching ◀─────┘
+//!                    │
+//!                    ├──▶ intent / severity  →  deny / warn / inform
+//!                    └──▶ audit (hash-chained JSONL) + compliance verdicts
+//! ```
+//!
+//! The single pure entry point used by both the live stdio handler and the
+//! `arai test` scenario runner is [`hooks::match_hook`] — any change to
+//! rule-matching logic goes there so the two paths stay identical.  Side
+//! effects (audit write, telemetry, session write) live only on the CLI's
+//! stdin-handling path.
+//!
+//! # Module map
+//!
+//! | Module | Role |
+//! |--------|------|
+//! | [`parser`] | Rule extraction from markdown (7 layers of pattern matching) |
+//! | [`store`] | SQLite + FTS5 persistence (files, triples, code graph, rule intent) |
+//! | [`guardrails`] | Term extraction, subject matching, tool-scope filtering |
+//! | [`hooks`] | Hook protocol — PreToolUse/PostToolUse/UserPromptSubmit → decisions |
+//! | [`intent`] | Intent classification — action, timing, tool scope, severity |
+//! | [`audit`] | Local hash-chained JSONL firing log |
+//! | [`compliance`] | Pre/Post correlation — Obeyed/Ignored/Unclear verdicts |
+//! | [`config`] | Config file, project paths + slug, env vars |
+//! | [`discovery`] | Instruction-file discovery |
+//! | [`session`] | Per-session prerequisite + seen-rule tracking |
+//! | [`prompt_collector`] | Read-only prompt-pattern observation (no enforcement) |
+//! | [`canonicalize`] | Rule extraction from existing instruction files |
+//!
+//! Remaining modules (`init`, `mcp`, `stats`, `scenarios`, …) back specific
+//! CLI subcommands; they are exported for the `arai` binary but hidden from
+//! docs and not part of the supported library API.
+
+pub mod audit;
+pub mod canonicalize;
+pub mod compliance;
+pub mod config;
+pub mod discovery;
+pub mod guardrails;
+pub mod hooks;
+pub mod intent;
+pub mod parser;
+pub mod prompt_collector;
+pub mod session;
+pub mod store;
+
+// CLI-support modules: exported so the `arai` binary (and integration
+// tests) can reach them, but hidden from rustdoc — they back specific
+// subcommands and are not a supported embedding surface.
+#[doc(hidden)]
+pub mod code_scanner;
+#[doc(hidden)]
+pub mod enrich;
+#[doc(hidden)]
+pub mod extends;
+#[doc(hidden)]
+pub mod init;
+#[doc(hidden)]
+pub mod mcp;
+#[doc(hidden)]
+pub mod migrate;
+#[doc(hidden)]
+pub mod scenarios;
+#[doc(hidden)]
+pub mod stats;
+#[doc(hidden)]
+pub mod style;
+#[doc(hidden)]
+pub mod sync;
+#[doc(hidden)]
+pub mod telemetry;
+#[doc(hidden)]
+pub mod upgrade;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,25 @@
 //! Remaining modules (`init`, `mcp`, `stats`, `scenarios`, …) back specific
 //! CLI subcommands; they are exported for the `arai` binary but hidden from
 //! docs and not part of the supported library API.
+//!
+//! # Security model
+//!
+//! The library runs with its caller's privileges and trust domain.  APIs
+//! that mutate enforcement state (severity overrides, rule disabling,
+//! trust-list writes, audit purge) are the same operations the CLI exposes
+//! to the local user — embedding Arai does not create a privilege boundary,
+//! and a hostile caller with the user's filesystem access could edit the
+//! underlying SQLite/TOML state directly regardless.  The audit chain is
+//! *tamper-evident* (hash-chained, `arai audit --verify`), not
+//! access-controlled: entries appended through this API are sealed into the
+//! chain, but the chain does not authenticate *who* appended them.
+//!
+//! # Stability
+//!
+//! The CLI surface, hook protocol, and on-disk formats are semver-stable
+//! (v1.0.0).  The **library API is not yet** — item-level surface audit is
+//! ongoing, and signatures may change in minor releases until the library
+//! API is declared stable.  Pin a minor version if you embed Arai.
 
 pub mod audit;
 pub mod canonicalize;
@@ -80,6 +99,10 @@ pub mod style;
 #[doc(hidden)]
 pub mod sync;
 #[doc(hidden)]
-pub mod telemetry;
-#[doc(hidden)]
 pub mod upgrade;
+
+// Not exported at all: telemetry is consumed only by lib-internal callers
+// (hooks, init, mcp).  Keeping it private means no external caller can
+// enqueue events into the telemetry channel — the audit/telemetry
+// separation stays enforced by visibility, not just convention.
+mod telemetry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@
 //! All enforcement logic lives in [`arai`] (see `src/lib.rs`).
 
 use arai::{
-    audit, canonicalize, code_scanner, config, discovery, enrich, extends, guardrails, hooks,
-    init, intent, mcp, migrate, parser, scenarios, stats, store, style, sync, upgrade,
+    audit, canonicalize, code_scanner, config, discovery, enrich, extends, guardrails, hooks, init,
+    intent, mcp, migrate, parser, scenarios, stats, store, style, sync, upgrade,
 };
 use clap::{Parser, Subcommand};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,10 @@
-mod audit;
-mod canonicalize;
-mod code_scanner;
-mod compliance;
-mod config;
-mod discovery;
-mod enrich;
-mod extends;
-mod guardrails;
-mod hooks;
-mod init;
-mod intent;
-mod mcp;
-mod migrate;
-mod parser;
-mod prompt_collector;
-mod scenarios;
-mod session;
-mod stats;
-mod store;
-mod style;
-mod sync;
-mod telemetry;
-mod upgrade;
+//! Thin CLI over the `arai` library crate: argument parsing and IO only.
+//! All enforcement logic lives in [`arai`] (see `src/lib.rs`).
 
+use arai::{
+    audit, canonicalize, code_scanner, config, discovery, enrich, extends, guardrails, hooks,
+    init, intent, mcp, migrate, parser, scenarios, stats, store, style, sync, upgrade,
+};
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
@@ -1569,7 +1551,7 @@ fn cmd_why(input: Vec<String>, tool: String, event: String, json: bool) -> Resul
         }
         _ => serde_json::json!({ "preview": joined }),
     };
-    let canonical_tool = crate::guardrails::normalize_tool_name(&tool);
+    let canonical_tool = guardrails::normalize_tool_name(&tool);
     let hook = serde_json::json!({
         "hook_event_name": event,
         "tool_name": canonical_tool,

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -4,7 +4,7 @@
 //! - "rule_fired": a guardrail matched and was injected
 //! - "rule_followed": the LLM changed behavior after seeing the guardrail
 //!
-//! Opt-out: ARAI_TELEMETRY=off, DO_NOT_TRACK=1, or [telemetry] enabled = false in config.toml
+//! Opt-out: ARAI_TELEMETRY=off, DO_NOT_TRACK=1, or `[telemetry] enabled = false` in config.toml
 //! Never runs on the hot hook path — events are queued and flushed async.
 
 use std::path::Path;

--- a/tests/parser_coverage.rs
+++ b/tests/parser_coverage.rs
@@ -19,10 +19,11 @@
 //!      object text doesn't appear in any extracted rule.
 //!
 //! Why driven through the binary instead of importing the parser as a
-//! library: arai is a binary-only crate (no `[lib]` target), so external
-//! tests can't `use arai::parser`.  Running the actual binary has the
-//! side benefit of exercising the full lint→parser→intent classification
-//! pipeline end-to-end.
+//! library: `arai lint --json` is the documented surface a CI pipeline
+//! or pre-commit hook would use, and running the actual binary exercises
+//! the full lint→parser→intent classification pipeline end-to-end.
+//! (`use arai::parser` is possible since the lib/bin split, but would
+//! only cover the parser in isolation.)
 
 use serde_json::Value;
 use std::path::PathBuf;


### PR DESCRIPTION
Closes #148. First piece of the v1.1 bring-your-own-collector track (#152).

## What

- New `src/lib.rs` exposes the core pipeline — parser, store, guardrails, hooks, intent, audit, compliance, config, discovery, session, prompt_collector, canonicalize — as a documented library API, so wrappers and downstream tools can embed enforcement as a dependency instead of shelling out.
- CLI-support modules (init, mcp, stats, scenarios, …) stay exported for the binary but `#[doc(hidden)]`.
- `telemetry` is **private** to the lib: only hooks/init/mcp call it, so no external caller can enqueue telemetry events — the audit/telemetry channel separation is enforced by visibility, not convention.
- `src/main.rs` is now a thin CLI over the library (arg parsing + IO only).
- lib.rs documents the security model (same-trust-domain; audit chain is tamper-evident, not access-controlled) and marks the library API as **not yet semver-stable** pending an item-level surface audit — the CLI/hook/on-disk stability guarantee from v1.0.0 is unchanged.

## Acceptance criteria

- [x] Builds as both `rlib` and the existing `bin` (default + `--features enrich`)
- [x] Public API documented — `cargo doc` clean (0 warnings), deliberate module-level surface, no blanket re-exports
- [x] All existing tests pass unchanged (404 unit + 20 integration suites); CLI behavior untouched — no logic edits, module declarations only
- [x] CHANGELOG notes the embeddable-library milestone

## Adversarial review + speed check

8-angle adversarial review run before this PR (line-by-line, removed-behavior, cross-file, reuse, efficiency, altitude, conventions, security). Fixes folded in: telemetry made private, stale binary-only-crate comment in tests/parser_coverage.rs corrected, CLAUDE.md architecture map updated, security-model + stability notes added to lib.rs. Refuted empirically: hot-path regression — interleaved A/B, 120 runs each, median **2.97 ms (main) vs 2.84 ms (branch)**, release binary +0.1%; `panic="abort"` concern (Cargo ignores dependency profiles).

Follow-up candidate (not blocking): item-level pub API audit before declaring the library surface semver-stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)