### PR TITLE
docs(site): surface v1.1 features and sharpen the value proposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arai
 
-Arai enforces AI coding assistant instruction files (CLAUDE.md, AGENTS.md, .cursorrules, and others) via native hooks. Rules derived from prohibitive language block the tool call outright; advisory rules inject the relevant constraint at the point it applies.
+An instruction file is advice — the model can read CLAUDE.md and still force-push anyway. Arai turns instruction files (CLAUDE.md, AGENTS.md, .cursorrules, and others) into enforcement via native hooks: rules derived from prohibitive language **block the tool call outright**, advisory rules inject the relevant constraint at the point it applies, and a tamper-evident audit log records, per rule, whether the model actually complied.
 
 ![Arai blocking a forbidden command at the PreToolUse hook](demos/block.gif)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ An instruction file is advice — the model can read CLAUDE.md and still force-p
 
 ![Arai blocking a forbidden command at the PreToolUse hook](demos/block.gif)
 
+
 ## Quick Start
 
 ```bash
@@ -14,6 +15,7 @@ arai init
 ```
 
 That's it. Arai discovers your instruction files, extracts the rules, classifies their intent, scans your codebase for context, and sets up native hooks so guardrails fire at the right moment.
+
 
 ## What It Does
 
@@ -34,6 +36,7 @@ Rules only fire when relevant. No noise on `ls`. No repeating principles already
 
 Every firing is written to a local audit log, and every PostToolUse is correlated with the matching PreToolUse to produce a **compliance verdict** — so you can measure whether the model actually honours the rules you wrote.
 
+
 ## How It Works
 
 1. **Discovers** instruction files in your project and home directory
@@ -42,6 +45,7 @@ Every firing is written to a local audit log, and every PostToolUse is correlate
 4. **Scans** your codebase with tree-sitter to understand which tools own which directories
 5. **Tracks** session state — knows if you've already run tests before pushing
 6. **Fires** only relevant rules at the right moment via native hooks (where supported)
+
 
 ## Supported Instruction Files
 
@@ -81,6 +85,7 @@ working tree:
   in the same session, so per-rule compliance verdicts (Obeyed /
   Ignored / Unclear) stay accurate on parallel workloads.
 
+
 ## Smart Matching
 
 Arai doesn't just do keyword matching. It understands your rules:
@@ -91,6 +96,47 @@ Arai doesn't just do keyword matching. It understands your rules:
 - **Session awareness** — "never push without running tests" suppresses after tests have been run
 - **Timing routing** — domain rules fire on tool calls, principles stay silent (already in CLAUDE.md)
 - **Broad imperative coverage** — recognises `never/always/don't/must`, `should/shouldn't`, `cannot/refuse`, `make sure/be sure`, `consider/recommend`, bare `No X` prohibitions, conditional shapes (`When X, do Y` / `Before X: do Y` / `If X → do Y`), and the section-aware `Use X` style-guide pattern. Severity mapping mirrors grammatical weight: `should` is `Inform` (soft), `should not` is `Block` (the writer chose to call out a specific prohibition).
+
+
+## Why not just an instruction file?
+
+| An instruction file alone | With Arai |
+|---|---|
+| Advice the model can skip under pressure | Prohibitions deny the tool call at the hook |
+| No record of what was ignored | Hash-chained audit log; `arai audit --verify` |
+| You hope it listened | Per-rule obeyed / ignored / unclear verdicts |
+| Rewrite rules into a new policy format | Your existing files *are* the policy |
+
+
+## Commands
+
+```bash
+arai init                  # Discover, extract, classify, scan, set up hooks
+arai status                # Show what's being enforced
+arai guardrails            # List all active rules
+arai why "git push --force" # Explain which rules would fire (dry-run, no audit write)
+arai scan                  # Re-scan instruction files
+arai scan --code           # Also scan source code (tree-sitter AST)
+arai scan --enrich-llm     # Enhance rules via LLM CLI
+arai scan --enrich-api     # Enhance rules via API (OpenAI-compatible)
+arai add "Never X"         # Add a rule manually
+arai audit                 # Inspect the local log of rule firings
+arai audit --outcome=ignored # Compliance verdicts where the model ignored a rule
+arai audit --rule alembic  # Filter audit by rule subject/predicate/object substring
+arai audit --verify        # Verify the SHA-256 hash chain across every day-bucket
+arai stats                 # Aggregate audit log — top rules, compliance, token economics
+arai stats --by-rule       # Just the per-rule compliance + token economics
+arai severity alembic block # Pin a rule's severity (incremental deny rollout)
+arai severity --reset alembic # Drop the override; severity reverts to predicate-derived
+arai diff CLAUDE.md        # Preview rule-set delta before saving an edit
+arai test scenarios.json   # Replay synthetic hook scenarios against rules
+arai record --since=1h     # Capture recent firings as a scenario skeleton
+arai lint CLAUDE.md        # Parse a file and preview extracted rules
+arai trust                 # Manage URLs trusted for shared-policy extends
+arai mcp                   # Run the MCP server (stdio) for agent-authored guards
+arai upgrade --full        # Switch to full binary (with ONNX enrichment)
+```
+
 
 ## Compliance & audit
 
@@ -160,559 +206,6 @@ procurement-team feature inventory is in
 [`docs/arai-compliance-features.pdf`](docs/arai-compliance-features.pdf).
 The Word source (`.docx`) is committed alongside it for editing.
 
