### PR TITLE
Add taniwha.yaml — self-description for the org Atlas

### DIFF
--- a/taniwha.yaml
+++ b/taniwha.yaml
@@ -1,0 +1,12 @@
+name: arai
+repo: taniwhaai/arai
+role: Edge enforcement for AI coding agents (open-core wrapper around kete)
+layer: tooling
+language: python
+status: active
+successor_of: null
+upstream: [kete]
+downstream: []
+runs_product: null
+notes: >
+  DEV TOOLING. Contribution flow is PR-to-main (unlike kraken's push-to-master).


### PR DESCRIPTION
Adds a root `taniwha.yaml` so the org Atlas (taniwhaai/atlas) tracks this repo and it passes the require-taniwha-yaml gate. Mirrors the atlas manifest; provisional fields can be sharpened later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)