### PR TITLE
feat(telemetry): configurable endpoint for self-hosted collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ All notable changes to this project will be documented in this file.
   never reaches disk, logs, audit, telemetry, or error messages, and
   redirects stay disabled so the header cannot leak cross-host
   ([#150](https://github.com/taniwhaai/arai/issues/150))
+- *(telemetry)* Configurable telemetry endpoint: `[telemetry] endpoint`
+  (+ optional `bearer_env`) in config.toml points the existing queue at
+  a self-hosted collector — same events, no PostHog api_key, 5 s
+  timeout, queue retained on failure. Default sink unchanged when
+  unset; `ARAI_TELEMETRY=off` / `DO_NOT_TRACK=1` / `enabled = false`
+  win regardless of endpoint (the config-level `enabled = false`
+  opt-out is now actually enforced at the egress point — it was
+  documented but unimplemented). Payload schema documented in
+  docs/telemetry-payload.md
+  ([#151](https://github.com/taniwhaai/arai/issues/151))
 
 ## [1.0.2] - 2026-06-09
 

--- a/README.md
+++ b/README.md
@@ -851,6 +851,33 @@ We **never** collect file paths, rule text, code content, API keys, or anything 
 export ARAI_TELEMETRY=off   # or DO_NOT_TRACK=1
 ```
 
+or in `~/.taniwha/arai/config.toml`:
+
+```toml
+[telemetry]
+enabled = false
+```
+
+### Self-hosted collector
+
+Organizations that want the usage signal on **their own
+infrastructure** can point the existing queue at their own endpoint —
+same events, same anonymity constraints, your retention rules:
+
+```toml
+[telemetry]
+endpoint = "https://collector.example.com/arai"
+bearer_env = "ARAI_TELEMETRY_TOKEN"   # optional; env var NAME, not the token
+```
+
+Default behavior is unchanged when `endpoint` is unset. Opt-outs win
+regardless of endpoint. HTTPS required (plain HTTP allowed only for
+loopback dev collectors), batches retry on failure, and the payload
+schema is documented in
+[docs/telemetry-payload.md](docs/telemetry-payload.md) so you know
+exactly what you're receiving. The audit log remains a separate,
+local-only channel.
+
 ## Built By
 
 [Taniwha.ai](https://taniwha.ai) — extracted from the [Kete](https://github.com/taniwhaai/kete) code intelligence platform.

--- a/docs/telemetry-payload.md
+++ b/docs/telemetry-payload.md
@@ -1,0 +1,97 @@
+# Telemetry payload schema (self-hosted collectors)
+
+When `[telemetry] endpoint` is set in `~/.taniwha/arai/config.toml`, Ārai
+POSTs queued telemetry batches to your collector instead of the default
+sink. This documents exactly what arrives, so you know what you're
+storing.
+
+## Configuration
+
+```toml
+# ~/.taniwha/arai/config.toml
+[telemetry]
+enabled = true                                # opt-outs always win (see below)
+endpoint = "https://collector.example.com/arai"
+bearer_env = "ARAI_TELEMETRY_TOKEN"           # optional; env var NAME, not the token
+```
+
+- `endpoint` must be `https://`; plain `http://` is allowed only for
+  loopback (`127.0.0.1` / `localhost` / `[::1]`) so a local dev
+  collector works without a certificate.
+- `bearer_env` names an environment variable; when set and non-empty at
+  flush time, the request carries `Authorization: Bearer <token>`. Only
+  the variable name is ever stored.
+- Opt-outs override everything, endpoint included: `ARAI_TELEMETRY=off`,
+  `DO_NOT_TRACK=1`, or `enabled = false` all mean nothing leaves the
+  machine.
+
+## Transport
+
+- `POST <endpoint>` with `Content-Type: application/json`, 5-second
+  timeout, redirects disabled.
+- Flushes happen from CLI commands (`arai init` / `scan` / `audit` /
+  `stats`), never from the hook hot path.
+- Any 2xx clears the local queue; anything else retains it, and the next
+  flush retries the same batch. Design your collector to tolerate
+  duplicate batches (idempotent ingest or dedupe on event content).
+
+## Envelope
+
+```json
+{
+  "batch": [
+    {
+      "event": "rule_fired",
+      "properties": { "...": "see per-event tables below" },
+      "timestamp": "1751692800"
+    }
+  ]
+}
+```
+
+- `timestamp` is Unix seconds as a string, recorded at queue time.
+- The default-sink `api_key` field is **not** sent to custom endpoints.
+
+## Common properties (merged into every event at flush time)
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `distinct_id` | string | Random anonymous machine id (`arai-<8 hex>`); no hardware or user derivation |
+| `arai_version` | string | Crate version |
+| `os` | string | `std::env::consts::OS` |
+| `arch` | string | `std::env::consts::ARCH` |
+
+## Events
+
+### `rule_fired`
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `rule_hash` | string | Salted SHA-256 prefix (12 hex chars) of subject+predicate — rule text never leaves the machine |
+| `tool_name` | string | Tool the rule fired on (Bash, Edit, …) |
+| `hook_event` | string | PreToolUse / PostToolUse / UserPromptSubmit |
+| `match_pct` | number | Match confidence 0–100 |
+| `severity` | string | block / warn / inform |
+
+### `hook_latency`
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `hook_event` | string | Hook event name |
+| `latency_ms` | number | End-to-end hook handling time |
+| `matched` | bool | Whether any rule matched |
+
+### `arai_init`
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `rule_count` | number | Rules extracted |
+| `file_count` | number | Instruction files discovered |
+| `code_graph_tools` | number | Tools detected by the code scan |
+| `enrichment_tier` | string | taxonomy / onnx / llm |
+
+No project paths, no rule text, no prompts, no code content — the same
+anonymity constraints as the default sink. The audit log
+(`arai audit`) is a separate, local-only channel and is never shipped
+by telemetry regardless of endpoint (see `arai audit --ship` / #149 for
+the audit-side story).

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -4,8 +4,14 @@
 //! - "rule_fired": a guardrail matched and was injected
 //! - "rule_followed": the LLM changed behavior after seeing the guardrail
 //!
-//! Opt-out: ARAI_TELEMETRY=off, DO_NOT_TRACK=1, or `[telemetry] enabled = false` in config.toml
+//! Opt-out: ARAI_TELEMETRY=off, DO_NOT_TRACK=1, or `[telemetry] enabled = false` in config.toml.
+//! Opt-outs always win — including over a configured custom endpoint.
 //! Never runs on the hot hook path — events are queued and flushed async.
+//!
+//! Self-hosted collectors: `[telemetry] endpoint = "https://…"` (plus
+//! optional `bearer_env`) redirects the existing queue to your own
+//! infrastructure.  Default behavior is unchanged when unset.  Payload
+//! schema: docs/telemetry-payload.md.
 
 use std::path::Path;
 
@@ -167,9 +173,155 @@ pub fn track_hook_latency(arai_base: &Path, hook_event: &str, latency_ms: u128, 
     );
 }
 
-/// Flush queued events to PostHog (called from non-hook commands like `arai init`).
+/// `[telemetry]` settings from `{arai_base}/config.toml`.
+///
+/// - `enabled = false` — config-level opt-out.  Checked at the egress point
+///   (`flush`), so nothing ever leaves the machine; the local queue file may
+///   still accumulate up to its 2 MB cap but is never shipped.  The env
+///   opt-outs (`ARAI_TELEMETRY=off`, `DO_NOT_TRACK=1`) are checked on the
+///   hook path as before and always win.
+/// - `endpoint = "https://…"` — self-hosted collector.  When set, batches
+///   POST there instead of the default sink; the payload envelope is
+///   `{"batch": [...]}` (no PostHog `api_key`).  See
+///   `docs/telemetry-payload.md` for the schema.  HTTPS required, except
+///   plain HTTP to loopback (`127.0.0.1` / `::1` / `localhost`) for local
+///   collectors.
+/// - `bearer_env = "VAR"` — name of an environment variable holding a
+///   bearer token for the custom endpoint.  Same discipline as
+///   `arai trust --bearer-env`: only the name is configured, the token is
+///   resolved at flush time and never logged.
+struct TelemetryConfig {
+    enabled: bool,
+    endpoint: Option<String>,
+    bearer_env: Option<String>,
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        TelemetryConfig {
+            enabled: true,
+            endpoint: None,
+            bearer_env: None,
+        }
+    }
+}
+
+/// Parse the `[telemetry]` section out of a config.toml body.  Unknown keys
+/// and malformed files fall back to defaults — telemetry must never break a
+/// CLI command.
+fn parse_telemetry_config(content: &str) -> TelemetryConfig {
+    // `toml::Table`, not `toml::Value`: in toml v1 a document (with
+    // `[section]` headers) only parses as a table.
+    let Ok(table) = content.parse::<toml::Table>() else {
+        return TelemetryConfig::default();
+    };
+    let Some(section) = table.get("telemetry") else {
+        return TelemetryConfig::default();
+    };
+    TelemetryConfig {
+        enabled: section
+            .get("enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true),
+        endpoint: section
+            .get("endpoint")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        bearer_env: section
+            .get("bearer_env")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+    }
+}
+
+fn load_telemetry_config(arai_base: &Path) -> TelemetryConfig {
+    let path = arai_base.join("config.toml");
+    match std::fs::read_to_string(&path) {
+        Ok(content) => parse_telemetry_config(&content),
+        Err(_) => TelemetryConfig::default(),
+    }
+}
+
+/// Validate a custom collector endpoint.  HTTPS anywhere; plain HTTP only to
+/// loopback so a local dev collector works without a cert while off-host
+/// traffic can never carry events (or a bearer token) unencrypted.
+fn validate_endpoint(url: &str) -> Result<(), String> {
+    if url.starts_with("https://") {
+        return Ok(());
+    }
+    if let Some(rest) = url.strip_prefix("http://") {
+        let authority = rest.split(['/', '?', '#']).next().unwrap_or("");
+        // Reject userinfo outright: `http://localhost@evil.com/` connects to
+        // evil.com — a naive host check would read "localhost" and wave the
+        // loopback exception through.
+        if authority.contains('@') {
+            return Err("userinfo ('@') is not allowed in the telemetry endpoint".to_string());
+        }
+        let host = if authority.starts_with('[') {
+            // IPv6 literal: everything up to and including the bracket.
+            match authority.split_once(']') {
+                Some((h, _)) => format!("{h}]"),
+                None => return Err("malformed IPv6 literal in endpoint".to_string()),
+            }
+        } else {
+            authority
+                .rsplit_once(':')
+                .map(|(h, _)| h.to_string())
+                .unwrap_or_else(|| authority.to_string())
+        };
+        if host == "127.0.0.1" || host == "localhost" || host == "[::1]" {
+            return Ok(());
+        }
+        return Err("plain http is only allowed for loopback collectors \
+                    (127.0.0.1 / localhost / [::1]); use https"
+            .to_string());
+    }
+    Err("telemetry endpoint must be an https:// URL".to_string())
+}
+
+/// POST a batch payload to a custom collector.  Returns Ok on any 2xx.
+/// The bearer token travels only in the request header — never in argv
+/// (visible in the process list) and never in the returned error text.
+fn post_batch_custom(
+    endpoint: &str,
+    payload: &serde_json::Value,
+    bearer: Option<&str>,
+) -> Result<(), String> {
+    let scrub = |msg: String| match bearer {
+        Some(t) if !t.is_empty() => msg.replace(t, "[redacted]"),
+        _ => msg,
+    };
+    let agent = ureq::Agent::config_builder()
+        .timeout_global(Some(std::time::Duration::from_secs(5)))
+        .max_redirects(0)
+        .build()
+        .new_agent();
+    let mut request = agent
+        .post(endpoint)
+        .header("Content-Type", "application/json");
+    if let Some(token) = bearer {
+        request = request.header("Authorization", format!("Bearer {token}"));
+    }
+    let response = request
+        .send(payload.to_string().as_bytes())
+        .map_err(|e| scrub(format!("HTTP error: {e}")))?;
+    if !response.status().is_success() {
+        return Err(format!("HTTP {} from collector", response.status()));
+    }
+    Ok(())
+}
+
+/// Flush queued events to the configured sink (called from non-hook commands
+/// like `arai init` — never from the hook hot path).  Default sink unless a
+/// `[telemetry] endpoint` is configured; all opt-outs win regardless.
 pub fn flush(arai_base: &Path) {
     if !is_enabled() {
+        return;
+    }
+    let tcfg = load_telemetry_config(arai_base);
+    if !tcfg.enabled {
+        // Config-level opt-out: nothing leaves the machine, regardless of
+        // endpoint.  The queue file stays local and capped.
         return;
     }
 
@@ -222,6 +374,36 @@ pub fn flush(arai_base: &Path) {
         })
         .collect();
 
+    // Self-hosted collector: same events, their infrastructure.  Synchronous
+    // with a hard 5 s timeout (flush runs from CLI commands, never hooks);
+    // the queue is only cleared on success so a down collector loses nothing.
+    if let Some(endpoint) = &tcfg.endpoint {
+        if let Err(e) = validate_endpoint(endpoint) {
+            eprintln!("arai: telemetry endpoint rejected: {e}");
+            return;
+        }
+        let bearer = tcfg
+            .bearer_env
+            .as_deref()
+            .and_then(|name| std::env::var(name).ok())
+            .filter(|v| !v.is_empty());
+        // No PostHog api_key on the custom path — the envelope is just the
+        // batch.  Schema: docs/telemetry-payload.md.
+        let payload = serde_json::json!({ "batch": batch });
+        match post_batch_custom(endpoint, &payload, bearer.as_deref()) {
+            Ok(()) => {
+                std::fs::remove_file(&queue_path).ok();
+            }
+            Err(e) => {
+                // Queue retained — next flush retries.  Error is already
+                // token-scrubbed.
+                eprintln!("arai: telemetry flush to custom endpoint failed: {e}");
+            }
+        }
+        return;
+    }
+
+    // Default sink — unchanged behavior when no endpoint is configured.
     let payload = serde_json::json!({
         "api_key": POSTHOG_KEY,
         "batch": batch,
@@ -310,6 +492,191 @@ mod tests {
         let c = rule_hash("git", "always");
         assert_ne!(a, b, "different subject → different hash");
         assert_ne!(a, c, "different predicate → different hash");
+    }
+
+    // ── #151: configurable telemetry endpoint ────────────────────────────────
+
+    #[test]
+    fn telemetry_config_parses_and_defaults() {
+        // No section → defaults.
+        let c = parse_telemetry_config("extra_sources = []");
+        assert!(c.enabled && c.endpoint.is_none() && c.bearer_env.is_none());
+        // Malformed file → defaults (telemetry must never break a command).
+        let c = parse_telemetry_config("this is [ not toml");
+        assert!(c.enabled && c.endpoint.is_none());
+        // Full section.
+        let c = parse_telemetry_config(
+            "[telemetry]\nenabled = true\nendpoint = \"https://c.example.com/arai\"\nbearer_env = \"ARAI_TELEMETRY_TOKEN\"\n",
+        );
+        assert!(c.enabled);
+        assert_eq!(c.endpoint.as_deref(), Some("https://c.example.com/arai"));
+        assert_eq!(c.bearer_env.as_deref(), Some("ARAI_TELEMETRY_TOKEN"));
+        // Config opt-out.
+        let c = parse_telemetry_config("[telemetry]\nenabled = false\n");
+        assert!(!c.enabled);
+    }
+
+    #[test]
+    fn endpoint_validation_https_or_loopback_only() {
+        assert!(validate_endpoint("https://collector.example.com/v1").is_ok());
+        assert!(validate_endpoint("http://127.0.0.1:8080/ingest").is_ok());
+        assert!(validate_endpoint("http://localhost:9999").is_ok());
+        assert!(validate_endpoint("http://[::1]:8080/x").is_ok());
+        assert!(validate_endpoint("http://[::1]").is_ok());
+        assert!(validate_endpoint("http://collector.example.com/v1").is_err());
+        assert!(validate_endpoint("http://127.0.0.2/x").is_err());
+        assert!(validate_endpoint("ftp://x").is_err());
+        // Userinfo trick: the real host is evil.com, not loopback.
+        assert!(validate_endpoint("http://localhost@evil.com/x").is_err());
+        assert!(validate_endpoint("http://localhost:8080@evil.com/x").is_err());
+        assert!(validate_endpoint("http://127.0.0.1@evil.com").is_err());
+    }
+
+    /// Live loopback test: the batch reaches a custom collector with the
+    /// bearer header, without the PostHog api_key, and the queue is only
+    /// cleared on success.
+    #[test]
+    fn custom_endpoint_receives_batch_and_clears_queue_on_success() {
+        use std::io::{Read as _, Write as _};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            let (mut s, _) = listener.accept().unwrap();
+            // Headers and body arrive in separate writes — keep reading
+            // (bounded by a read timeout) until the stream pauses.
+            s.set_read_timeout(Some(std::time::Duration::from_millis(500)))
+                .unwrap();
+            let mut buf = Vec::new();
+            let mut tmp = [0u8; 4096];
+            loop {
+                match s.read(&mut tmp) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        buf.extend_from_slice(&tmp[..n]);
+                        let text = String::from_utf8_lossy(&buf);
+                        // Stop once the full declared body has arrived.
+                        if let Some((head, body)) = text.split_once("\r\n\r\n") {
+                            let expected = head
+                                .lines()
+                                .find_map(|l| {
+                                    l.to_lowercase()
+                                        .strip_prefix("content-length:")
+                                        .map(|v| v.trim().parse::<usize>().unwrap_or(0))
+                                })
+                                .unwrap_or(0);
+                            if body.len() >= expected {
+                                break;
+                            }
+                        }
+                    }
+                    Err(_) => break, // timeout: whatever arrived is the request
+                }
+            }
+            s.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                .unwrap();
+            String::from_utf8_lossy(&buf).to_string()
+        });
+
+        let base = std::env::temp_dir().join(format!("arai_tel_flush_{}", std::process::id()));
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::write(
+            base.join("config.toml"),
+            format!("[telemetry]\nendpoint = \"http://127.0.0.1:{port}/ingest\"\n"),
+        )
+        .unwrap();
+        let queue = base.join("telemetry_queue.jsonl");
+        std::fs::write(
+            &queue,
+            "{\"event\":\"rule_fired\",\"properties\":{\"rule_hash\":\"abc\"},\"timestamp\":\"1\"}\n{\"event\":\"hook_latency\",\"properties\":{\"latency_ms\":3},\"timestamp\":\"2\"}\n",
+        )
+        .unwrap();
+
+        flush(&base);
+
+        let request = handle.join().unwrap();
+        assert!(request.contains("POST /ingest"));
+        assert!(request.contains("rule_fired") && request.contains("hook_latency"));
+        assert!(
+            !request.contains(POSTHOG_KEY),
+            "custom collectors must not receive the default sink api_key"
+        );
+        assert!(!queue.exists(), "queue must be cleared after a 2xx");
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    /// A failing collector must retain the queue for the next flush, and the
+    /// bearer token must reach the wire but never the error text.
+    #[test]
+    fn custom_endpoint_failure_keeps_queue_and_scrubs_token() {
+        use std::io::{Read as _, Write as _};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            let (mut s, _) = listener.accept().unwrap();
+            let mut tmp = [0u8; 4096];
+            let n = s.read(&mut tmp).unwrap_or(0);
+            let req = String::from_utf8_lossy(&tmp[..n]).to_string();
+            s.write_all(
+                b"HTTP/1.1 503 Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            )
+            .unwrap();
+            req
+        });
+
+        let payload = serde_json::json!({"batch": []});
+        let err = post_batch_custom(
+            &format!("http://127.0.0.1:{port}/ingest"),
+            &payload,
+            Some("tel-sekrit"),
+        )
+        .expect_err("503 must be an error");
+        let request = handle.join().unwrap();
+        assert!(
+            request
+                .to_lowercase()
+                .contains("authorization: bearer tel-sekrit"),
+            "bearer must reach the collector; got:\n{request}"
+        );
+        assert!(
+            !err.contains("tel-sekrit"),
+            "error text leaked the token: {err}"
+        );
+    }
+
+    /// `[telemetry] enabled = false` must stop egress even with an endpoint
+    /// configured — no connection is attempted, the queue stays local.
+    #[test]
+    fn config_optout_blocks_custom_endpoint_egress() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        listener.set_nonblocking(true).unwrap();
+
+        let base = std::env::temp_dir().join(format!("arai_tel_optout_{}", std::process::id()));
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::write(
+            base.join("config.toml"),
+            format!(
+                "[telemetry]\nenabled = false\nendpoint = \"http://127.0.0.1:{port}/ingest\"\n"
+            ),
+        )
+        .unwrap();
+        let queue = base.join("telemetry_queue.jsonl");
+        std::fs::write(
+            &queue,
+            "{\"event\":\"rule_fired\",\"properties\":{},\"timestamp\":\"1\"}\n",
+        )
+        .unwrap();
+
+        flush(&base);
+
+        assert!(
+            matches!(listener.accept(), Err(e) if e.kind() == std::io::ErrorKind::WouldBlock),
+            "flush must not connect when enabled = false"
+        );
+        assert!(queue.exists(), "queue must be retained (local, capped)");
+        std::fs::remove_dir_all(&base).ok();
     }
 
     #[test]