-## Enrichment
-
-Three tiers of rule understanding, each more accurate:
-
-```bash
-arai scan                  # Tier 1: Built-in verb taxonomy (free, instant)
-arai scan --enrich         # Tier 2: Sentence transformer model (local, ~80MB download)
-arai scan --enrich-llm     # Tier 3a: LLM classification via CLI
-arai scan --enrich-api     # Tier 3b: LLM classification via API (no CLI needed)
-```
-
-Configure your LLM:
-```bash
-# Via CLI tool (shell-out)
-ARAI_LLM_CMD="claude -p" arai scan --enrich-llm
-ARAI_LLM_CMD="ollama run llama3" arai scan --enrich-llm
-
-# Via API (OpenAI-compatible endpoints)
-ARAI_API_KEY=sk-... arai scan --enrich-api                    # OpenAI (default)
-ARAI_API_URL=http://localhost:11434/v1 arai scan --enrich-api  # Ollama (auto-detected)
-ARAI_API_URL=https://api.groq.com/openai/v1 ARAI_API_KEY=gsk-... ARAI_API_MODEL=llama-3.3-70b-versatile arai scan --enrich-api
-
-# Or in ~/.taniwha/arai/config.toml
-[enrich]
-llm_command = "llm -m gpt-4o-mini"       # for --enrich-llm
-api_url = "https://api.openai.com/v1"     # for --enrich-api
-api_key_env = "OPENAI_API_KEY"
-model = "gpt-4o-mini"
-```
-
-## Commands
-
-```bash
-arai init                  # Discover, extract, classify, scan, set up hooks
-arai status                # Show what's being enforced
-arai guardrails            # List all active rules
-arai why "git push --force" # Explain which rules would fire (dry-run, no audit write)
-arai scan                  # Re-scan instruction files
-arai scan --code           # Also scan source code (tree-sitter AST)
-arai scan --enrich-llm     # Enhance rules via LLM CLI
-arai scan --enrich-api     # Enhance rules via API (OpenAI-compatible)
-arai add "Never X"         # Add a rule manually
-arai audit                 # Inspect the local log of rule firings
-arai audit --outcome=ignored # Compliance verdicts where the model ignored a rule
-arai audit --rule alembic  # Filter audit by rule subject/predicate/object substring
-arai audit --verify        # Verify the SHA-256 hash chain across every day-bucket
-arai stats                 # Aggregate audit log — top rules, compliance, token economics
-arai stats --by-rule       # Just the per-rule compliance + token economics
-arai severity alembic block # Pin a rule's severity (incremental deny rollout)
-arai severity --reset alembic # Drop the override; severity reverts to predicate-derived
-arai diff CLAUDE.md        # Preview rule-set delta before saving an edit
-arai test scenarios.json   # Replay synthetic hook scenarios against rules
-arai record --since=1h     # Capture recent firings as a scenario skeleton
-arai lint CLAUDE.md        # Parse a file and preview extracted rules
-arai trust                 # Manage URLs trusted for shared-policy extends
-arai mcp                   # Run the MCP server (stdio) for agent-authored guards
-arai upgrade --full        # Switch to full binary (with ONNX enrichment)
-```
-
-## Deny mode — actually block bad actions
-
-Starting in v0.2.3, Arai no longer just *advises*: rules derived from
-prohibitive predicates (`never`, `forbids`, `must_not`) emit
-`permissionDecision: "deny"` (or equivalent) so the assistant refuses the tool call. Advisory
-rules (`always`, `requires`, `prefers`) keep the previous behaviour.
-
-Severity is inferred from the predicate at extract time:
-
-| Predicate | Severity | Hook behaviour |
-|-----------|----------|----------------|
-| `never`, `forbids`, `must_not` | `block`  | `permissionDecision: "deny"` + reason |
-| `always`, `requires`, `enforces` | `warn` | `permissionDecision: "allow"` + context |
-| `prefers`, `learned_from` | `inform` | `permissionDecision: "allow"` + context |
-
-Rolling Arai out incrementally? Flip deny mode off at the env level:
-
-```bash
-ARAI_DENY_MODE=off   # advisory-only — rules still fire in additionalContext
-```
-
-Useful pattern: ship Arai in advise mode for a week, watch `arai audit
---outcome=ignored`, tune the rules the model keeps flouting, then enable
-deny mode when the rule set is trustworthy.
-
-## Compliance tracking
-
-After every PostToolUse, Arai correlates the call against recent
-PreToolUse firings in the same session and emits a `Compliance` event to
-the audit log per rule:
-
-- **obeyed** — forbidden phrase absent from the executed command (for
-  prohibitive rules), or the required evidence present (for affirmative
-  rules).
-- **ignored** — forbidden phrase still in the executed command.
-  The model ran the thing anyway (either deny was off or the assistant
-  chose to proceed).
-- **unclear** — not enough signal to decide (short object text, or
-  affirmative rule without evidence in this call).
-
-```bash
-arai audit --event=Compliance     # all verdicts
-arai audit --outcome=ignored      # shortcut for the painful ones
-arai audit --outcome=obeyed       # show the rules doing their job
-```
-
-This closes the feedback loop the audit log was missing: not just *which*
-rules fired, but *which ones the model actually honoured*.
-
-## arai why — explain before you commit
-
-`arai why <action>` replays a hypothetical tool call through the live
-matching pipeline and prints the rules that would fire, with severity,
-derivation (source + line + parser layer), and match percentage. No audit
-write; read-only against the rule set.
-
-```bash
-arai why "git push --force origin main"
-arai why --tool Write /src/migrations/001_init.py
-arai why --tool Bash --event PostToolUse "rm -rf /data"
-arai why "git push --force" --json   # machine-readable
-```
-
-Use it to: debug "why did that rule fire?", preview new rules before
-committing them, or include the output in a PR description when you
-change a CLAUDE.md.
-
-## Rule expiry — self-pruning rules
-
-Annotate rules with `(expires YYYY-MM-DD)` or `(until YYYY-MM-DD)` at the
-end of the line. The annotation is stripped from the rule body at parse
-time and stored separately; `load_guardrails` filters out expired rows so
-the rule stops firing on its own, without you having to remember to
-clean it up.
-
-```markdown
-- Never touch the old auth module (expires 2026-09-01)
-- Always rebase against release-1.8 until 2026-12-31
-- Prefer the new payment SDK over the legacy one (until 2027-06-30)
-```
-
-Perfect for `learned_from` incidents that have a shelf life, migration
-windows, and "temporarily forbid X until we finish the refactor" rules.
-
-## Per-rule enrichment opt-out — `(noenrich)`
-
-`arai scan --enrich-llm` and `--enrich-api` send the full text of every
-guardrail to whatever LLM you've configured (`ARAI_LLM_CMD` /
-`ARAI_API_URL`). For most rules that's fine — they're already in
-`CLAUDE.md`. But if a single rule mentions an internal codename you'd
-rather not ship to a third-party endpoint, append `(noenrich)`:
-
-```markdown
-- Never deploy to internal-codename-cluster (noenrich)
-```
-
-The annotation is stripped from the rule body at parse time and stored
-separately; the enrichment paths filter the rule out before building the
-prompt. `(noenrich)` and `(expires …)` can appear together in either
-order. To opt out globally, just don't pass `--enrich-llm` /
-`--enrich-api` — neither runs by default.
-
-Before each enrichment run Arai prints a one-line notice with the
-resolved destination and a locality verdict (`local` / `REMOTE` /
-`unknown locality`), plus the count of rules excluded via `(noenrich)`,
-so you can see at a glance whether rule text is about to leave the
-host.
-
-## Audit log
-
-Every time a rule fires, Arai appends one line to a local JSONL log at
-`~/.taniwha/arai/audit/<project-slug>/<YYYYMMDD>.jsonl`. The log captures the
-hook event, the tool that was called, a truncated prompt preview, the
-decision (`inject`, `deny`, `review`), and every rule that matched —
-with source file, line number, parser layer, severity, and confidence.
-
-Nothing leaves your machine — this is separate from the anonymous
-usage telemetry below.
-
-```bash
-arai audit                    # Today's firings, table view
-arai audit --since=7d         # Last week
-arai audit --tool=Bash        # Only Bash tool calls
-arai audit --event=PreToolUse # Only pre-tool-use firings
-arai audit --event=Compliance # Compliance verdicts (Pre/Post correlation)
-arai audit --outcome=ignored  # Shortcut: Compliance events marked ignored
-arai audit --rule alembic     # Filter to firings/verdicts touching this rule
-arai audit --json             # JSONL stream (pipe-friendly)
-arai audit --verify           # Verify the SHA-256 hash chain (exits non-zero on any tamper)
-arai audit --verify --json    # Machine-readable verify report for CI / cron
-```
-
-`--rule` is a case-insensitive substring match against the rule's
-subject, predicate, or object — the same shape `arai severity` uses.
-Pairs naturally with `--outcome=ignored` to answer "every time the
-alembic rule was ignored this week".
-
-Useful for answering:
-
-- *"Why did Claude suddenly change approach halfway through?"* —
-  look up the firing, see which rule matched.
-- *"Which rules are actually load-bearing?"* — sort firings by rule,
-  prune rules that never trigger.
-- *"Did the guardrail fire before that regrettable git push?"* —
-  grep by session id.
-
-## Status — health check your rule set
-
-`arai status` shows how many rules are loaded, where they came from,
-and when they were last scanned. As of v0.2.2 it also surfaces two
-common rule-set health issues:
-
-- **Duplicate rules** — the same (subject, predicate, object) ingested
-  from more than one source file. Usually safe to consolidate into
-  one source to reduce drift.
-- **Opposing predicates** — the same subject carries both a
-  prohibitive predicate (`never`, `must_not`, `avoid`) and a required
-  predicate (`always`, `must`, `requires`, `ensure`). Not always a
-  real conflict (the objects may differ), but worth a human look.
-
-These are advisory only — the hook path ignores them. Fix them at the
-source.
-
-## Stats — aggregate the audit log
-
-`arai stats` rolls up the same JSONL `arai audit` tails and answers
-the questions every maintainer asks after a few weeks of use:
-
-```bash
-arai stats                # Top rules, compliance, token economics
-arai stats --since=30d    # Window to the last month
-arai stats --top=5        # Show only top 5 per section
-arai stats --by-rule      # Compliance + token economics only
-arai stats --json         # Machine-readable for dashboards
-```
-
-Output includes: total firings, most-fired rules, tools attracting the
-most guardrails, day-by-day activity, **and a per-rule compliance
-roll-up** — for every rule that has fired, how many Pre/Post pairs
-ended up `obeyed` vs `ignored`, plus a ratio:
-
-```
-Per-rule compliance
-  fires obeyed ignored unclear   ratio  rule
-     12     11       1       0     92%  alembic must_not: hand-write migrations
-      7      4       3       0     57%  git must_not: --no-verify  ⚠
-      9      9       0       0    100%  cargo always: test before commit
-```
-
-The ⚠ flag highlights rules with low ratios and enough volume to
-mean it — these are the ones to either rewrite (rule subject too
-narrow / object too vague) or escalate via `arai severity` (see
-below) once you trust the wording.
-
-The ratio is computed **once per Pre firing** using a first-
-definitive-wins rule: the first non-`unclear` Compliance verdict
-correlated against a Pre is the verdict for that Pre, regardless
-of how many subsequent Posts also fall inside the 5-minute
-correlation window. So a rule that fires once and is honored stays
-at 1 obeyed / 1 fire, not 8 obeyed / 1 fire just because eight
-unrelated commands followed.
-
-Nothing leaves the machine — stats are a local view over your own
-audit log.
-
-## Token economics — calibrated estimates
-
-`arai stats` also surfaces a *token economics* section with
-calibrated estimates of how Arai is affecting your model's token
-burn. Two streams contribute:
-
-```
-Token economics (estimates)
-     12  repeat-injection suppressions  (~600 tokens, 50 ea.)
-      4  denied-and-honored mistakes    (~8000 tokens, 2000 ea.)
-     17  advised-and-honored events     (~8500 tokens, 500 ea.)
-            total estimated tokens saved:  ~17100
-            (calibrated estimates, not measurements)
-```
-
-- **Repeat-injection suppressions** — when a rule fires a second
-  time in the same session, Arai emits a compact "still: subject
-  predicate object" line instead of re-injecting the full source /
-  layer / severity payload. The model already has that context from
-  the first firing. The 50-token estimate is the rough delta
-  between the full and compact forms.
-- **Denied-and-honored mistakes** — a `block`-severity rule fired,
-  the model would otherwise have run a destructive action, and the
-  PostToolUse correlation confirms it didn't. The 2000-token
-  estimate is a conservative bound on what "fix the mess" cycles
-  cost (revert files, undo migrations, rollback deploys).
-- **Advised-and-honored events** — a `warn` or `inform` rule fired
-  and the model complied. Lower confidence saving (the model might
-  have done the right thing anyway), so a smaller 500-token
-  estimate.
-
-These are **estimates, not measurements**. The constants live in
-[`src/stats.rs`](src/stats.rs) and are documented there; treat the
-total as an order-of-magnitude reading, not a precise number. If
-you want to see the underlying counts, `arai stats --json` exposes
-the `token_economics` object with all three streams broken out.
-
-## Severity — per-rule deny-mode rollout
-
-`arai severity` pins a rule's enforcement strength so re-running
-`arai scan` won't reset it to the predicate-derived classification.
-Use it for **incremental deny-mode rollout**: ship the rule set in
-advise mode (`ARAI_DENY_MODE=off`), watch `arai stats --by-rule`,
-and flip individual rules into `block` once the model is honouring
-them in the wild — without forcing the whole rule set into a strict
-mode it isn't ready for yet.
-
-```bash
-arai severity                          # List active overrides
-arai severity alembic block            # Pin every rule whose subject/object
-                                       # contains "alembic" to block
-arai severity git warn                 # Demote git rules to advise-only
-arai severity --reset alembic          # Drop the override; severity reverts
-                                       # to the predicate-derived value
-arai severity alembic block --json     # Machine-readable list of changes
-```
-
-Pattern matching is case-insensitive substring against the rule's
-subject *or* object, so `arai severity migrate` covers both
-`alembic must_not: hand-write migrations` and `migrations require:
-backfill_plan`.
-
-Overrides survive `arai scan` and `arai init` — they live in their
-own column and are never touched by re-classification. Drop one with
-`--reset` when you're ready to re-derive severity from the rule's
-predicate.
-
-## Diff — preview rule-set changes
-
-`arai diff <file>` shows what changes a candidate edit to an
-instruction file would make to the live rule set — added, removed,
-moved — before you save and run `arai scan`. Read-only against
-the store; pairs with `arai lint` (preview a file in isolation)
-and `arai why` (preview a single tool call).
-
-```bash
-arai diff CLAUDE.md                            # Plain table view
-arai diff memory/feedback_testing.md --json    # For pre-commit hooks
-```
-
-Output is grouped into three sections — `Added` (rules in the file
-that aren't in the store yet), `Removed` (rules in the store whose
-text isn't in the new file), `Moved` (same rule, different line
-number — caught when you re-order a file without changing its rules).
-JSON output keeps the same shape for CI.
-
-## Lint — preview what a file produces
-
-`arai lint <file>` parses an instruction file and prints every rule it
-would extract along with the intent classification, without touching
-the DB. Use it to iterate on CLAUDE.md wording and see the effect
-before you commit.
-
-```bash
-arai lint CLAUDE.md
-arai lint memory/feedback_testing.md --json   # machine-readable
-```
-
-Output for each rule: subject / predicate / object, the classified
-action (Create / Modify / Execute / General), the hook timing it routes
-to (ToolCall / Stop / Start / Principle), and which tools the rule
-applies to.
-
-## Test — regression harness for rules
-
-`arai test` replays synthetic hook payloads through the *same*
-`match_hook` pipeline the live hook handler uses, so rule changes get
-caught before they affect a real session.
-
-The canonical [alembic example](scenarios/alembic-migration.json) is
-checked in — run it after `arai init` on any repo with an alembic rule
-in CLAUDE.md:
-
-```bash
-arai test scenarios/alembic-migration.json
-```
-
-Scenario files are JSON:
-
-```json
-{
-  "scenarios": [
-    {
-      "name": "force-push triggers the git guardrail",
-      "hook": {
-        "hook_event_name": "PreToolUse",
-        "tool_name": "Bash",
-        "tool_input": { "command": "git push --force origin master" }
-      },
-      "expect": {
-        "matches_subject": ["git"],
-        "does_not_match_subject": ["alembic"],
-        "min_matches": 1
-      }
-    }
-  ]
-}
-```
-
-```bash
-arai test scenarios/guards.json
-arai test scenarios/guards.json --json   # structured pass/fail for CI
-```
-
-Exit code is non-zero when any scenario fails. Matches are checked by
-subject substring because full SPO triples tend to drift across
-re-ingest.
-
-## Record — seed scenarios from real firings
-
-`arai record` turns entries in the audit log into scenario skeletons
-so you don't hand-write regression tests. Flow: run your assistant, hit a
-rule firing you want pinned, `arai record --since=1h > tests.json`,
-tune the expectations, check in.
-
-```bash
-arai record --since=1h              # last hour
-arai record --since=7d --tool=Bash  # only Bash firings from the last week
-arai record --limit=50              # cap audit entries scanned
-```
-
-Deduplicates by (tool, prompt) so repeated identical firings collapse
-to one scenario. Each scenario's `expect` seeds `matches_subject` with
-whatever actually fired and `min_matches: 1` — tune from there.
-
-Runtime-capturing *new rules* (as opposed to testing existing ones) is
-a different loop: that goes through the MCP `arai_add_guard` tool,
-documented below.
-
-## Shared policies — `arai:extends`
-
-Instruction files can inherit rules from a trusted upstream URL. This
-is the "org-wide CLAUDE.md" pattern without a policy service — just
-another markdown file hosted wherever you like.
-
-Declare the upstream in your CLAUDE.md:
-
-```markdown
-<!-- arai:extends https://example.com/standards/rust-backend.md -->
-
-# My project rules
-- Never publish artifacts before tag push
-```
-
-Then trust the URL:
-
-```bash
-arai trust --add https://example.com/standards/rust-backend.md
-arai trust                  # List trusted URLs
-arai trust --remove <url>   # Revoke
-```
-
-Ārai never fetches a URL that isn't explicitly trusted. HTTPS only,
-512 KB size cap, 24-hour cache with stale-while-error fallback, and
-extends are not recursive — the fetched file can't pull in further
-URLs. On `arai init`, trusted upstream content is inlined ahead of the
-local rules before the parser runs, so the rest of the pipeline sees
-one merged file.
-
-### Private policy sources (authenticated extends)
-
-If your org policy file lives behind auth (an internal service, a
-private GitHub raw URL, an artifact store), give the trust entry the
-*name* of an environment variable holding a bearer token:
-
-```bash
-arai trust --add https://policy.internal.example/org-rules.md \
-           --bearer-env ARAI_EXTENDS_TOKEN
-export ARAI_EXTENDS_TOKEN="<token>"   # e.g. from your secret manager
-arai scan                             # fetches with Authorization: Bearer <token>
-```
-
-Secret handling, by construction:
-
-- Only the variable **name** is stored (in `trusted_extends.toml`); the
-  token itself never touches disk, the audit log, telemetry, or error
-  messages.
-- The header is sent **only** to the exact trusted URL (and its
-  `<url>.sig` signature sidecar on the same origin). Redirects are
-  disabled on the fetch path, so a 30x can never carry the token to
-  another host. HTTPS only, as always.
-- If the variable is unset or empty, the fetch proceeds
-  unauthenticated with a warning — same behavior as before the
-  credential was configured.
-- Content pinning (`@sha256:`), ed25519 signatures, tiers, caching,
-  and the size cap all work unchanged on authenticated responses.
-
-## MCP: agent-authored guardrails
-
-`arai mcp` is also the integration path for assistants that don't have a
-native PreToolUse hook surface. Cursor and Windsurf are both MCP clients — point
-them at `arai mcp` and the agent can read the same rule set, register new guards
-mid-session, and self-check recent decisions.
-The strongest blocking enforcement is available in assistants with native hook
-support (currently Claude Code and Grok TUI), but everything else — rule lookup,
-agent-authored guards, decision history — is shared via MCP.
-
-`arai mcp` runs a [Model Context Protocol](https://modelcontextprotocol.io/)
-server on stdio. Three tools, exposed to any MCP-capable agent:
-
-| Tool | What it does |
-|------|--------------|
-| `arai_add_guard(rule, reason?)` | Register a new guardrail mid-session. Takes effect on the next PreToolUse hook — same enforcement path as rules in your CLAUDE.md. |
-| `arai_list_guards(pattern?)` | List active guardrails, optionally substring-filtered, so the agent can check what constraints are live before acting. |
-| `arai_recent_decisions(session_id?, limit?, since?)` | Look up recent Ārai decisions (deny / inject / review) so the agent can self-check after a refusal — closes the model-side feedback loop. |
-
-This closes two gaps instruction files don't cover. First, when an agent
-discovers a rule mid-session (*"from now on, never write to /etc"*,
-*"always run the full test suite before pushing"*), it now has
-somewhere to register it for deterministic enforcement rather than
-hoping context retention holds. Second, after a deny, the agent can
-call `arai_recent_decisions` to see what it was just refused for —
-useful for avoiding "try the same thing twice" loops when a single
-rule keeps getting hit.
-
-Register it with your assistant (for example in Claude Code or Cline) by adding to your MCP settings:
-
-```json
-{
-  "mcpServers": {
-    "arai": {
-      "command": "arai",
-      "args": ["mcp"]
-    }
-  }
-}
-```
-
-For Cline (in `cline_mcp_settings.json`, or via the MCP UI):
-
-```json
-{
-  "mcpServers": {
-    "arai": {
-      "command": "arai",
-      "args": ["mcp"],
-      "disabled": false,
-      "autoApprove": []
-    }
-  }
-}
-```
-
-For Cursor and Windsurf, follow each tool's MCP server registration UI
-and point it at the same `arai mcp` command — the protocol is identical.
-
-Prerequisite: `arai` must be on your `PATH`. The install script, `cargo
-install arai`, `npm install -g @taniwhaai/arai`, and the Homebrew tap all
-put it there.
 
 ## Installation
 
@@ -826,6 +319,7 @@ SHA-256 stays the default in `install.sh` / `npm` because it doesn't
 require any extra tooling client-side. cosign and SLSA are opt-in for
 environments that need the higher tier.
 
+
 ## Performance
 
 | Operation | Median | p95 |
@@ -840,6 +334,7 @@ End-to-end wall clock per tool call (on supported assistants), measured by
 rules thanks to the LEFT-JOIN'd intent and Aho-Corasick content sniffing.
 Rule count between 50 and 500 doesn't materially move the median —
 matching is no longer the bottleneck.
+
 
 ## Telemetry
 
@@ -884,9 +379,34 @@ schema is documented in
 exactly what you're receiving. The audit log remains a separate,
 local-only channel.
 
+
+## Going deeper
+
+The sections above are enough to install Arai and see it block. The full
+capability set is documented in focused guides:
+
+- [Enforcement in depth](docs/enforcement.md) — deny mode, per-rule severity
+  rollout (`arai severity`), dry-run explanations (`arai why`), compliance
+  verdicts, rule expiry
+- [The audit log](docs/audit.md) — querying, `--verify` chain checks,
+  `arai status`, `arai stats`, token economics
+- [Shipping the audit trail](docs/audit-ship.md) — `arai audit --ship` to
+  your own collector, with server-side chain verification
+- [Testing your rule set](docs/rule-testing.md) — `arai diff`, `arai lint`,
+  `arai test`, `arai record`
+- [Shared policies](docs/extends.md) — `arai:extends`, trust list, pinning,
+  signatures, private policy sources
+- [MCP integration](docs/mcp.md) — agent-authored guards for Cursor,
+  Windsurf, and any MCP client
+- [Rule enrichment](docs/enrichment.md) — the three classification tiers
+- [Telemetry payload schema](docs/telemetry-payload.md) — what a
+  self-hosted collector receives
+
+
 ## Built By
 
 [Taniwha.ai](https://taniwha.ai) — extracted from the [Kete](https://github.com/taniwhaai/kete) code intelligence platform.
+
 
 ## License
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,0 +1,140 @@
+# The audit log
+
+Querying the local firing log, chain verification, rule-set health, aggregate stats, and token economics.
+
+## Audit log
+
+Every time a rule fires, Arai appends one line to a local JSONL log at
+`~/.taniwha/arai/audit/<project-slug>/<YYYYMMDD>.jsonl`. The log captures the
+hook event, the tool that was called, a truncated prompt preview, the
+decision (`inject`, `deny`, `review`), and every rule that matched —
+with source file, line number, parser layer, severity, and confidence.
+
+Nothing leaves your machine — this is separate from the anonymous
+usage telemetry below.
+
+```bash
+arai audit                    # Today's firings, table view
+arai audit --since=7d         # Last week
+arai audit --tool=Bash        # Only Bash tool calls
+arai audit --event=PreToolUse # Only pre-tool-use firings
+arai audit --event=Compliance # Compliance verdicts (Pre/Post correlation)
+arai audit --outcome=ignored  # Shortcut: Compliance events marked ignored
+arai audit --rule alembic     # Filter to firings/verdicts touching this rule
+arai audit --json             # JSONL stream (pipe-friendly)
+arai audit --verify           # Verify the SHA-256 hash chain (exits non-zero on any tamper)
+arai audit --verify --json    # Machine-readable verify report for CI / cron
+```
+
+`--rule` is a case-insensitive substring match against the rule's
+subject, predicate, or object — the same shape `arai severity` uses.
+Pairs naturally with `--outcome=ignored` to answer "every time the
+alembic rule was ignored this week".
+
+Useful for answering:
+
+- *"Why did Claude suddenly change approach halfway through?"* —
+  look up the firing, see which rule matched.
+- *"Which rules are actually load-bearing?"* — sort firings by rule,
+  prune rules that never trigger.
+- *"Did the guardrail fire before that regrettable git push?"* —
+  grep by session id.
+
+
+## Status — health check your rule set
+
+`arai status` shows how many rules are loaded, where they came from,
+and when they were last scanned. As of v0.2.2 it also surfaces two
+common rule-set health issues:
+
+- **Duplicate rules** — the same (subject, predicate, object) ingested
+  from more than one source file. Usually safe to consolidate into
+  one source to reduce drift.
+- **Opposing predicates** — the same subject carries both a
+  prohibitive predicate (`never`, `must_not`, `avoid`) and a required
+  predicate (`always`, `must`, `requires`, `ensure`). Not always a
+  real conflict (the objects may differ), but worth a human look.
+
+These are advisory only — the hook path ignores them. Fix them at the
+source.
+
+
+## Stats — aggregate the audit log
+
+`arai stats` rolls up the same JSONL `arai audit` tails and answers
+the questions every maintainer asks after a few weeks of use:
+
+```bash
+arai stats                # Top rules, compliance, token economics
+arai stats --since=30d    # Window to the last month
+arai stats --top=5        # Show only top 5 per section
+arai stats --by-rule      # Compliance + token economics only
+arai stats --json         # Machine-readable for dashboards
+```
+
+Output includes: total firings, most-fired rules, tools attracting the
+most guardrails, day-by-day activity, **and a per-rule compliance
+roll-up** — for every rule that has fired, how many Pre/Post pairs
+ended up `obeyed` vs `ignored`, plus a ratio:
+
+```
+Per-rule compliance
+  fires obeyed ignored unclear   ratio  rule
+     12     11       1       0     92%  alembic must_not: hand-write migrations
+      7      4       3       0     57%  git must_not: --no-verify  ⚠
+      9      9       0       0    100%  cargo always: test before commit
+```
+
+The ⚠ flag highlights rules with low ratios and enough volume to
+mean it — these are the ones to either rewrite (rule subject too
+narrow / object too vague) or escalate via `arai severity` (see
+below) once you trust the wording.
+
+The ratio is computed **once per Pre firing** using a first-
+definitive-wins rule: the first non-`unclear` Compliance verdict
+correlated against a Pre is the verdict for that Pre, regardless
+of how many subsequent Posts also fall inside the 5-minute
+correlation window. So a rule that fires once and is honored stays
+at 1 obeyed / 1 fire, not 8 obeyed / 1 fire just because eight
+unrelated commands followed.
+
+Nothing leaves the machine — stats are a local view over your own
+audit log.
+
+
+## Token economics — calibrated estimates
+
+`arai stats` also surfaces a *token economics* section with
+calibrated estimates of how Arai is affecting your model's token
+burn. Two streams contribute:
+
+```
+Token economics (estimates)
+     12  repeat-injection suppressions  (~600 tokens, 50 ea.)
+      4  denied-and-honored mistakes    (~8000 tokens, 2000 ea.)
+     17  advised-and-honored events     (~8500 tokens, 500 ea.)
+            total estimated tokens saved:  ~17100
+            (calibrated estimates, not measurements)
+```
+
+- **Repeat-injection suppressions** — when a rule fires a second
+  time in the same session, Arai emits a compact "still: subject
+  predicate object" line instead of re-injecting the full source /
+  layer / severity payload. The model already has that context from
+  the first firing. The 50-token estimate is the rough delta
+  between the full and compact forms.
+- **Denied-and-honored mistakes** — a `block`-severity rule fired,
+  the model would otherwise have run a destructive action, and the
+  PostToolUse correlation confirms it didn't. The 2000-token
+  estimate is a conservative bound on what "fix the mess" cycles
+  cost (revert files, undo migrations, rollback deploys).
+- **Advised-and-honored events** — a `warn` or `inform` rule fired
+  and the model complied. Lower confidence saving (the model might
+  have done the right thing anyway), so a smaller 500-token
+  estimate.
+
+These are **estimates, not measurements**. The constants live in
+[`src/stats.rs`](src/stats.rs) and are documented there; treat the
+total as an order-of-magnitude reading, not a precise number. If
+you want to see the underlying counts, `arai stats --json` exposes
+the `token_economics` object with all three streams broken out.

--- a/docs/enforcement.md
+++ b/docs/enforcement.md
@@ -1,0 +1,121 @@
+# Enforcement in depth
+
+Deny mode, per-rule severity rollout, dry-run explanations, compliance verdicts, and rule expiry.
+
+## Deny mode — actually block bad actions
+
+Starting in v0.2.3, Arai no longer just *advises*: rules derived from
+prohibitive predicates (`never`, `forbids`, `must_not`) emit
+`permissionDecision: "deny"` (or equivalent) so the assistant refuses the tool call. Advisory
+rules (`always`, `requires`, `prefers`) keep the previous behaviour.
+
+Severity is inferred from the predicate at extract time:
+
+| Predicate | Severity | Hook behaviour |
+|-----------|----------|----------------|
+| `never`, `forbids`, `must_not` | `block`  | `permissionDecision: "deny"` + reason |
+| `always`, `requires`, `enforces` | `warn` | `permissionDecision: "allow"` + context |
+| `prefers`, `learned_from` | `inform` | `permissionDecision: "allow"` + context |
+
+Rolling Arai out incrementally? Flip deny mode off at the env level:
+
+```bash
+ARAI_DENY_MODE=off   # advisory-only — rules still fire in additionalContext
+```
+
+Useful pattern: ship Arai in advise mode for a week, watch `arai audit
+--outcome=ignored`, tune the rules the model keeps flouting, then enable
+deny mode when the rule set is trustworthy.
+
+
+## Severity — per-rule deny-mode rollout
+
+`arai severity` pins a rule's enforcement strength so re-running
+`arai scan` won't reset it to the predicate-derived classification.
+Use it for **incremental deny-mode rollout**: ship the rule set in
+advise mode (`ARAI_DENY_MODE=off`), watch `arai stats --by-rule`,
+and flip individual rules into `block` once the model is honouring
+them in the wild — without forcing the whole rule set into a strict
+mode it isn't ready for yet.
+
+```bash
+arai severity                          # List active overrides
+arai severity alembic block            # Pin every rule whose subject/object
+                                       # contains "alembic" to block
+arai severity git warn                 # Demote git rules to advise-only
+arai severity --reset alembic          # Drop the override; severity reverts
+                                       # to the predicate-derived value
+arai severity alembic block --json     # Machine-readable list of changes
+```
+
+Pattern matching is case-insensitive substring against the rule's
+subject *or* object, so `arai severity migrate` covers both
+`alembic must_not: hand-write migrations` and `migrations require:
+backfill_plan`.
+
+Overrides survive `arai scan` and `arai init` — they live in their
+own column and are never touched by re-classification. Drop one with
+`--reset` when you're ready to re-derive severity from the rule's
+predicate.
+
+
+## arai why — explain before you commit
+
+`arai why <action>` replays a hypothetical tool call through the live
+matching pipeline and prints the rules that would fire, with severity,
+derivation (source + line + parser layer), and match percentage. No audit
+write; read-only against the rule set.
+
+```bash
+arai why "git push --force origin main"
+arai why --tool Write /src/migrations/001_init.py
+arai why --tool Bash --event PostToolUse "rm -rf /data"
+arai why "git push --force" --json   # machine-readable
+```
+
+Use it to: debug "why did that rule fire?", preview new rules before
+committing them, or include the output in a PR description when you
+change a CLAUDE.md.
+
+
+## Compliance tracking
+
+After every PostToolUse, Arai correlates the call against recent
+PreToolUse firings in the same session and emits a `Compliance` event to
+the audit log per rule:
+
+- **obeyed** — forbidden phrase absent from the executed command (for
+  prohibitive rules), or the required evidence present (for affirmative
+  rules).
+- **ignored** — forbidden phrase still in the executed command.
+  The model ran the thing anyway (either deny was off or the assistant
+  chose to proceed).
+- **unclear** — not enough signal to decide (short object text, or
+  affirmative rule without evidence in this call).
+
+```bash
+arai audit --event=Compliance     # all verdicts
+arai audit --outcome=ignored      # shortcut for the painful ones
+arai audit --outcome=obeyed       # show the rules doing their job
+```
+
+This closes the feedback loop the audit log was missing: not just *which*
+rules fired, but *which ones the model actually honoured*.
+
+
+## Rule expiry — self-pruning rules
+
+Annotate rules with `(expires YYYY-MM-DD)` or `(until YYYY-MM-DD)` at the
+end of the line. The annotation is stripped from the rule body at parse
+time and stored separately; `load_guardrails` filters out expired rows so
+the rule stops firing on its own, without you having to remember to
+clean it up.
+
+```markdown
+- Never touch the old auth module (expires 2026-09-01)
+- Always rebase against release-1.8 until 2026-12-31
+- Prefer the new payment SDK over the legacy one (until 2027-06-30)
+```
+
+Perfect for `learned_from` incidents that have a shelf life, migration
+windows, and "temporarily forbid X until we finish the refactor" rules.

--- a/docs/enrichment.md
+++ b/docs/enrichment.md
@@ -1,0 +1,58 @@
+# Rule enrichment
+
+The three classification tiers and the per-rule (noenrich) opt-out.
+
+## Enrichment
+
+Three tiers of rule understanding, each more accurate:
+
+```bash
+arai scan                  # Tier 1: Built-in verb taxonomy (free, instant)
+arai scan --enrich         # Tier 2: Sentence transformer model (local, ~80MB download)
+arai scan --enrich-llm     # Tier 3a: LLM classification via CLI
+arai scan --enrich-api     # Tier 3b: LLM classification via API (no CLI needed)
+```
+
+Configure your LLM:
+```bash
+# Via CLI tool (shell-out)
+ARAI_LLM_CMD="claude -p" arai scan --enrich-llm
+ARAI_LLM_CMD="ollama run llama3" arai scan --enrich-llm
+
+# Via API (OpenAI-compatible endpoints)
+ARAI_API_KEY=sk-... arai scan --enrich-api                    # OpenAI (default)
+ARAI_API_URL=http://localhost:11434/v1 arai scan --enrich-api  # Ollama (auto-detected)
+ARAI_API_URL=https://api.groq.com/openai/v1 ARAI_API_KEY=gsk-... ARAI_API_MODEL=llama-3.3-70b-versatile arai scan --enrich-api
+
+# Or in ~/.taniwha/arai/config.toml
+[enrich]
+llm_command = "llm -m gpt-4o-mini"       # for --enrich-llm
+api_url = "https://api.openai.com/v1"     # for --enrich-api
+api_key_env = "OPENAI_API_KEY"
+model = "gpt-4o-mini"
+```
+
+
+## Per-rule enrichment opt-out — `(noenrich)`
+
+`arai scan --enrich-llm` and `--enrich-api` send the full text of every
+guardrail to whatever LLM you've configured (`ARAI_LLM_CMD` /
+`ARAI_API_URL`). For most rules that's fine — they're already in
+`CLAUDE.md`. But if a single rule mentions an internal codename you'd
+rather not ship to a third-party endpoint, append `(noenrich)`:
+
+```markdown
+- Never deploy to internal-codename-cluster (noenrich)
+```
+
+The annotation is stripped from the rule body at parse time and stored
+separately; the enrichment paths filter the rule out before building the
+prompt. `(noenrich)` and `(expires …)` can appear together in either
+order. To opt out globally, just don't pass `--enrich-llm` /
+`--enrich-api` — neither runs by default.
+
+Before each enrichment run Arai prints a one-line notice with the
+resolved destination and a locality verdict (`local` / `REMOTE` /
+`unknown locality`), plus the count of rules excluded via `(noenrich)`,
+so you can see at a glance whether rule text is about to leave the
+host.

--- a/docs/extends.md
+++ b/docs/extends.md
@@ -1,0 +1,61 @@
+# Shared policies
+
+Org-wide rules via arai:extends: trust list, content pinning, signatures, and private policy sources.
+
+## Shared policies — `arai:extends`
+
+Instruction files can inherit rules from a trusted upstream URL. This
+is the "org-wide CLAUDE.md" pattern without a policy service — just
+another markdown file hosted wherever you like.
+
+Declare the upstream in your CLAUDE.md:
+
+```markdown
+<!-- arai:extends https://example.com/standards/rust-backend.md -->
+
+# My project rules
+- Never publish artifacts before tag push
+```
+
+Then trust the URL:
+
+```bash
+arai trust --add https://example.com/standards/rust-backend.md
+arai trust                  # List trusted URLs
+arai trust --remove <url>   # Revoke
+```
+
+Ārai never fetches a URL that isn't explicitly trusted. HTTPS only,
+512 KB size cap, 24-hour cache with stale-while-error fallback, and
+extends are not recursive — the fetched file can't pull in further
+URLs. On `arai init`, trusted upstream content is inlined ahead of the
+local rules before the parser runs, so the rest of the pipeline sees
+one merged file.
+
+### Private policy sources (authenticated extends)
+
+If your org policy file lives behind auth (an internal service, a
+private GitHub raw URL, an artifact store), give the trust entry the
+*name* of an environment variable holding a bearer token:
+
+```bash
+arai trust --add https://policy.internal.example/org-rules.md \
+           --bearer-env ARAI_EXTENDS_TOKEN
+export ARAI_EXTENDS_TOKEN="<token>"   # e.g. from your secret manager
+arai scan                             # fetches with Authorization: Bearer <token>
+```
+
+Secret handling, by construction:
+
+- Only the variable **name** is stored (in `trusted_extends.toml`); the
+  token itself never touches disk, the audit log, telemetry, or error
+  messages.
+- The header is sent **only** to the exact trusted URL (and its
+  `<url>.sig` signature sidecar on the same origin). Redirects are
+  disabled on the fetch path, so a 30x can never carry the token to
+  another host. HTTPS only, as always.
+- If the variable is unset or empty, the fetch proceeds
+  unauthenticated with a warning — same behavior as before the
+  credential was configured.
+- Content pinning (`@sha256:`), ed25519 signatures, tiers, caching,
+  and the size cap all work unchanged on authenticated responses.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,66 @@
+# MCP integration
+
+The stdio MCP server: agent-authored guards, decision self-checks, and authentication.
+
+## MCP: agent-authored guardrails
+
+`arai mcp` is also the integration path for assistants that don't have a
+native PreToolUse hook surface. Cursor and Windsurf are both MCP clients — point
+them at `arai mcp` and the agent can read the same rule set, register new guards
+mid-session, and self-check recent decisions.
+The strongest blocking enforcement is available in assistants with native hook
+support (currently Claude Code and Grok TUI), but everything else — rule lookup,
+agent-authored guards, decision history — is shared via MCP.
+
+`arai mcp` runs a [Model Context Protocol](https://modelcontextprotocol.io/)
+server on stdio. Three tools, exposed to any MCP-capable agent:
+
+| Tool | What it does |
+|------|--------------|
+| `arai_add_guard(rule, reason?)` | Register a new guardrail mid-session. Takes effect on the next PreToolUse hook — same enforcement path as rules in your CLAUDE.md. |
+| `arai_list_guards(pattern?)` | List active guardrails, optionally substring-filtered, so the agent can check what constraints are live before acting. |
+| `arai_recent_decisions(session_id?, limit?, since?)` | Look up recent Ārai decisions (deny / inject / review) so the agent can self-check after a refusal — closes the model-side feedback loop. |
+
+This closes two gaps instruction files don't cover. First, when an agent
+discovers a rule mid-session (*"from now on, never write to /etc"*,
+*"always run the full test suite before pushing"*), it now has
+somewhere to register it for deterministic enforcement rather than
+hoping context retention holds. Second, after a deny, the agent can
+call `arai_recent_decisions` to see what it was just refused for —
+useful for avoiding "try the same thing twice" loops when a single
+rule keeps getting hit.
+
+Register it with your assistant (for example in Claude Code or Cline) by adding to your MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "arai": {
+      "command": "arai",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+For Cline (in `cline_mcp_settings.json`, or via the MCP UI):
+
+```json
+{
+  "mcpServers": {
+    "arai": {
+      "command": "arai",
+      "args": ["mcp"],
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
+For Cursor and Windsurf, follow each tool's MCP server registration UI
+and point it at the same `arai mcp` command — the protocol is identical.
+
+Prerequisite: `arai` must be on your `PATH`. The install script, `cargo
+install arai`, `npm install -g @taniwhaai/arai`, and the Homebrew tap all
+put it there.

--- a/docs/rule-testing.md
+++ b/docs/rule-testing.md
@@ -1,0 +1,108 @@
+# Testing your rule set
+
+Preview, diff, replay, and regression-test rule changes before they hit a live session.
+
+## Diff — preview rule-set changes
+
+`arai diff <file>` shows what changes a candidate edit to an
+instruction file would make to the live rule set — added, removed,
+moved — before you save and run `arai scan`. Read-only against
+the store; pairs with `arai lint` (preview a file in isolation)
+and `arai why` (preview a single tool call).
+
+```bash
+arai diff CLAUDE.md                            # Plain table view
+arai diff memory/feedback_testing.md --json    # For pre-commit hooks
+```
+
+Output is grouped into three sections — `Added` (rules in the file
+that aren't in the store yet), `Removed` (rules in the store whose
+text isn't in the new file), `Moved` (same rule, different line
+number — caught when you re-order a file without changing its rules).
+JSON output keeps the same shape for CI.
+
+
+## Lint — preview what a file produces
+
+`arai lint <file>` parses an instruction file and prints every rule it
+would extract along with the intent classification, without touching
+the DB. Use it to iterate on CLAUDE.md wording and see the effect
+before you commit.
+
+```bash
+arai lint CLAUDE.md
+arai lint memory/feedback_testing.md --json   # machine-readable
+```
+
+Output for each rule: subject / predicate / object, the classified
+action (Create / Modify / Execute / General), the hook timing it routes
+to (ToolCall / Stop / Start / Principle), and which tools the rule
+applies to.
+
+
+## Test — regression harness for rules
+
+`arai test` replays synthetic hook payloads through the *same*
+`match_hook` pipeline the live hook handler uses, so rule changes get
+caught before they affect a real session.
+
+The canonical [alembic example](scenarios/alembic-migration.json) is
+checked in — run it after `arai init` on any repo with an alembic rule
+in CLAUDE.md:
+
+```bash
+arai test scenarios/alembic-migration.json
+```
+
+Scenario files are JSON:
+
+```json
+{
+  "scenarios": [
+    {
+      "name": "force-push triggers the git guardrail",
+      "hook": {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": { "command": "git push --force origin master" }
+      },
+      "expect": {
+        "matches_subject": ["git"],
+        "does_not_match_subject": ["alembic"],
+        "min_matches": 1
+      }
+    }
+  ]
+}
+```
+
+```bash
+arai test scenarios/guards.json
+arai test scenarios/guards.json --json   # structured pass/fail for CI
+```
+
+Exit code is non-zero when any scenario fails. Matches are checked by
+subject substring because full SPO triples tend to drift across
+re-ingest.
+
+
+## Record — seed scenarios from real firings
+
+`arai record` turns entries in the audit log into scenario skeletons
+so you don't hand-write regression tests. Flow: run your assistant, hit a
+rule firing you want pinned, `arai record --since=1h > tests.json`,
+tune the expectations, check in.
+
+```bash
+arai record --since=1h              # last hour
+arai record --since=7d --tool=Bash  # only Bash firings from the last week
+arai record --limit=50              # cap audit entries scanned
+```
+
+Deduplicates by (tool, prompt) so repeated identical firings collapse
+to one scenario. Each scenario's `expect` seeds `matches_subject` with
+whatever actually fired and `min_matches: 1` — tune from there.
+
+Runtime-capturing *new rules* (as opposed to testing existing ones) is
+a different loop: that goes through the MCP `arai_add_guard` tool,
+documented below.

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Arai — Instruction files that actually work</title>
-    <meta name="description" content="Enforce AI coding assistant instruction files via hooks. One command. Runs locally. Zero cost.">
+    <meta name="description" content="Your AI assistant ignores CLAUDE.md when it matters. Arai turns instruction files into enforced guardrails — blocked tool calls, a tamper-evident audit trail, per-rule compliance stats. One command. Local. Zero cost.">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -289,7 +289,7 @@
 <section class="hero">
     <div class="container">
         <h1>Instruction files that actually block.</h1>
-        <p>Enforce your AI coding assistant instruction files via hooks. Claude Code and Grok TUI currently provide the strongest support, including the ability to block tool calls for rules marked <code>never</code>. Other tools receive advisory enforcement via MCP. Every firing is audited and correlated with what the model actually did. One command. Local. Zero cost.</p>
+        <p>You already wrote the rules &mdash; CLAUDE.md, AGENTS.md, .cursorrules. Your assistant still ignores them when it matters. Arai turns those files into enforcement: prohibitions <strong>block the tool call before it runs</strong>, every firing lands in a tamper-evident audit log, and per-rule stats show whether the model actually obeyed. One command. Local. Zero cost.</p>
         <div class="install-box" onclick="copyInstall(this)">
             <span class="prompt">$</span>
             <span>curl -sSf https://arai.taniwha.ai/install | sh</span>
@@ -408,7 +408,7 @@
             </div>
             <div class="feature">
                 <h3>Hash-chained audit log</h3>
-                <p>Every audit-log line carries <code>prev_hash</code> + <code>hash</code> (SHA-256 over canonical bytes); a per-day sidecar anchors the chain tip. <code>arai audit --verify</code> walks every day-bucket and exits non-zero on any tamper, reorder, or deletion. Owner-only on disk (0700/0600 on Unix; <code>icacls</code>-pinned on Windows). Day-buckets are retained indefinitely &mdash; bucketing is the segmentation, no auto-prune.</p>
+                <p>Every audit-log line carries <code>prev_hash</code> + <code>hash</code> (SHA-256 over canonical bytes); a per-day sidecar anchors the chain tip. <code>arai audit --verify</code> walks every day-bucket and exits non-zero on any tamper, reorder, or deletion. Owner-only on disk (0700/0600 on Unix; <code>icacls</code>-pinned on Windows). Retention is policy, not accident: <code>arai audit --purge --older=90</code> sweeps whole day-buckets only, so retained days keep a valid chain.</p>
             </div>
             <div class="feature">
                 <h3>MCP authentication</h3>
@@ -440,11 +440,31 @@
             </div>
             <div class="feature">
                 <h3>Shared policies</h3>
-                <p>Inherit org-wide rules with one directive: <code>arai:extends https://...</code>. Trusted per URL, HTTPS only, cached locally. No policy service &mdash; just a markdown file upstream.</p>
+                <p>Inherit org-wide rules with one directive: <code>arai:extends https://...</code>. Trusted per URL, HTTPS only, cached locally, with <code>@sha256</code> content pinning and ed25519 signatures. Private policy endpoints work too: <code>arai trust --add &lt;url&gt; --bearer-env VAR</code> sends a bearer token to that exact URL and nowhere else. No policy service &mdash; just a markdown file upstream.</p>
             </div>
             <div class="feature">
                 <h3>Agent-authored guards</h3>
                 <p>Runs as an MCP server. The agent can register new rules mid-session and Arai enforces them on the next tool call (where supported). <code>arai_recent_decisions</code> lets the agent self-check recent decisions. MCP is the primary integration for Cursor, Windsurf and similar tools (advisory only). Native blocking hooks are currently available in Claude Code and Grok TUI.</p>
+            </div>
+            <div class="feature">
+                <h3>Ship the evidence &mdash; to your collector</h3>
+                <p><code>arai audit --ship</code> sends day-buckets <em>with their chain heads</em> to your own HTTPS endpoint, so the hash chain verifies server-side too. Resume cursor, idempotent re-ship, bearer auth via env var. Explicit opt-in only &mdash; local-first stays the default.</p>
+            </div>
+            <div class="feature">
+                <h3>Self-hosted telemetry</h3>
+                <p>Want the usage signal on your infrastructure? Point <code>[telemetry] endpoint</code> at your own collector &mdash; same anonymous events, your retention rules. Opt-outs (<code>ARAI_TELEMETRY=off</code>, <code>DO_NOT_TRACK=1</code>) win regardless. Payload schema documented.</p>
+            </div>
+            <div class="feature">
+                <h3>Embeddable library</h3>
+                <p>Arai builds as a Rust library alongside the CLI: parser layers, rule store, guardrail matching, audit chain, and hook decisions as a crates.io dependency. Wrappers and IDE integrations consume enforcement directly instead of shelling out.</p>
+            </div>
+            <div class="feature">
+                <h3>Rule set stays live</h3>
+                <p>Edit CLAUDE.md and Arai re-scans in the background &mdash; the next tool call enforces the new wording, no manual rescan. <code>cd</code> into a monorepo subpackage and matching switches to that project&rsquo;s rules.</p>
+            </div>
+            <div class="feature">
+                <h3>One source of truth</h3>
+                <p><code>arai canonicalize</code> extracts your rules into <code>arai.toml</code>; <code>arai sync</code> writes per-tool instruction files from it &mdash; CLAUDE.md, AGENTS.md, .cursorrules stay in lockstep instead of drifting.</p>
             </div>
             <div class="feature">
                 <h3>Zero noise</h3>
@@ -469,7 +489,8 @@
         <ul class="compliance-list">
             <li><strong>CC6.1 logical access</strong> &mdash; audit dir locked to owner (0700/0600 on Unix; <code>icacls</code>-pinned on Windows).</li>
             <li><strong>CC6.6 supply chain</strong> &mdash; SHA-256 binary verification on every install path; <code>arai:extends</code> SSRF-hardened transport plus cache-at-rest signature.</li>
-            <li><strong>CC7.2 monitoring</strong> &mdash; per-firing JSONL audit log, hash-chained (<code>prev_hash</code> + <code>hash</code>) so tampering is detected by <code>arai audit --verify</code>.</li>
+            <li><strong>CC7.2 monitoring</strong> &mdash; per-firing JSONL audit log, hash-chained (<code>prev_hash</code> + <code>hash</code>) so tampering is detected by <code>arai audit --verify</code>; <code>arai audit --ship</code> centralises the trail on your own collector with the chain heads attached, so integrity verifies server-side too.</li>
+            <li><strong>CC6.5 data disposal</strong> &mdash; <code>arai audit --purge</code> gives age-based (<code>--older=90</code>) and project-scoped retention sweeps with <code>--dry-run</code> review; whole day-buckets only, so retained days keep a valid chain.</li>
             <li><strong>CC7.3 detection</strong> &mdash; Pre/Post correlation produces obeyed / ignored / unclear verdicts per rule. Evidence of <em>effectiveness</em>, not just attempts.</li>
             <li><strong>CC8.1 change management</strong> &mdash; <code>arai diff</code>, <code>arai test</code>, <code>arai record</code>, and the synthetic parser-coverage corpus turn rule edits into CI assertions.</li>
             <li><strong>CC9.2 vendor management</strong> &mdash; MCP server supports an optional shared-secret (<code>ARAI_MCP_AUTH_TOKEN</code>); input caps bound a misbehaving agent.</li>
@@ -509,7 +530,7 @@
 <section class="family">
     <div class="container">
         <h2>Part of the Taniwha family</h2>
-        <p>Arai is the open-source guardrail core of <a href="https://taniwha.ai/kete">Kete</a>, Taniwha AI&rsquo;s runtime reliability platform for AI coding agents. Arai handles per-developer enforcement and audit locally; Kete adds the team layer on top &mdash; centralised rule distribution, aggregated compliance dashboards across a fleet of developers, semantic enrichment, and impact analysis across callers and transitive dependents. The local audit and verdict pipeline doesn&rsquo;t change. If your instruction files just need enforcing on one machine, Arai is all you need. For the full feature inventory mapped to procurement-review questions, see the <a href="https://github.com/taniwhaai/arai/blob/main/docs/arai-compliance-features.pdf">compliance inventory</a>.</p>
+        <p>Arai is the open-source guardrail core of <a href="https://taniwha.ai/kete">Kete</a>, Taniwha AI&rsquo;s runtime reliability platform for AI coding agents. Arai handles per-developer enforcement and audit locally, and ships the self-hosting primitives &mdash; private rule sources via authenticated <code>arai:extends</code>, audit shipping to your own collector, a configurable telemetry endpoint &mdash; for teams that want to assemble centralisation themselves. Kete is the managed layer on top: rule distribution without running an endpoint, aggregated compliance dashboards across a fleet of developers, semantic enrichment, and impact analysis across callers and transitive dependents. The local audit and verdict pipeline doesn&rsquo;t change either way. If your instruction files just need enforcing on one machine, Arai is all you need. For the full feature inventory mapped to procurement-review questions, see the <a href="https://github.com/taniwhaai/arai/blob/main/docs/arai-compliance-features.pdf">compliance inventory</a>.</p>
         <p class="family-links"><a href="https://taniwha.ai">Taniwha.ai</a> &middot; <a href="https://taniwha.ai/kete">Kete</a> &middot; <a href="https://taniwha.ai/products">All products</a></p>
     </div>
 </section>

--- a/site/index.html
+++ b/site/index.html
@@ -125,6 +125,40 @@
             font-size: 1.5rem; font-weight: 700;
             text-align: center; margin-bottom: 2.5rem;
         }
+        .feature-group { margin-bottom: 3rem; }
+        .feature-group:last-child { margin-bottom: 0; }
+        .group-title {
+            font-size: 1.15rem; font-weight: 700;
+            margin-bottom: 0.35rem; color: var(--text);
+        }
+        .group-blurb {
+            font-size: 0.9rem; color: var(--text-secondary);
+            margin-bottom: 1.25rem;
+        }
+        .eyebrow {
+            font-size: 0.8rem; font-weight: 600;
+            letter-spacing: 0.08em; text-transform: uppercase;
+            color: var(--primary); margin-bottom: 0.75rem;
+        }
+        .contrast {
+            padding: 3.5rem 0; border-top: 1px solid var(--border);
+        }
+        .contrast h2 {
+            font-size: 1.5rem; font-weight: 700;
+            text-align: center; margin-bottom: 1.75rem;
+        }
+        .contrast-table {
+            max-width: 700px; margin: 0 auto;
+            border-collapse: collapse; width: 100%;
+            font-size: 0.9rem;
+        }
+        .contrast-table th, .contrast-table td {
+            text-align: left; padding: 0.6rem 1rem;
+            border-bottom: 1px solid var(--border);
+        }
+        .contrast-table th { color: var(--text-secondary); font-weight: 600; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; }
+        .contrast-table td:last-child { color: var(--primary); font-weight: 500; }
+        .contrast-table td:first-child { color: var(--text-secondary); }
         .feature-grid {
             display: grid; grid-template-columns: repeat(3, 1fr);
             gap: 2rem;
@@ -288,13 +322,27 @@
 
 <section class="hero">
     <div class="container">
+        <div class="eyebrow">Runtime policy enforcement for AI coding agents</div>
         <h1>Instruction files that actually block.</h1>
-        <p>You already wrote the rules &mdash; CLAUDE.md, AGENTS.md, .cursorrules. Your assistant still ignores them when it matters. Arai turns those files into enforcement: prohibitions <strong>block the tool call before it runs</strong>, every firing lands in a tamper-evident audit log, and per-rule stats show whether the model actually obeyed. One command. Local. Zero cost.</p>
+        <p>Your assistant reads CLAUDE.md and ignores it when it matters. Arai turns the instruction files <strong>you already have</strong> &mdash; CLAUDE.md, AGENTS.md, .cursorrules &mdash; into enforcement: prohibitions block the tool call before it runs, and a tamper-evident audit trail proves, per rule, whether the model obeyed. Nothing to rewrite. No new format. One command. Local. Zero cost.</p>
         <div class="install-box" onclick="copyInstall(this)">
             <span class="prompt">$</span>
             <span>curl -sSf https://arai.taniwha.ai/install | sh</span>
             <span class="copy-hint">click to copy</span>
         </div>
+    </div>
+</section>
+
+<section class="contrast">
+    <div class="container">
+        <h2>Why not just write a CLAUDE.md?</h2>
+        <table class="contrast-table">
+            <tr><th>An instruction file alone</th><th>With Arai</th></tr>
+            <tr><td>Advice the model can skip under pressure</td><td>Prohibitions deny the tool call at the hook</td></tr>
+            <tr><td>No record of what was ignored</td><td>Hash-chained audit log; <code>arai audit --verify</code></td></tr>
+            <tr><td>You hope it listened</td><td>Per-rule obeyed / ignored / unclear verdicts</td></tr>
+            <tr><td>Rewrite your rules into a new policy format</td><td>Your existing files <em>are</em> the policy</td></tr>
+        </table>
     </div>
 </section>
 
@@ -356,8 +404,15 @@
 
 <section class="features">
     <div class="container">
-        <h2>Smart, not noisy</h2>
-        <div class="feature-grid">
+        <h2>Built around outcomes</h2>
+        <div class="feature-group">
+            <h3 class="group-title">Stop bad actions before they run</h3>
+            <p class="group-blurb">Prohibitions deny the tool call at the hook — before the file is written or the command runs.</p>
+            <div class="feature-grid">
+            <div class="feature">
+                <h3>Block, don&rsquo;t just advise</h3>
+                <p>Rules with <code>never</code>/<code>forbids</code>/<code>must_not</code> can deny the tool call in Claude Code and Grok TUI (the two assistants with native hook support today). <code>always</code> and <code>prefers</code> still advise. Incremental rollout via <code>ARAI_DENY_MODE=off</code>. Cursor, Windsurf and others get advisory enforcement via MCP.</p>
+            </div>
             <div class="feature">
                 <h3>Intent-aware</h3>
                 <p>"Never hand-write migrations" fires on Write but not Edit. Editing existing migrations is fine.</p>
@@ -371,64 +426,48 @@
                 <p>"Never push without tests" silences after cargo test runs. Arai remembers what happened this session.</p>
             </div>
             <div class="feature">
-                <h3>Block, don&rsquo;t just advise</h3>
-                <p>Rules with <code>never</code>/<code>forbids</code>/<code>must_not</code> can deny the tool call in Claude Code and Grok TUI (the two assistants with native hook support today). <code>always</code> and <code>prefers</code> still advise. Incremental rollout via <code>ARAI_DENY_MODE=off</code>. Cursor, Windsurf and others get advisory enforcement via MCP.</p>
+                <h3>Rule set stays live</h3>
+                <p>Edit CLAUDE.md and Arai re-scans in the background &mdash; the next tool call enforces the new wording, no manual rescan. <code>cd</code> into a monorepo subpackage and matching switches to that project&rsquo;s rules.</p>
             </div>
             <div class="feature">
-                <h3>Per-rule rollout</h3>
-                <p><code>arai severity alembic block</code> pins one rule to deny while the rest of the set stays in advise. Survives <code>arai scan</code>. Ship the set in advise mode, watch which rules earn the trust, then flip them one at a time.</p>
+                <h3>Zero noise</h3>
+                <p>Only fires domain-specific rules. Principles already in your instruction files stay silent.</p>
+            </div>
+            </div>
+        </div>
+        <div class="feature-group">
+            <h3 class="group-title">Know what happened &mdash; and prove it</h3>
+            <p class="group-blurb">A tamper-evident record of every firing, correlated with what the model actually did.</p>
+            <div class="feature-grid">
+            <div class="feature">
+                <h3>Hash-chained audit log</h3>
+                <p>Every audit-log line carries <code>prev_hash</code> + <code>hash</code> (SHA-256 over canonical bytes); a per-day sidecar anchors the chain tip. <code>arai audit --verify</code> walks every day-bucket and exits non-zero on any tamper, reorder, or deletion. Owner-only on disk (0700/0600 on Unix; <code>icacls</code>-pinned on Windows). Retention is policy, not accident: <code>arai audit --purge --older=90</code> sweeps whole day-buckets only, so retained days keep a valid chain.</p>
             </div>
             <div class="feature">
                 <h3>Compliance tracking</h3>
                 <p>Every PostToolUse is correlated against its PreToolUse firings. Each rule gets an <em>obeyed</em>, <em>ignored</em>, or <em>unclear</em> verdict. <code>arai audit --outcome=ignored</code> tells you which rules the model keeps flouting; filter to a specific rule with <code>--rule</code>.</p>
             </div>
             <div class="feature">
-                <h3>Derivation trace</h3>
-                <p>Every firing carries source file, line, and parser layer. Hook output shows the origin (e.g. <code>[CLAUDE.md:42 layer-1]</code> or <code>[AGENTS.md:42 layer-1]</code>) — no more guessing why a rule fired.</p>
-            </div>
-            <div class="feature">
-                <h3>Explain before you commit</h3>
-                <p><code>arai why "git push --force"</code> replays a hypothetical tool call through the live match pipeline. Read-only. Ship new rules with confidence.</p>
-            </div>
-            <div class="feature">
-                <h3>Self-pruning rules</h3>
-                <p>Annotate a rule with <code>(expires 2026-12-31)</code> or <code>(until 2027-06-30)</code>. Arai filters it out after the date automatically &mdash; perfect for incident-driven rules that have a shelf life.</p>
-            </div>
-            <div class="feature">
-                <h3>Audit log</h3>
-                <p>Every firing is appended to a local JSONL you can query. See which rules fire, on which tools, for which prompts. Nothing leaves your machine.</p>
-            </div>
-            <div class="feature">
-                <h3>Local-first, air-gap friendly</h3>
-                <p>No network on the hook hot path. Enforcement, audit, compliance verdicts, and stats all run against the local SQLite + JSONL. Works offline, in restricted environments, and during outages &mdash; nothing to monitor, nothing to vendor-onboard.</p>
-            </div>
-            <div class="feature">
-                <h3>Supply-chain hardened</h3>
-                <p>Downloads verified against SHA-256 <code>checksums.txt</code> on every install path (curl, npm, cargo). <code>arai:extends</code> upstream policy fetches refuse loopback, RFC1918, link-local, cloud metadata, and redirects &mdash; and cached upstream files carry a SHA-256 sidecar so an at-rest tamper is detected before the rules reach the parser. MCP-source rules capped per project to bound a malfunctioning agent.</p>
-            </div>
-            <div class="feature">
-                <h3>Hash-chained audit log</h3>
-                <p>Every audit-log line carries <code>prev_hash</code> + <code>hash</code> (SHA-256 over canonical bytes); a per-day sidecar anchors the chain tip. <code>arai audit --verify</code> walks every day-bucket and exits non-zero on any tamper, reorder, or deletion. Owner-only on disk (0700/0600 on Unix; <code>icacls</code>-pinned on Windows). Retention is policy, not accident: <code>arai audit --purge --older=90</code> sweeps whole day-buckets only, so retained days keep a valid chain.</p>
-            </div>
-            <div class="feature">
-                <h3>MCP authentication</h3>
-                <p>The agent-facing MCP server supports an optional shared-secret via <code>ARAI_MCP_AUTH_TOKEN</code>. When set, <code>initialize</code> must present a matching token (constant-time compare) before any tool call succeeds. Open by default for backwards compatibility.</p>
-            </div>
-            <div class="feature">
                 <h3>Per-rule compliance ratios</h3>
                 <p><code>arai stats</code> rolls up the audit log into <em>fires / obeyed / ignored / ratio</em> per rule. Now you can answer "is this rule actually working?" &mdash; not "is it firing?" The &#x26A0; flag highlights low-ratio rules with enough volume to mean it.</p>
+            </div>
+            <div class="feature">
+                <h3>Derivation trace</h3>
+                <p>Every firing carries source file, line, and parser layer. Hook output shows the origin (e.g. <code>[CLAUDE.md:42 layer-1]</code> or <code>[AGENTS.md:42 layer-1]</code>) — no more guessing why a rule fired.</p>
             </div>
             <div class="feature">
                 <h3>Token economics</h3>
                 <p>Repeat firings of the same rule in a session emit a compact one-liner instead of re-injecting the full payload. <code>arai stats</code> surfaces a calibrated <em>tokens saved</em> estimate from suppressed repeats plus denied-and-honored mistakes &mdash; secondary signal, primary mission stays correctness.</p>
             </div>
-            <div class="feature">
-                <h3>Rule regression tests</h3>
-                <p><code>arai test</code> replays synthetic hook payloads through the live match pipeline. Catch rule behaviour drift before a real session does. CI-friendly JSON output.</p>
             </div>
+        </div>
+        <div class="feature-group">
+            <h3 class="group-title">Ship rule changes safely</h3>
+            <p class="group-blurb">Treat your rule set like code: preview, diff, test, roll out incrementally, let stale rules expire.</p>
+            <div class="feature-grid">
             <div class="feature">
-                <h3>Capture to replay</h3>
-                <p><code>arai record</code> turns real firings from the audit log into scenario fixtures. You don&rsquo;t hand-write regression tests &mdash; you capture the ones that matter and pin them.</p>
+                <h3>Explain before you commit</h3>
+                <p><code>arai why "git push --force"</code> replays a hypothetical tool call through the live match pipeline. Read-only. Ship new rules with confidence.</p>
             </div>
             <div class="feature">
                 <h3>Preview before commit</h3>
@@ -439,12 +478,34 @@
                 <p><code>arai diff</code> shows what an edit would change in the live rule set &mdash; added, removed, moved &mdash; before you commit it. Pre-commit-hook fodder via <code>--json</code>.</p>
             </div>
             <div class="feature">
-                <h3>Shared policies</h3>
-                <p>Inherit org-wide rules with one directive: <code>arai:extends https://...</code>. Trusted per URL, HTTPS only, cached locally, with <code>@sha256</code> content pinning and ed25519 signatures. Private policy endpoints work too: <code>arai trust --add &lt;url&gt; --bearer-env VAR</code> sends a bearer token to that exact URL and nowhere else. No policy service &mdash; just a markdown file upstream.</p>
+                <h3>Rule regression tests</h3>
+                <p><code>arai test</code> replays synthetic hook payloads through the live match pipeline. Catch rule behaviour drift before a real session does. CI-friendly JSON output.</p>
             </div>
             <div class="feature">
-                <h3>Agent-authored guards</h3>
-                <p>Runs as an MCP server. The agent can register new rules mid-session and Arai enforces them on the next tool call (where supported). <code>arai_recent_decisions</code> lets the agent self-check recent decisions. MCP is the primary integration for Cursor, Windsurf and similar tools (advisory only). Native blocking hooks are currently available in Claude Code and Grok TUI.</p>
+                <h3>Capture to replay</h3>
+                <p><code>arai record</code> turns real firings from the audit log into scenario fixtures. You don&rsquo;t hand-write regression tests &mdash; you capture the ones that matter and pin them.</p>
+            </div>
+            <div class="feature">
+                <h3>Per-rule rollout</h3>
+                <p><code>arai severity alembic block</code> pins one rule to deny while the rest of the set stays in advise. Survives <code>arai scan</code>. Ship the set in advise mode, watch which rules earn the trust, then flip them one at a time.</p>
+            </div>
+            <div class="feature">
+                <h3>Self-pruning rules</h3>
+                <p>Annotate a rule with <code>(expires 2026-12-31)</code> or <code>(until 2027-06-30)</code>. Arai filters it out after the date automatically &mdash; perfect for incident-driven rules that have a shelf life.</p>
+            </div>
+            <div class="feature">
+                <h3>One source of truth</h3>
+                <p><code>arai canonicalize</code> extracts your rules into <code>arai.toml</code>; <code>arai sync</code> writes per-tool instruction files from it &mdash; CLAUDE.md, AGENTS.md, .cursorrules stay in lockstep instead of drifting.</p>
+            </div>
+            </div>
+        </div>
+        <div class="feature-group">
+            <h3 class="group-title">Scale to teams</h3>
+            <p class="group-blurb">Org-wide policy and centralised evidence on your own infrastructure &mdash; opt-in, never by default.</p>
+            <div class="feature-grid">
+            <div class="feature">
+                <h3>Shared policies</h3>
+                <p>Inherit org-wide rules with one directive: <code>arai:extends https://...</code>. Trusted per URL, HTTPS only, cached locally, with <code>@sha256</code> content pinning and ed25519 signatures. Private policy endpoints work too: <code>arai trust --add &lt;url&gt; --bearer-env VAR</code> sends a bearer token to that exact URL and nowhere else. No policy service &mdash; just a markdown file upstream.</p>
             </div>
             <div class="feature">
                 <h3>Ship the evidence &mdash; to your collector</h3>
@@ -455,28 +516,39 @@
                 <p>Want the usage signal on your infrastructure? Point <code>[telemetry] endpoint</code> at your own collector &mdash; same anonymous events, your retention rules. Opt-outs (<code>ARAI_TELEMETRY=off</code>, <code>DO_NOT_TRACK=1</code>) win regardless. Payload schema documented.</p>
             </div>
             <div class="feature">
+                <h3>Agent-authored guards</h3>
+                <p>Runs as an MCP server. The agent can register new rules mid-session and Arai enforces them on the next tool call (where supported). <code>arai_recent_decisions</code> lets the agent self-check recent decisions. MCP is the primary integration for Cursor, Windsurf and similar tools (advisory only). Native blocking hooks are currently available in Claude Code and Grok TUI.</p>
+            </div>
+            <div class="feature">
+                <h3>MCP authentication</h3>
+                <p>The agent-facing MCP server supports an optional shared-secret via <code>ARAI_MCP_AUTH_TOKEN</code>. When set, <code>initialize</code> must present a matching token (constant-time compare) before any tool call succeeds. Open by default for backwards compatibility.</p>
+            </div>
+            </div>
+        </div>
+        <div class="feature-group">
+            <h3 class="group-title">Runs on your terms</h3>
+            <p class="group-blurb">Local-first, fast, verifiable, and embeddable &mdash; nothing to monitor, nothing to vendor-onboard.</p>
+            <div class="feature-grid">
+            <div class="feature">
+                <h3>Local-first, air-gap friendly</h3>
+                <p>No network on the hook hot path. Enforcement, audit, compliance verdicts, and stats all run against the local SQLite + JSONL. Works offline, in restricted environments, and during outages &mdash; nothing to monitor, nothing to vendor-onboard.</p>
+            </div>
+            <div class="feature">
+                <h3>~30ms latency</h3>
+                <p>End-to-end per tool call, dominated by binary launch. SQLite lookups on the hook path. No network calls. No LLM calls at runtime.</p>
+            </div>
+            <div class="feature">
+                <h3>Supply-chain hardened</h3>
+                <p>Downloads verified against SHA-256 <code>checksums.txt</code> on every install path (curl, npm, cargo). <code>arai:extends</code> upstream policy fetches refuse loopback, RFC1918, link-local, cloud metadata, and redirects &mdash; and cached upstream files carry a SHA-256 sidecar so an at-rest tamper is detected before the rules reach the parser. MCP-source rules capped per project to bound a malfunctioning agent.</p>
+            </div>
+            <div class="feature">
                 <h3>Embeddable library</h3>
                 <p>Arai builds as a Rust library alongside the CLI: parser layers, rule store, guardrail matching, audit chain, and hook decisions as a crates.io dependency. Wrappers and IDE integrations consume enforcement directly instead of shelling out.</p>
-            </div>
-            <div class="feature">
-                <h3>Rule set stays live</h3>
-                <p>Edit CLAUDE.md and Arai re-scans in the background &mdash; the next tool call enforces the new wording, no manual rescan. <code>cd</code> into a monorepo subpackage and matching switches to that project&rsquo;s rules.</p>
-            </div>
-            <div class="feature">
-                <h3>One source of truth</h3>
-                <p><code>arai canonicalize</code> extracts your rules into <code>arai.toml</code>; <code>arai sync</code> writes per-tool instruction files from it &mdash; CLAUDE.md, AGENTS.md, .cursorrules stay in lockstep instead of drifting.</p>
-            </div>
-            <div class="feature">
-                <h3>Zero noise</h3>
-                <p>Only fires domain-specific rules. Principles already in your instruction files stay silent.</p>
             </div>
             <div class="feature">
                 <h3>Any LLM enrichment</h3>
                 <p>Classify rules via Claude, Ollama, or any LLM CLI. Or use the built-in sentence transformer.</p>
             </div>
-            <div class="feature">
-                <h3>~30ms latency</h3>
-                <p>End-to-end per tool call, dominated by binary launch. SQLite lookups on the hook path. No network calls. No LLM calls at runtime.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Front-door refresh in two rounds, driven by external review feedback (GPT + Grok). Presentation layering only — no feature or code changes.

## Round 1 — surface what shipped, sharpen the why

- Hero/README/repo-description now lead with the one-sentence why: *you already wrote the rules; the model ignores them; Arai makes them block, audits every firing, and measures per-rule obedience.*
- Added the missing v1.1 features (audit --ship, self-hosted telemetry, authenticated extends), embeddable library, auto-rescan, canonicalize/sync.
- Fixed a stale claim (audit retention: `--purge` has existed since v0.2.20) and added CC6.5/CC7.2 lines to the SOC 2 list.
- Kete paragraph reframed: Arai = self-hosting primitives, Kete = managed layer.

## Round 2 — outcome layering ("the page reads like release notes")

**Site**: 30 flat feature tiles regrouped into five outcome groups — *Stop bad actions before they run · Know what happened, and prove it · Ship rule changes safely · Scale to teams · Runs on your terms* — each with a one-line blurb; duplicate audit tile merged. Hero gains a category eyebrow (**Runtime policy enforcement for AI coding agents**) and makes zero-migration explicit ("Nothing to rewrite. No new format."). New "Why not just write a CLAUDE.md?" contrast table right after the hero — the no-rewrite differentiator, no competitor naming.

**README**: optimized for reaching `arai init` in under two minutes — 893 → 413 lines with zero content deleted. Deep dives moved verbatim to focused guides (docs/enforcement.md, audit.md, rule-testing.md, extends.md, mcp.md, enrichment.md) indexed from a new "Going deeper" section alongside the existing audit-ship and telemetry-payload docs.

Check the Cloudflare Pages preview for the rendered result — this is voice/positioning, so worth an eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)