### PR TITLE
refactor(lib): item-level library API surface audit

### DIFF
--- a/src/canonicalize.rs
+++ b/src/canonicalize.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+/// Root of a canonical `arai.toml` rules file (see `docs/rules-file-spec.md`).
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CanonicalFile {
     pub meta: Meta,
@@ -26,6 +27,7 @@ pub struct CanonicalFile {
     pub rules: Vec<CanonicalRule>,
 }
 
+/// The `[meta]` header of a canonical rules file.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Meta {
     pub schema_version: u32,
@@ -35,17 +37,22 @@ pub struct Meta {
     pub extends: Vec<String>,
 }
 
+/// One `[[rule]]` entry in a canonical rules file.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CanonicalRule {
+    /// Stable, human-readable rule id (unique within the file).
     pub id: String,
     pub description: String,
     pub when: When,
     pub then: Then,
+    /// Severity label (`block` / `warn` / `inform`).
     pub severity: String,
+    /// Optional ISO expiry date, mirroring the `(expires …)` annotation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires: Option<String>,
 }
 
+/// The `when` clause of a canonical rule — what tool calls it applies to.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct When {
     pub tool: Vec<String>,
@@ -55,16 +62,22 @@ pub struct When {
     pub command_pattern: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content_pattern: Option<String>,
+    /// Prerequisite terms that must NOT have been seen in the session for
+    /// the rule to fire (e.g. `["cargo", "test"]`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub session_lacks: Vec<String>,
 }
 
+/// The `then` clause of a canonical rule — what happens on a match.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Then {
+    /// Action label (`deny` / `warn` / `inform`).
     pub action: String,
+    /// Message surfaced to the model / user when the rule fires.
     pub message: String,
 }
 
