### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-05
+
+### Added
+
+- Restructure as library + thin CLI binary ([#153](https://github.com/taniwhaai/arai/pull/153))
+- *(extends)* Authenticated arai:extends for private rule sources ([#154](https://github.com/taniwhaai/arai/pull/154))
+- *(telemetry)* Configurable endpoint for self-hosted collectors ([#155](https://github.com/taniwhaai/arai/pull/155))
+- *(audit)* Arai audit --ship — send the audit trail to your own collector ([#156](https://github.com/taniwhaai/arai/pull/156))
+
+### Documentation
+
+- *(site)* Surface v1.1 features and sharpen the value proposition ([#158](https://github.com/taniwhaai/arai/pull/158))
+
+### Fixed
+
+- *(grok)* Realign integration with current Grok Build hooks contract ([#159](https://github.com/taniwhaai/arai/pull/159))
+
+### Refactored
+
+- *(lib)* Item-level library API surface audit ([#162](https://github.com/taniwhaai/arai/pull/162)) ([#163](https://github.com/taniwhaai/arai/pull/163))
+
+
 ### Fixed
 
 - *(grok)* Realign the Grok Build (formerly Grok TUI / supergrok)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,28 @@ All notable changes to this project will be documented in this file.
 
 - *(lib)* Item-level library API surface audit ([#162](https://github.com/taniwhaai/arai/pull/162)) ([#163](https://github.com/taniwhaai/arai/pull/163))
 
+### Breaking changes (library API only)
+
+The CLI surface, hook protocol, and on-disk formats are unchanged and
+remain semver-stable. If you embed the `arai` *library* crate (new in
+this release's lib/bin split), note that the pre-audit surface —
+documented as unstable in 1.0.x — changed in the audit ([#163](https://github.com/taniwhaai/arai/pull/163)):
+
+- `intent::Severity::from_str`, `intent::Timing::from_str`, and
+  `intent::Action::from_str` are renamed to `from_str_lossy` (they are
+  infallible fallback parsers, not `std::str::FromStr` impls);
+  `Timing::as_str` / `Action::as_str` now return `&'static str`
+- Internal helpers left the public API (now `pub(crate)`):
+  `parser::extract_expiry` / `extract_noenrich` / `extract_annotations`,
+  `discovery::parse_frontmatter`, `config::resolve_base_dir` +
+  `ResolvedBaseDir` / `DeprecationNotice`, `Config` hook-path helpers
+  (`claude_memory_*`, `claude_settings_path`, `grok_*_hooks_dir`),
+  `Store::count_mcp_rules` / `query_tools_for_directory`, and
+  `guardrails::sniff_content_for_tools_pub` (wrapper removed)
+
+From this release the `pub` items of the documented library modules are
+item-level audited, documented, and covered by semver.
+
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 1.0.2 -> 1.1.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.0] - 2026-07-05

### Added

- Restructure as library + thin CLI binary ([#153](https://github.com/taniwhaai/arai/pull/153))
- *(extends)* Authenticated arai:extends for private rule sources ([#154](https://github.com/taniwhaai/arai/pull/154))
- *(telemetry)* Configurable endpoint for self-hosted collectors ([#155](https://github.com/taniwhaai/arai/pull/155))
- *(audit)* Arai audit --ship — send the audit trail to your own collector ([#156](https://github.com/taniwhaai/arai/pull/156))

### Documentation

- *(site)* Surface v1.1 features and sharpen the value proposition ([#158](https://github.com/taniwhaai/arai/pull/158))

### Fixed

- *(grok)* Realign integration with current Grok Build hooks contract ([#159](https://github.com/taniwhaai/arai/pull/159))

### Refactored

- *(lib)* Item-level library API surface audit ([#162](https://github.com/taniwhaai/arai/pull/162)) ([#163](https://github.com/taniwhaai/arai/pull/163))

### Breaking changes (library API only)

The CLI surface, hook protocol, and on-disk formats are unchanged and
remain semver-stable. If you embed the `arai` *library* crate (new in
this release's lib/bin split), note that the pre-audit surface —
documented as unstable in 1.0.x — changed in the audit ([#163](https://github.com/taniwhaai/arai/pull/163)):

- `intent::Severity::from_str`, `intent::Timing::from_str`, and
  `intent::Action::from_str` are renamed to `from_str_lossy` (they are
  infallible fallback parsers, not `std::str::FromStr` impls);
  `Timing::as_str` / `Action::as_str` now return `&'static str`
- Internal helpers left the public API (now `pub(crate)`):
  `parser::extract_expiry` / `extract_noenrich` / `extract_annotations`,
  `discovery::parse_frontmatter`, `config::resolve_base_dir` +
  `ResolvedBaseDir` / `DeprecationNotice`, `Config` hook-path helpers
  (`claude_memory_*`, `claude_settings_path`, `grok_*_hooks_dir`),
  `Store::count_mcp_rules` / `query_tools_for_directory`, and
  `guardrails::sniff_content_for_tools_pub` (wrapper removed)

From this release the `pub` items of the documented library modules are
item-level audited, documented, and covered by semver.


### Fixed

- *(grok)* Realign the Grok Build (formerly Grok TUI / supergrok)
  integration with current docs.x.ai behavior: hook payload fields are
  now read in both snake_case (Claude protocol + Grok's Claude-compat
  layer) and camelCase (`hookEventName`/`toolName`/`toolInput`/
  `sessionId`, Grok Build native); `.grok/hooks/arai.json` registers
  only events Grok Build supports; `arai init` now tells users to run
  `/hooks-trust` (project hooks are trust-gated); tool aliases added
  for `write_file`/`create_file`/`edit_file`/`apply_patch` so
  Write/Edit-scoped rules can't silently no-fire on those names


### Added

- Ārai now builds as a library crate (`src/lib.rs`) alongside the CLI
  binary, making the core — parser layers, rule store, guardrail
  matching, audit chain, hook decision logic — embeddable as a
  dependency. The CLI surface, hook contract, and DB schema are
  unchanged; `src/main.rs` is now a thin CLI over the library
  ([#148](https://github.com/taniwhaai/arai/issues/148))
- *(extends)* Authenticated `arai:extends` for private rule sources:
  `arai trust --add <url> --bearer-env <ENV_VAR>` attaches
  `Authorization: Bearer <token>` to fetches of that exact trusted URL
  (and its `.sig` sidecar). Only the variable name is stored; the token
  never reaches disk, logs, audit, telemetry, or error messages, and
  redirects stay disabled so the header cannot leak cross-host
  ([#150](https://github.com/taniwhaai/arai/issues/150))
- *(telemetry)* Configurable telemetry endpoint: `[telemetry] endpoint`
  (+ optional `bearer_env`) in config.toml points the existing queue at
  a self-hosted collector — same events, no PostHog api_key, 5 s
  timeout, queue retained on failure. Default sink unchanged when
  unset; `ARAI_TELEMETRY=off` / `DO_NOT_TRACK=1` / `enabled = false`
  win regardless of endpoint (the config-level `enabled = false`
  opt-out is now actually enforced at the egress point — it was
  documented but unimplemented). Payload schema documented in
  docs/telemetry-payload.md
  ([#151](https://github.com/taniwhaai/arai/issues/151))
- *(audit)* `arai audit --ship <url>`: send audit day-buckets — plus
  their `.head.YYYYMMDD` chain sidecars — to your own HTTPS collector,
  so the hash chain can be verified server-side (tamper evidence
  survives transport). Resume cursor, idempotent re-ship (dedupe on
  per-entry chain hash), `[ship]` config section with optional
  `bearer_env` auth, non-zero exit on rejection, and never on the hook
  hot path. Collector reference: docs/audit-ship.md
  ([#149](https://github.com/taniwhaai/arai/issues/149))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
