### PR TITLE
chore: release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-07-10
+
+### Atlas
+
+- Correct taniwha.yaml (arai/kete dep direction; codeworld lineage) ([#169](https://github.com/taniwhaai/arai/pull/169))
+
+
 ## [1.1.1] - 2026-07-06
 
 ### Miscellaneous

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arai"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arai"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 description = "AI coding rules that actually work. Enforce instruction files via hooks — CLAUDE.md, .cursorrules, copilot-instructions, and more."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `arai`: 1.1.1 -> 1.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.2] - 2026-07-10

### Atlas

- Correct taniwha.yaml (arai/kete dep direction; codeworld lineage) ([#169](https://github.com/taniwhaai/arai/pull/169))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).