+/// What [`run`] did: how many rules were written from how many files.
 pub struct Summary {
     pub rules_written: usize,
     pub files_read: usize,

--- a/src/compliance.rs
+++ b/src/compliance.rs
@@ -35,6 +35,8 @@ pub enum Outcome {
 }
 
 impl Outcome {
+    /// The lowercase label emitted in Compliance audit events and accepted
+    /// by `arai audit --outcome=`.
     pub fn as_str(&self) -> &'static str {
         match self {
             Outcome::Obeyed => "obeyed",

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,16 +2,32 @@ use sha2::{Digest, Sha256};
 use std::io::IsTerminal;
 use std::path::PathBuf;
 
+/// Resolved runtime configuration: project root, state directory, and the
+/// optional knobs from `{arai_base}/config.toml` plus environment variables.
+/// Build one with [`Config::load`]; nearly every library entry point takes
+/// a `&Config`.
 #[derive(Debug, Clone)]
 pub struct Config {
+    /// The enclosing git repository root (found by walking up from the CWD).
     pub project_root: PathBuf,
+    /// The user's home directory.
     pub home_dir: PathBuf,
+    /// Arai's state root (default `~/.taniwha/arai`) — DB, audit log,
+    /// sessions, trust list all live under here.
     pub arai_base_dir: PathBuf,
+    /// Extra instruction-file paths from `[sources] extra` in config.toml,
+    /// relative to the project root.
     pub extra_sources: Vec<String>,
+    /// Guardrails mode from config.toml (`"advise"` by default).
     pub guardrails_mode: String,
+    /// Shell command for Tier-3 LLM enrichment (`ARAI_LLM_CMD` env var or
+    /// `[enrich] llm_command`).
     pub llm_command: Option<String>,
+    /// OpenAI-compatible endpoint for API enrichment.
     pub api_url: Option<String>,
+    /// Name of the env var holding the API key (never the key itself).
     pub api_key_env: Option<String>,
+    /// Model name for API enrichment.
     pub api_model: Option<String>,
 }
 
@@ -20,7 +36,7 @@ pub struct Config {
 /// human-readable message string the caller can emit verbatim to standard
 /// error.  The two variants are mutually exclusive.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DeprecationNotice {
+pub(crate) enum DeprecationNotice {
     /// Branch 2: the deprecated `ARAI_DB_DIR` environment variable
     /// supplied the path.  The message instructs the user to rename the
     /// environment variable to `ARAI_BASE_DIR`.
@@ -33,7 +49,7 @@ pub enum DeprecationNotice {
 
 impl DeprecationNotice {
     /// Borrow the human-readable message string carried by this notice.
-    pub fn message(&self) -> &str {
+    pub(crate) fn message(&self) -> &str {
         match self {
             DeprecationNotice::DeprecatedEnvVar(msg) => msg,
             DeprecationNotice::DeprecatedDefaultPath(msg) => msg,
@@ -47,9 +63,9 @@ impl DeprecationNotice {
 /// when the chosen path was selected via a deprecated mechanism (branches
 /// 2 and 4 in the resolver's five-branch precedence order).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ResolvedBaseDir {
-    pub path: String,
-    pub notice: Option<DeprecationNotice>,
+pub(crate) struct ResolvedBaseDir {
+    pub(crate) path: String,
+    pub(crate) notice: Option<DeprecationNotice>,
 }
 
 /// Pure resolver for the Arai base directory.
@@ -80,7 +96,11 @@ pub struct ResolvedBaseDir {
 /// 3. else `path_exists(<home>/.taniwha/arai)` true → that path, no notice.
 /// 4. else `path_exists(<home>/.arai)` true → that path, `DeprecatedDefaultPath` notice.
 /// 5. else fresh-install fallback → `<home>/.taniwha/arai`, no notice.
-pub fn resolve_base_dir<E, P>(env_lookup: E, path_exists: P, home_dir: &str) -> ResolvedBaseDir
+pub(crate) fn resolve_base_dir<E, P>(
+    env_lookup: E,
+    path_exists: P,
+    home_dir: &str,
+) -> ResolvedBaseDir
 where
     E: Fn(&str) -> Option<String>,
     P: Fn(&str) -> bool,
@@ -142,6 +162,10 @@ where
 }
 
 impl Config {
+    /// Load configuration for the current working directory's project:
+    /// locate the git root, resolve the Arai base directory (env vars,
+    /// then existing default paths), and merge `{arai_base}/config.toml`
+    /// with enrichment env vars (env wins).
     pub fn load() -> Result<Config, String> {
         let project_root = find_project_root()?;
         let home_dir = dirs::home_dir().ok_or("Could not determine home directory")?;
@@ -267,13 +291,13 @@ impl Config {
     }
 
     /// Claude Code memory slug: /home/matt/r/arai → -home-matt-r-arai
-    pub fn claude_memory_slug(&self) -> String {
+    pub(crate) fn claude_memory_slug(&self) -> String {
         let path_str = self.project_root.to_string_lossy();
         path_str.replace('/', "-")
     }
 
     /// Path to Claude Code memory files for this project
-    pub fn claude_memory_dir(&self) -> PathBuf {
+    pub(crate) fn claude_memory_dir(&self) -> PathBuf {
         self.home_dir
             .join(".claude")
             .join("projects")
@@ -282,19 +306,19 @@ impl Config {
     }
 
     /// Path to the project's .claude/settings.json
-    pub fn claude_settings_path(&self) -> PathBuf {
+    pub(crate) fn claude_settings_path(&self) -> PathBuf {
         self.project_root.join(".claude").join("settings.json")
     }
 
     /// Path to the project's .grok/hooks directory (for native Grok TUI hook registration).
     /// We prefer writing arai.json here when the user has a .grok/ project layout.
-    pub fn grok_hooks_dir(&self) -> PathBuf {
+    pub(crate) fn grok_hooks_dir(&self) -> PathBuf {
         self.project_root.join(".grok").join("hooks")
     }
 
     /// Path to the global Grok hooks directory (~/.grok/hooks).
     #[allow(dead_code)]
-    pub fn grok_global_hooks_dir(&self) -> PathBuf {
+    pub(crate) fn grok_global_hooks_dir(&self) -> PathBuf {
         self.home_dir.join(".grok").join("hooks")
     }
 }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -3,13 +3,20 @@ use crate::extends;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+/// One instruction file found by [`discover`], with its content already
+/// read and any `arai:extends` directives resolved.
 #[derive(Debug, Clone)]
 pub struct DiscoveredFile {
+    /// Filesystem path the file was read from.
     pub path: String,
+    /// Source-type tag (`claude_md_project`, `cursor_rules`, `agents_md`, …)
+    /// used as the extraction-confidence namespace.
     pub source_type: String,
+    /// Base extraction confidence for rules from this file.
     pub confidence: f64,
+    /// Full file content (post-`extends` resolution).
     pub content: String,
-    #[allow(dead_code)]
+    /// Parsed YAML-ish frontmatter key/value pairs, empty when absent.
     pub frontmatter: HashMap<String, String>,
 }
 
@@ -195,7 +202,7 @@ fn read_memory_file(path: &PathBuf) -> Option<DiscoveredFile> {
 
 /// Parse YAML-like frontmatter from markdown.
 /// Returns (frontmatter_map, body_without_frontmatter).
-pub fn parse_frontmatter(content: &str) -> (HashMap<String, String>, String) {
+pub(crate) fn parse_frontmatter(content: &str) -> (HashMap<String, String>, String) {
     let mut map = HashMap::new();
 
     if !content.starts_with("---") {

--- a/src/enrich.rs
+++ b/src/enrich.rs
@@ -814,7 +814,7 @@ fn apply_classifications(
         let mut is_partial = false;
 
         let action = if Action::is_valid(raw_action) {
-            Action::from_str(raw_action)
+            Action::from_str_lossy(raw_action)
         } else {
             eprintln!(
                 "    \u{26a0} Rule '{}': unrecognized action '{}', using fuzzy match",
@@ -825,7 +825,7 @@ fn apply_classifications(
         };
 
         let timing_raw = if crate::intent::Timing::is_valid(raw_timing) {
-            crate::intent::Timing::from_str(raw_timing)
+            crate::intent::Timing::from_str_lossy(raw_timing)
         } else {
             eprintln!(
                 "    \u{26a0} Rule '{}': unrecognized timing '{}', using fuzzy match",

--- a/src/guardrails.rs
+++ b/src/guardrails.rs
@@ -11,7 +11,6 @@ const SKIP_TOOLS: &[&str] = &["Read", "Glob", "Agent", "ToolSearch"];
 /// These are the names that appear in SKIP_TOOLS, extract_terms dispatch, etc.
 /// This list serves as the single source of truth for tool names coming from
 /// any supported coding agent hook (Claude Code, Grok TUI, etc.).
-#[allow(dead_code)]
 pub const CANONICAL_TOOLS: &[&str] = &[
     "Bash",
     "Edit",
@@ -227,11 +226,6 @@ fn extract_file_terms(tool_input: &Value) -> Vec<String> {
     terms
 }
 
-/// Public entry point for content sniffing from hooks.
-pub fn sniff_content_for_tools_pub(content: &str, terms: &mut Vec<String>) {
-    sniff_content_for_tools(content, terms);
-}
-
 /// Compiled Aho-Corasick automaton over `KNOWN_TOOLS`, ASCII-case-insensitive.
 /// Built once per process (the hook is a fresh process per Claude Code tool
 /// call, so "per process" is "per call" — the build cost is paid once instead
@@ -255,7 +249,7 @@ fn known_tools_automaton() -> &'static AhoCorasick {
 /// boundaries are checked on the byte before/after each match using
 /// `is_ascii_alphanumeric`; non-ASCII bytes count as boundaries (which is
 /// what we want — `KNOWN_TOOLS` are all ASCII).
-fn sniff_content_for_tools(content: &str, terms: &mut Vec<String>) {
+pub(crate) fn sniff_content_for_tools(content: &str, terms: &mut Vec<String>) {
     let bytes = content.as_bytes();
     let automaton = known_tools_automaton();
     // Keep "found once is enough" semantics — track which patterns have

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -297,7 +297,7 @@ pub fn match_hook(hook: &Value, cfg: &Config, db: &Store) -> Result<HookMatch, S
     // side effect the hook handler owns, not the scenario runner)
     if event == "PostToolUse" {
         if let Some(result) = hook.get("tool_result").and_then(|v| v.as_str()) {
-            guardrails::sniff_content_for_tools_pub(result, &mut terms);
+            guardrails::sniff_content_for_tools(result, &mut terms);
         }
         terms.sort();
         terms.dedup();
@@ -375,6 +375,12 @@ fn desired_exit_code(host: Host, event: &str, deny_outcome: bool) -> i32 {
     }
 }
 
+/// Read one hook payload from stdin, run the match pipeline, and emit the
+/// hook response on stdout — the side-effectful counterpart of
+/// [`match_hook`].  Owns everything the pure path doesn't: the audit write,
+/// telemetry, session state, compliance correlation, and the process exit
+/// code.  This is what `arai guardrails --match-stdin` (the registered hook
+/// command) calls.
 pub fn handle_stdin() -> Result<(), String> {
     // Default to PreToolUse so a bad payload (oversize / non-UTF8 / non-JSON)
     // — which we can't parse to know the real event — is treated as a
@@ -719,7 +725,7 @@ fn handle_stdin_impl(event_hint: &mut String) -> Result<i32, String> {
                         .and_then(|o| o.get("content"))
                         .and_then(|c| c.as_str())
                     {
-                        guardrails::sniff_content_for_tools_pub(text, &mut terms);
+                        guardrails::sniff_content_for_tools(text, &mut terms);
                     }
                 }
                 terms.sort();
@@ -758,7 +764,7 @@ fn handle_stdin_impl(event_hint: &mut String) -> Result<i32, String> {
                 .unwrap_or(Value::Object(serde_json::Map::new()));
             let mut terms = guardrails::extract_terms(&tool_name, &tool_input);
             if let Some(result) = hook.get("tool_result").and_then(|v| v.as_str()) {
-                guardrails::sniff_content_for_tools_pub(result, &mut terms);
+                guardrails::sniff_content_for_tools(result, &mut terms);
             }
             terms.sort();
             terms.dedup();

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -3,10 +3,17 @@ use serde::{Deserialize, Serialize};
 /// Structured intent for a guardrail rule.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuleIntent {
+    /// The action category the rule targets (create / modify / execute / general).
     pub action: Action,
+    /// When in the workflow lifecycle the rule should fire.
     pub timing: Timing,
+    /// Tool names the rule is scoped to; `"*"` means every tool.
     pub tools: Vec<String>,
+    /// For prohibitive creation rules: explicitly skip `Edit` calls
+    /// (the rule forbids *creating*, so editing an existing file is fine).
     pub allow_inverse: bool,
+    /// Which enrichment tier produced this classification
+    /// (`"taxonomy"`, `"onnx"`, `"llm"`, …).
     pub enriched_by: String,
     /// How strictly the rule should be enforced at hook time.  Derived from
     /// the predicate unless explicitly overridden.  Defaults to `Warn` so a
@@ -39,6 +46,7 @@ pub enum Severity {
 }
 
 impl Severity {
+    /// The lowercase label stored in the DB and emitted in audit JSON.
     pub fn as_str(&self) -> &'static str {
         match self {
             Severity::Block => "block",
@@ -47,12 +55,12 @@ impl Severity {
         }
     }
 
-    // Not `std::str::FromStr`: this parser is infallible — unknown input
-    // falls back to `Warn` instead of erroring, which FromStr can't express
-    // without a lying `Err` type.  Rename is deferred to the library API
-    // surface audit (#148 follow-up).
-    #[allow(clippy::should_implement_trait)]
-    pub fn from_str(s: &str) -> Self {
+    /// Parse a stored severity label, falling back to `Warn` on unknown
+    /// input.  Deliberately not `std::str::FromStr`: this parser is
+    /// infallible — an unrecognised label keeps the advise-only default
+    /// instead of erroring, which `FromStr` can't express without a lying
+    /// `Err` type.
+    pub fn from_str_lossy(s: &str) -> Self {
         match s {
             "block" => Severity::Block,
             "inform" => Severity::Inform,
@@ -87,7 +95,8 @@ pub enum Timing {
 }
 
 impl Timing {
-    pub fn as_str(&self) -> &str {
+    /// The lowercase label stored in the DB and emitted in audit JSON.
+    pub fn as_str(&self) -> &'static str {
         match self {
             Timing::ToolCall => "tool_call",
             Timing::Stop => "stop",
@@ -96,9 +105,10 @@ impl Timing {
         }
     }
 
-    // Infallible fallback parser — see the note on `Severity::from_str`.
-    #[allow(clippy::should_implement_trait)]
-    pub fn from_str(s: &str) -> Self {
+    /// Parse a stored timing label, falling back to `ToolCall` on unknown
+    /// input.  Infallible fallback parser — see the note on
+    /// [`Severity::from_str_lossy`].
+    pub fn from_str_lossy(s: &str) -> Self {
         match s {
             "tool_call" => Timing::ToolCall,
             "stop" => Timing::Stop,
@@ -108,11 +118,12 @@ impl Timing {
         }
     }
 
+    /// Whether `s` is one of the recognised timing labels.
     pub fn is_valid(s: &str) -> bool {
         matches!(s, "tool_call" | "stop" | "start" | "principle")
     }
 
-    #[allow(dead_code)]
+    /// Every recognised timing label, for validation error messages.
     pub fn valid_values() -> &'static [&'static str] {
         &["tool_call", "stop", "start", "principle"]
     }
@@ -142,7 +153,8 @@ pub enum Action {
 }
 
 impl Action {
-    pub fn as_str(&self) -> &str {
+    /// The lowercase label stored in the DB and emitted in audit JSON.
+    pub fn as_str(&self) -> &'static str {
         match self {
             Action::Create => "create",
             Action::Modify => "modify",
@@ -151,9 +163,10 @@ impl Action {
         }
     }
 
-    // Infallible fallback parser — see the note on `Severity::from_str`.
-    #[allow(clippy::should_implement_trait)]
-    pub fn from_str(s: &str) -> Self {
+    /// Parse a stored action label, falling back to `General` on unknown
+    /// input.  Infallible fallback parser — see the note on
+    /// [`Severity::from_str_lossy`].
+    pub fn from_str_lossy(s: &str) -> Self {
         match s {
             "create" => Action::Create,
             "modify" => Action::Modify,
@@ -162,11 +175,12 @@ impl Action {
         }
     }
 
+    /// Whether `s` is one of the recognised action labels.
     pub fn is_valid(s: &str) -> bool {
         matches!(s, "create" | "modify" | "execute" | "general")
     }
 
-    #[allow(dead_code)]
+    /// Every recognised action label, for validation error messages.
     pub fn valid_values() -> &'static [&'static str] {
         &["create", "modify", "execute", "general"]
     }
@@ -394,12 +408,18 @@ fn contains_known_tool_ref(lower_text: &str) -> bool {
 }
 
 /// Classify a rule into structured intent based on its predicate and object text.
-/// Optionally pass the subject for tool-reference checking.
-#[allow(dead_code)]
+/// Shorthand for [`classify_rule_with_subject`] without a subject.
 pub fn classify_rule(predicate: &str, object: &str) -> RuleIntent {
     classify_rule_with_subject(predicate, object, None)
 }
 
+/// Classify a rule into structured intent (Tier 1, taxonomy-based).
+///
+/// Scores the object text against the creation / modification / execution
+/// phrase taxonomies to pick an [`Action`], derives [`Timing`] (rules that
+/// reference a known tool always fire on tool calls), maps the action to a
+/// tool scope, and derives [`Severity`] from the predicate.  Pass the rule's
+/// subject when available — it participates in the known-tool check.
 pub fn classify_rule_with_subject(
     predicate: &str,
     object: &str,
@@ -689,10 +709,10 @@ mod tests {
     #[test]
     fn test_severity_roundtrip_string() {
         for sev in [Severity::Block, Severity::Warn, Severity::Inform] {
-            assert_eq!(Severity::from_str(sev.as_str()), sev);
+            assert_eq!(Severity::from_str_lossy(sev.as_str()), sev);
         }
         // Unknown severities fall back to Warn so rule sets stay advise-only
         // until re-classified.
-        assert_eq!(Severity::from_str("bogus"), Severity::Warn);
+        assert_eq!(Severity::from_str_lossy("bogus"), Severity::Warn);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,9 +58,12 @@
 //! # Stability
 //!
 //! The CLI surface, hook protocol, and on-disk formats are semver-stable
-//! (v1.0.0).  The **library API is not yet** — item-level surface audit is
-//! ongoing, and signatures may change in minor releases until the library
-//! API is declared stable.  Pin a minor version if you embed Arai.
+//! (v1.0.0).  The library API surface has been item-level audited: every
+//! `pub` item in the documented modules above is intentional — documented,
+//! and kept compatible under semver like any other Rust library API.
+//! Internal helpers are `pub(crate)`, and the `#[doc(hidden)]` CLI-support
+//! modules remain exempt from any compatibility promise — don't build on
+//! those.
 
 pub mod audit;
 pub mod canonicalize;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,19 +2,35 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
 
+/// One extracted rule as a subject–predicate–object triple, plus extraction
+/// metadata (confidence, source location, parser layer, annotations,
+/// provenance).  This is the parser's output shape and the store's input
+/// shape — `store::upsert_file` persists a `Vec<Triple>` per source file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Triple {
+    /// Rule subject — usually the tool or domain the rule is about (e.g. `git`).
     #[serde(rename = "s")]
     pub subject: String,
+    /// Rule predicate — the normalised modality (`never`, `always`,
+    /// `requires`, `prefers`, …).  Drives severity classification.
     #[serde(rename = "p")]
     pub predicate: String,
+    /// Rule object — what the rule requires or forbids, with trailing
+    /// annotations (`(expires …)`, `(noenrich)`) already stripped.
     #[serde(rename = "o")]
     pub object: String,
+    /// Extraction confidence inherited from the source file's type
+    /// (project CLAUDE.md ranks above global memory files).
     pub confidence: f64,
+    /// Source-type namespace, e.g. `memory.claude_md_project`.
     pub domain: String,
+    /// Path of the instruction file the rule came from.  May be empty at
+    /// extraction time; callers fill it in before persisting.
     pub source_file: String,
+    /// First line of the source list item, 1-based.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_start: Option<i64>,
+    /// Last line of the source list item, 1-based.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_end: Option<i64>,
     /// Which of the seven `match_imperative` layers fired.  Lets `arai audit` /
@@ -188,7 +204,6 @@ pub fn extract_rules_with_provenance(
 /// This is the provenance-aware variant of [`extract_rules`].  Callers that
 /// use the flat `resolve()` output should call this function so rules from
 /// upstream blocks are correctly stamped.
-#[allow(dead_code)]
 pub fn extract_rules_from_resolved(
     content: &str,
     source_type: &str,
@@ -307,7 +322,7 @@ fn extract_kv_attr(s: &str, key: &str) -> Option<String> {
 /// from the rule object and return the cleaned object plus the parsed date.
 /// Accepts case-insensitive `expires` / `expire` / `until`.  If nothing is
 /// found, the object is returned unchanged with `None`.
-pub fn extract_expiry(object: &str) -> (String, Option<String>) {
+pub(crate) fn extract_expiry(object: &str) -> (String, Option<String>) {
     static EXPIRY_RE: OnceLock<Regex> = OnceLock::new();
     let re = EXPIRY_RE.get_or_init(|| {
         Regex::new(r"(?i)\s*\((?:expires?|until)\s+(\d{4}-\d{2}-\d{2})\)\s*$").expect("valid regex")
@@ -325,7 +340,7 @@ pub fn extract_expiry(object: &str) -> (String, Option<String>) {
 /// the cleaned object plus a flag indicating whether the marker was present.
 /// Case-insensitive.  Used to opt a single rule out of LLM/API enrichment
 /// without disabling the feature globally.
-pub fn extract_noenrich(object: &str) -> (String, bool) {
+pub(crate) fn extract_noenrich(object: &str) -> (String, bool) {
     static NOENRICH_RE: OnceLock<Regex> = OnceLock::new();
     let re =
         NOENRICH_RE.get_or_init(|| Regex::new(r"(?i)\s*\(noenrich\)\s*$").expect("valid regex"));
@@ -342,7 +357,7 @@ pub fn extract_noenrich(object: &str) -> (String, bool) {
 /// hides anything to its left from the other regex; we loop until neither
 /// strips anything to handle `(expires ...) (noenrich)` and the reverse
 /// uniformly.
-pub fn extract_annotations(object: &str) -> (String, Option<String>, bool) {
+pub(crate) fn extract_annotations(object: &str) -> (String, Option<String>, bool) {
     let mut current = object.to_string();
     let mut expires: Option<String> = None;
     let mut noenrich = false;

--- a/src/store.rs
+++ b/src/store.rs
@@ -3,6 +3,11 @@ use rusqlite::{params, Connection};
 use sha2::{Digest, Sha256};
 use std::path::Path;
 
+/// SQLite-backed rule store for one project: source files, extracted
+/// triples, classified intent, severity overrides, the code graph, and the
+/// disabled-rules list.  Open one with [`Store::open`] at
+/// [`Config::db_path`](crate::config::Config::db_path); migrations run
+/// automatically on open.
 pub struct Store {
     conn: Connection,
 }
@@ -16,6 +21,9 @@ type Migration = fn(&Connection) -> rusqlite::Result<()>;
 const MIGRATIONS: &[Migration] = &[migrate_v1, migrate_v2, migrate_v3, migrate_v4];
 
 impl Store {
+    /// Open (or create) the store at `db_path`, creating parent directories,
+    /// setting connection PRAGMAs (WAL journal etc.), and running any
+    /// pending schema migrations.
     pub fn open(db_path: &Path) -> Result<Store, String> {
         // Ensure parent directory exists
         if let Some(parent) = db_path.parent() {
@@ -243,6 +251,7 @@ impl Store {
         }
     }
 
+    /// Every source-file path currently in the store, sorted.
     pub fn list_files(&self) -> rusqlite::Result<Vec<String>> {
         let mut stmt = self.conn.prepare("SELECT path FROM files ORDER BY path")?;
         let paths = stmt
@@ -251,6 +260,9 @@ impl Store {
         Ok(paths)
     }
 
+    /// Count of stored rules with an actionable predicate (the same
+    /// predicate filter [`Store::load_guardrails`] applies, without the
+    /// expiry / disabled filters).
     pub fn guardrail_count(&self) -> rusqlite::Result<i64> {
         self.conn.query_row(
             "SELECT COUNT(*) FROM triples WHERE p IN ('forbids','must_not','never','always','requires','enforces','prefers')",
@@ -263,7 +275,7 @@ impl Store {
     /// bound the number of MCP-source rules so a runaway agent can't fill the
     /// store.  MCP rules live under synthetic file paths starting with
     /// `manual://arai-mcp/` (see `mcp::tool_add_guard`).
-    pub fn count_mcp_rules(&self) -> rusqlite::Result<i64> {
+    pub(crate) fn count_mcp_rules(&self) -> rusqlite::Result<i64> {
         self.conn.query_row(
             "SELECT COUNT(*) FROM triples t \
              JOIN files f ON f.id = t.file_id \
@@ -273,6 +285,8 @@ impl Store {
         )
     }
 
+    /// Read a value from the key/value `meta` table (scan timestamps,
+    /// schema bookkeeping).  `None` when the key is absent.
     pub fn get_meta(&self, key: &str) -> rusqlite::Result<Option<String>> {
         self.conn
             .query_row(
@@ -286,6 +300,7 @@ impl Store {
             })
     }
 
+    /// Insert or update a value in the key/value `meta` table.
     pub fn set_meta(&self, key: &str, value: &str) -> rusqlite::Result<()> {
         self.conn.execute(
             "INSERT INTO meta (key, value) VALUES (?1, ?2)
@@ -319,7 +334,10 @@ impl Store {
     }
 
     /// Query what tools are imported by files in a given directory.
-    pub fn query_tools_for_directory(&self, directory: &str) -> rusqlite::Result<Vec<String>> {
+    pub(crate) fn query_tools_for_directory(
+        &self,
+        directory: &str,
+    ) -> rusqlite::Result<Vec<String>> {
         let mut stmt = self
             .conn
             .prepare("SELECT DISTINCT tool_name FROM code_graph WHERE directory = ?1")?;
@@ -425,12 +443,12 @@ impl Store {
 
                 let effective = severity_override
                     .as_deref()
-                    .map(crate::intent::Severity::from_str)
-                    .unwrap_or_else(|| crate::intent::Severity::from_str(&severity_str));
+                    .map(crate::intent::Severity::from_str_lossy)
+                    .unwrap_or_else(|| crate::intent::Severity::from_str_lossy(&severity_str));
 
                 Ok(crate::intent::RuleIntent {
-                    action: crate::intent::Action::from_str(&action_str),
-                    timing: crate::intent::Timing::from_str(&timing_str),
+                    action: crate::intent::Action::from_str_lossy(&action_str),
+                    timing: crate::intent::Timing::from_str_lossy(&timing_str),
                     tools,
                     allow_inverse: allow_inverse != 0,
                     enriched_by,
@@ -535,7 +553,7 @@ impl Store {
 
             let from = had
                 .as_deref()
-                .map(crate::intent::Severity::from_str)
+                .map(crate::intent::Severity::from_str_lossy)
                 .unwrap_or_else(|| crate::intent::Severity::from_predicate(&g.predicate));
             let to = crate::intent::Severity::from_predicate(&g.predicate);
             cleared.push(SeverityChange {
@@ -571,7 +589,7 @@ impl Store {
             let source: String = row.get(4)?;
             let override_str: String = row.get(5)?;
             let from = crate::intent::Severity::from_predicate(&predicate);
-            let to = crate::intent::Severity::from_str(&override_str);
+            let to = crate::intent::Severity::from_str_lossy(&override_str);
             Ok(SeverityChange {
                 triple_id,
                 subject,
@@ -698,17 +716,23 @@ pub struct RuleIssues {
     pub opposing: Vec<OpposingRules>,
 }
 
+/// A rule whose exact (subject, predicate, object) appears in more than one
+/// source file.
 #[derive(Debug, serde::Serialize)]
 pub struct DuplicateRule {
     pub subject: String,
     pub predicate: String,
     pub object: String,
+    /// The distinct source files the rule appears in, sorted.
     pub sources: Vec<String>,
 }
 
+/// A subject that carries both prohibitive and required predicates —
+/// possibly (not necessarily) contradictory rules worth a human look.
 #[derive(Debug, serde::Serialize)]
 pub struct OpposingRules {
     pub subject: String,
+    /// The distinct predicates seen on this subject, sorted.
     pub predicates: Vec<String>,
 }
 
@@ -824,12 +848,12 @@ fn parse_intent_from_row(
 
     let effective = severity_override
         .as_deref()
-        .map(crate::intent::Severity::from_str)
-        .unwrap_or_else(|| crate::intent::Severity::from_str(&severity_str));
+        .map(crate::intent::Severity::from_str_lossy)
+        .unwrap_or_else(|| crate::intent::Severity::from_str_lossy(&severity_str));
 
     Ok(Some(crate::intent::RuleIntent {
-        action: crate::intent::Action::from_str(&action_str),
-        timing: crate::intent::Timing::from_str(&timing_str),
+        action: crate::intent::Action::from_str_lossy(&action_str),
+        timing: crate::intent::Timing::from_str_lossy(&timing_str),
         tools,
         allow_inverse: allow_inverse != 0,
         enriched_by,
@@ -837,14 +861,27 @@ fn parse_intent_from_row(
     }))
 }
 
+/// One active rule as loaded from the store — a [`Triple`] joined with its
+/// classified intent and ready for matching.  Produced by
+/// [`Store::load_guardrails`] / [`Store::rules_for_file`]; consumed by
+/// `guardrails::match_guardrails` and everything downstream of it.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Guardrail {
+    /// Stable row id of the underlying triple — the join key used across
+    /// the audit log, compliance verdicts, and session seen-rule tracking.
     pub triple_id: i64,
+    /// Rule subject (tool / domain).
     pub subject: String,
+    /// Normalised modality (`never`, `always`, `requires`, …).
     pub predicate: String,
+    /// What the rule requires or forbids.
     pub object: String,
+    /// Extraction confidence inherited from the source file type.
     pub confidence: f64,
+    /// Source path recorded on the triple at extraction time (may be empty
+    /// for older rows; prefer `file_path`).
     pub source_file: String,
+    /// Path of the source file row the triple is attached to.
     pub file_path: String,
     /// Parser layer (1..=6) that produced this rule.  Preserved through the
     /// store so `arai audit` / `arai why` can trace a firing back to the


### PR DESCRIPTION
Closes #162.

PR #153 exposed 12 core modules whose `pub` items predate the lib/bin split. This audits every one of them against actual consumers (the `arai` binary, the integration tests — which all drive the compiled binary — and lib-internal callers), shrinks the surface to the intentional API, and documents what remains.

## Renames

`Severity::from_str`, `Timing::from_str`, `Action::from_str` → **`from_str_lossy`**. The name states the contract (infallible, unknown input falls back to the safe default), the deferred `#[allow(clippy::should_implement_trait)]` workarounds are gone, and the old justification comments became rustdoc. `Timing::as_str` / `Action::as_str` also tightened to `&'static str`, matching `Severity`.

## Demoted to `pub(crate)`

| Item | Why |
|---|---|
| `parser::extract_expiry` / `extract_noenrich` / `extract_annotations` | annotation plumbing, used only inside the parser |
| `discovery::parse_frontmatter` | used only by the parser |
| `config::resolve_base_dir` + `ResolvedBaseDir` + `DeprecationNotice` | resolution mechanics behind `Config::load` |
| `Config::claude_memory_*` / `claude_settings_path` / `grok_*_hooks_dir` | hook-injection paths for init/discovery |
| `Store::count_mcp_rules`, `Store::query_tools_for_directory` | MCP cap plumbing / internal to `query_tools_for_path` |
| `guardrails::sniff_content_for_tools` | the `sniff_content_for_tools_pub` wrapper is deleted; hooks call the real fn |

## Kept pub + documented

Everything an embedder replicating the CLI's hook loop needs: the audit append/read API (`record_firing` / `record_event` / `record_bypass` / `query` — the lib.rs security model explicitly covers appends), the `session` module, the guardrails pipeline (`extract_terms` → `enrich_terms_from_graph` → `match_guardrails` → `format_context`), and the `Store` data-access surface. Doc comments added to `Store`, `Guardrail`, `Triple`, `Config`, `DiscoveredFile`, the canonicalize serde types, `hooks::handle_stdin`, and the intent accessors. Five stale `#[allow(dead_code)]`s from the pre-split binary era dropped.

The lib.rs Stability note now declares the documented modules item-level audited and semver-covered; `#[doc(hidden)]` CLI-support modules stay exempt.

## Verification

- `cargo test`: 602 tests across 20 suites, 0 failures
- `cargo clippy -- -D warnings`: clean
- `cargo doc --no-deps`: no warnings; `cargo fmt --check` clean
- **CLI byte-identical**: built the binary from base and from this branch, ran both through an 11-command suite against isolated `ARAI_BASE_DIR`s (help, lint, scan, status, guardrails, why, three `--match-stdin` payloads including the deny path and the prompt-collector event, severity, diff) — 203 output lines identical except the wall-clock `Last scan` timestamp.

Note: this is itself a breaking change to the pre-audit library API (the parser renames + demotions) — intentional, since lib.rs documented that surface as unstable pending exactly this audit.

Pre-existing, out of scope: two clippy-1.95 lints in `tests/gateway_glyphs_verifier.rs` and `tests/prompt_collector_verifier.rs` that only fire under `--all-targets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)