### PR DESCRIPTION
Closes #151. Part of the v1.1 bring-your-own-collector track (#152).

## What

```toml
# ~/.taniwha/arai/config.toml
[telemetry]
endpoint = "https://collector.example.com/arai"
bearer_env = "ARAI_TELEMETRY_TOKEN"   # optional; env var NAME, not the token
```

Same events, your infrastructure, your retention rules.

## Acceptance criteria

- [x] **Endpoint override honored; default unchanged when unset** — the no-endpoint path is byte-identical (same curl fire-and-forget). The custom path uses ureq (already a dependency) with a 5 s timeout, redirects disabled, and clears the queue only on 2xx — a down collector loses nothing.
- [x] **Opt-out flags override everything (tested)** — `ARAI_TELEMETRY=off` / `DO_NOT_TRACK=1` / `enabled = false` win regardless of endpoint. Live test binds a listener, sets `enabled = false` + endpoint, and asserts no connection is attempted. Bonus fix: the config-level `enabled = false` opt-out was **documented but unimplemented** — it's now enforced at the egress point.
- [x] **No hot-path change; no new data fields** — `track()` untouched; config.toml is read only in `flush()` (CLI commands, never hooks). Custom payload is the same batch minus the PostHog `api_key`.
- [x] **Payload schema documented** — [docs/telemetry-payload.md](docs/telemetry-payload.md): envelope, transport/retry semantics, common properties, per-event field tables.

## Adversarial review + hardness

Reviewed inline. Findings fixed during review: `toml::Value` vs `toml::Table` document-parse bug (caught by tests); endpoint validator was vulnerable to the userinfo trick — `http://localhost:8080@evil.com/x` would pass a naive host check while actually connecting to evil.com — now `@` is rejected in the authority and IPv6 literals are parsed properly (tested). Bearer token: header-only (never curl argv where `ps` could read it), never persisted, scrubbed from transport errors (tested against a live 503). Audit/telemetry channel separation unchanged — this PR touches only the telemetry path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)